### PR TITLE
Fix release zlob build

### DIFF
--- a/vendor/fff/Cargo.lock
+++ b/vendor/fff/Cargo.lock
@@ -2471,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "zlob"
-version = "1.3.0"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07934fb13f0f4e14281bab6b0e984cfc03891d2cf5b0a8bd0ab14fd240e21106"
+checksum = "41f3522fa9701b74ec72758aedb96da278f6e0533bc16b6a79090bfb465d4661"
 dependencies = [
  "bindgen",
  "bitflags 2.9.1",

--- a/vendor/fff/Cargo.toml
+++ b/vendor/fff/Cargo.toml
@@ -30,7 +30,7 @@ heed = "0.22.0"
 ignore = "0.4.22"
 memmap2 = "0.9"
 mimalloc = "0.1.47"
-zlob = "1.3.0"
+zlob = "1.3.3"
 
 mlua = { version = "0.11.1", features = ["module", "luajit"] }
 neo_frizbee = "0.8.2"


### PR DESCRIPTION
## Summary
- Bump vendored fff zlob dependency to 1.3.3 for Zig 0.16 compatibility
- Regenerate the vendored fff Cargo.lock

## Verification
- cd vendor/fff && cargo clean -p zlob -p fff-c -p fff-search -p fff-query-parser && cargo build --release --package fff-c --features zlob