### PR TITLE
Fix macOS Zig 0.16 dev build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
       matrix:
         target:
           - linux-x86_64
+          - macos-arm64
+          - macos-x86_64
 
     runs-on: ${{ matrix.target == 'linux-x86_64' && 'ubuntu-24.04' || matrix.target == 'macos-x86_64' && 'macos-15-intel' || 'macos-14' }}
     env:

--- a/packages/desktop/src/browser/cef/backend.zig
+++ b/packages/desktop/src/browser/cef/backend.zig
@@ -4,12 +4,36 @@ const std = @import("std");
 const builtin = @import("builtin");
 const browser_input = @import("../input.zig");
 const browser_bridge = @import("bridge.zig");
-const browser_helper = @import("linux_helper.zig");
 const browser_platform = @import("platform.zig");
 const browser_queue = @import("../queue.zig");
 const browser_session = @import("../session.zig");
 const browser_texture = @import("../texture.zig");
 const browser_types = @import("../types.zig");
+const browser_helper = if (builtin.os.tag == .linux) @import("linux_helper.zig") else struct {
+    pub const Controller = struct {
+        pub fn init(_: std.mem.Allocator, _: []const u8) !Controller {
+            return error.BrowserUnavailable;
+        }
+
+        pub fn deinit(_: *Controller) void {}
+        pub fn show(_: *Controller, _: u32, _: u32, _: []const u8) !void {}
+        pub fn hide(_: *Controller) !void {}
+        pub fn resize(_: *Controller, _: u32, _: u32) !void {}
+        pub fn navigate(_: *Controller, _: u32, _: u32, _: []const u8) !void {}
+        pub fn eval(_: *Controller, _: []const u8) !void {}
+        pub fn postJson(_: *Controller, _: []const u8) !void {}
+        pub fn handleMouse(_: *Controller, _: browser_input.MouseEvent) !bool {
+            return false;
+        }
+        pub fn handleKey(_: *Controller, _: browser_input.KeyEvent) !bool {
+            return false;
+        }
+        pub fn popEvent(_: *Controller) ?browser_types.Event {
+            return null;
+        }
+        pub fn uploadFrame(_: *Controller, _: *browser_texture.PaneTexture) !void {}
+    };
+};
 
 const DEFAULT_PANE_WIDTH: u32 = 1280;
 const DEFAULT_PANE_HEIGHT: u32 = 720;
@@ -224,7 +248,7 @@ pub const Backend = struct {
 
     // Reports whether this build should use the real helper runtime instead of the synthetic preview.
     fn usingNativeRuntime(self: *const Backend) bool {
-        return (builtin.os.tag == .linux or builtin.os.tag == .macos) and self.sdkConfigured() and !self.stubPreview();
+        return builtin.os.tag == .linux and self.sdkConfigured() and !self.stubPreview();
     }
 
     // Warms the runtime once so the browser cost is paid on first open instead of app launch.

--- a/packages/desktop/src/terminal/terminal.zig
+++ b/packages/desktop/src/terminal/terminal.zig
@@ -1038,7 +1038,7 @@ const UnixSession = struct {
         errdefer terminal.deinit(allocator);
         try terminal.setPwd(cwd);
 
-        const child = try spawnShell(cwd, cols, rows);
+        const child = try spawnShell(allocator, cwd, cols, rows);
         errdefer {
             std.posix.kill(child.child_pid, std.posix.SIG.TERM) catch {};
             _ = std.c.close(child.master_fd);
@@ -1324,7 +1324,10 @@ const UnixSession = struct {
         );
     }
 
-    fn spawnShell(cwd: []const u8, cols: u16, rows: u16) !SpawnResult {
+    fn spawnShell(allocator: std.mem.Allocator, cwd: []const u8, cols: u16, rows: u16) !SpawnResult {
+        const cwd_z = try allocator.dupeZ(u8, cwd);
+        defer allocator.free(cwd_z);
+
         var master_fd: c_int = -1;
         const winsize = std.posix.winsize{
             .row = rows,
@@ -1336,7 +1339,7 @@ const UnixSession = struct {
         if (fork_result < 0) return error.ForkPtyFailed;
 
         if (fork_result == 0) {
-            childExec(cwd);
+            childExec(cwd_z);
         }
 
         try setNonBlocking(@intCast(master_fd));
@@ -1346,8 +1349,8 @@ const UnixSession = struct {
         };
     }
 
-    fn childExec(cwd: []const u8) noreturn {
-        if (std.c.chdir(@ptrCast(cwd.ptr)) != 0) {
+    fn childExec(cwd: [:0]const u8) noreturn {
+        if (std.c.chdir(cwd.ptr) != 0) {
             std.c._exit(127);
         }
 

--- a/packages/desktop/src/utils.zig
+++ b/packages/desktop/src/utils.zig
@@ -1515,9 +1515,13 @@ fn convertClipboardTiffToPng(
     }
 
     const png_bytes = png_bytes: {
-        const png_file = try std.fs.openFileAbsolute(output_path, .{});
-        defer png_file.close();
-        break :png_bytes try png_file.readToEndAlloc(allocator, CLIPBOARD_IMAGE_MAX_BYTES);
+        var png_file = try std.Io.Dir.openFileAbsolute(threaded.io(), output_path, .{ .mode = .read_only });
+        defer png_file.close(threaded.io());
+        const png_size = try png_file.stat(threaded.io());
+        if (png_size.size > CLIPBOARD_IMAGE_MAX_BYTES) return error.StreamTooLong;
+        var read_buffer: [8 * 1024]u8 = undefined;
+        var reader = png_file.reader(threaded.io(), &read_buffer);
+        break :png_bytes try reader.interface.readAlloc(allocator, @intCast(png_size.size));
     };
     std.Io.Dir.deleteFileAbsolute(threaded.io(), input_path) catch {};
     std.Io.Dir.deleteFileAbsolute(threaded.io(), output_path) catch {};

--- a/packages/desktop/src/utils.zig
+++ b/packages/desktop/src/utils.zig
@@ -937,8 +937,9 @@ fn macApplicationExists(app_name: []const u8) bool {
 }
 
 fn directoryExistsAbsolute(path: []const u8) bool {
-    var dir = std.fs.openDirAbsolute(path, .{}) catch return false;
-    defer dir.close();
+    var threaded = std.Io.Threaded.init_single_threaded;
+    var dir = std.Io.Dir.openDirAbsolute(threaded.io(), path, .{}) catch return false;
+    defer dir.close(threaded.io());
     return true;
 }
 
@@ -1493,9 +1494,12 @@ fn convertClipboardTiffToPng(
     defer allocator.free(output_path);
 
     {
-        var file = try std.fs.createFileAbsolute(input_path, .{ .truncate = true });
-        defer file.close();
-        try file.writeAll(capture.bytes);
+        var file = try std.Io.Dir.createFileAbsolute(threaded.io(), input_path, .{ .truncate = true });
+        defer file.close(threaded.io());
+        var write_buffer: [8 * 1024]u8 = undefined;
+        var writer = file.writer(threaded.io(), &write_buffer);
+        try writer.interface.writeAll(capture.bytes);
+        try writer.interface.flush();
     }
 
     const convert_result = runChild(allocator, &.{ "sips", "-s", "format", "png", input_path, "--out", output_path }, ".", 16 * 1024) catch |err| switch (err) {

--- a/packages/ghostty/build.zig.zon
+++ b/packages/ghostty/build.zig.zon
@@ -25,8 +25,7 @@
         },
         .zig_objc = .{
             // mitchellh/zig-objc
-            .url = "https://deps.files.ghostty.org/zig_objc-f356ed02833f0f1b8e84d50bed9e807bf7cdc0ae.tar.gz",
-            .hash = "zig_objc-0.0.0-Ir_Sp5gTAQCvxxR7oVIrPXxXwsfKgVP7_wqoOQrZjFeK",
+            .path = "../zig_objc",
             .lazy = true,
         },
         .zig_js = .{

--- a/packages/ghostty/pkg/apple-sdk/build.zig
+++ b/packages/ghostty/pkg/apple-sdk/build.zig
@@ -60,7 +60,7 @@ pub fn addPaths(
             }) catch break :darwin;
 
             // Render the file compatible with the `--libc` Zig flag.
-            var stream: std.io.Writer.Allocating = .init(b.allocator);
+            var stream: std.Io.Writer.Allocating = .init(b.allocator);
             defer stream.deinit();
             try libc.render(&stream.writer);
 

--- a/packages/ghostty/pkg/apple-sdk/build.zig
+++ b/packages/ghostty/pkg/apple-sdk/build.zig
@@ -53,9 +53,9 @@ pub fn addPaths(
             // Detect our SDK using the "findNative" Zig stdlib function.
             // This is really important because it forces using `xcrun` to
             // find the SDK path.
-            const libc = std.zig.LibCInstallation.findNative(.{
-                .allocator = b.allocator,
+            const libc = std.zig.LibCInstallation.findNative(b.allocator, b.graph.io, .{
                 .target = &step.rootModuleTarget(),
+                .environ_map = &b.graph.environ_map,
                 .verbose = false,
             }) catch break :darwin;
 

--- a/packages/ghostty/src/build/GhosttyLibVt.zig
+++ b/packages/ghostty/src/build/GhosttyLibVt.zig
@@ -174,7 +174,7 @@ pub fn initStaticAppleUniversal(
             .os_tag = p.os_tag,
             .os_version_min = Config.osVersionMin(p.os_tag),
         };
-        if (detectAppleSDK(b.resolveTargetQuery(target_query).result)) {
+        if (detectAppleSDK(b, b.resolveTargetQuery(target_query).result)) {
             const dev_zig = try zig.retarget(b, cfg, deps, b.resolveTargetQuery(target_query));
             result.put(p.device, try initStatic(b, &dev_zig));
 
@@ -438,10 +438,10 @@ pub fn xcframework(
 }
 
 /// Returns true if the Apple SDK for the given target is installed.
-fn detectAppleSDK(target: std.Target) bool {
-    _ = std.zig.LibCInstallation.findNative(.{
-        .allocator = std.heap.page_allocator,
+fn detectAppleSDK(b: *std.Build, target: std.Target) bool {
+    _ = std.zig.LibCInstallation.findNative(b.allocator, b.graph.io, .{
         .target = &target,
+        .environ_map = &b.graph.environ_map,
         .verbose = false,
     }) catch return false;
     return true;

--- a/packages/ghostty/src/os/mach.zig
+++ b/packages/ghostty/src/os/mach.zig
@@ -92,9 +92,8 @@ const TaggedPageAllocator = struct {
             aligned_len
         else
             mem.alignForward(usize, aligned_len + max_drop_len, page_size);
-        const hint = @atomicLoad(@TypeOf(std.heap.next_mmap_addr_hint), &std.heap.next_mmap_addr_hint, .unordered);
         const slice = std.posix.mmap(
-            hint,
+            null,
             overalloc_len,
             std.posix.PROT.READ | std.posix.PROT.WRITE,
             .{ .TYPE = .PRIVATE, .ANONYMOUS = true },
@@ -109,8 +108,6 @@ const TaggedPageAllocator = struct {
         if (drop_len != 0) std.posix.munmap(slice[0..drop_len]);
         const remaining_len = overalloc_len - drop_len;
         if (remaining_len > aligned_len) std.posix.munmap(@alignCast(result_ptr[aligned_len..remaining_len]));
-        const new_hint: [*]align(std.heap.page_size_min) u8 = @alignCast(result_ptr + aligned_len);
-        _ = @cmpxchgStrong(@TypeOf(std.heap.next_mmap_addr_hint), &std.heap.next_mmap_addr_hint, hint, new_hint, .monotonic, .monotonic);
         return result_ptr;
     }
 

--- a/packages/ghostty/src/os/mach.zig
+++ b/packages/ghostty/src/os/mach.zig
@@ -95,7 +95,7 @@ const TaggedPageAllocator = struct {
         const slice = std.posix.mmap(
             null,
             overalloc_len,
-            std.posix.PROT.READ | std.posix.PROT.WRITE,
+            .{ .READ = true, .WRITE = true },
             .{ .TYPE = .PRIVATE, .ANONYMOUS = true },
             tag.make(),
             0,

--- a/packages/ghostty/src/terminal/kitty/graphics_image.zig
+++ b/packages/ghostty/src/terminal/kitty/graphics_image.zig
@@ -179,7 +179,7 @@ pub const LoadingImage = struct {
         var buf: [std.fs.max_path_bytes]u8 = undefined;
         const pathz = std.fmt.bufPrintZ(&buf, "{s}", .{path}) catch return error.InvalidData;
 
-        const fd = std.c.shm_open(pathz, @as(c_int, @bitCast(std.c.O{ .ACCMODE = .RDONLY })), 0);
+        const fd = std.c.shm_open(pathz, @as(c_int, @bitCast(std.c.O{ .ACCMODE = .RDONLY })), @as(std.c.mode_t, 0));
         switch (std.posix.errno(fd)) {
             .SUCCESS => {},
             else => |err| {

--- a/packages/zig_objc/.envrc
+++ b/packages/zig_objc/.envrc
@@ -1,0 +1,5 @@
+# If we are a computer with nix-shell available, then use that to setup
+# the build environment with exactly what we need.
+if has nix; then
+  use nix
+fi

--- a/packages/zig_objc/.github/workflows/test.yml
+++ b/packages/zig_objc/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  build:
+    runs-on: namespace-profile-ghostty-macos
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      # Cross-compile the binary. We always use static building for this
+      # because its the only way to access the headers.
+      - name: Test
+        run: nix develop -c zig build test --summary all

--- a/packages/zig_objc/.gitignore
+++ b/packages/zig_objc/.gitignore
@@ -1,0 +1,3 @@
+.direnv/
+.zig-cache
+zig-out

--- a/packages/zig_objc/LICENSE
+++ b/packages/zig_objc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/zig_objc/README.md
+++ b/packages/zig_objc/README.md
@@ -1,0 +1,101 @@
+# zig-objc - Objective-C Runtime Bindings for Zig
+
+zig-objc allows Zig to call Objective-C using the macOS
+[Objective-C runtime](https://developer.apple.com/documentation/objectivec/objective-c_runtime?language=objc).
+
+**Project Status:** This library does not currently have 100% coverage over the Objective-C
+runtime, but supports enough features to be useful. I use this library in
+shipping code that I run every day.
+
+## Features
+
+  * Classes:
+    - Find classes
+    - Read property metadata
+    - Call methods
+    - Create subclasses
+    - Add methods
+    - Replace methods
+    - Add instance variables
+  * Objects:
+    - Class or class name for object
+    - Read and write properties
+    - Read and write instance variables
+    - Call methods
+    - Call superclass methods
+  * Protocols:
+    - Check conformance
+    - Read property metadata
+  * Blocks:
+    - Define and invoke blocks with captured values
+    - Pass blocks to C APIs which can then invoke your Zig code
+  * Autorelease pools
+
+There is still a bunch of the runtime API that isn't supported. It wouldn't
+be hard work to add it, I just haven't needed it. For example: object
+instance variables, protocols, dynamically registering new classes, etc.
+
+Feel free to open a pull request if you want additional features.
+**Do not open issues to request features (only pull requests).** I'm
+only going to add features I need, _unless_ you open a pull request to
+add it yourself.
+
+## Example
+
+Here is an example that uses `NSProcessInfo` to implement a function
+`macosVersionAtLeast` that returns true if the running macOS versions
+is at least the given arguments.
+
+```zig
+const objc = @import("objc");
+
+pub fn macosVersionAtLeast(major: i64, minor: i64, patch: i64) bool {
+    /// Get the objc class from the runtime
+    const NSProcessInfo = objc.getClass("NSProcessInfo").?;
+
+    /// Call a class method with no arguments that returns another objc object.
+    const info = NSProcessInfo.msgSend(objc.Object, "processInfo", .{});
+
+    /// Call an instance method that returns a boolean and takes a single
+    /// argument.
+    return info.msgSend(bool, "isOperatingSystemAtLeastVersion:", .{
+        NSOperatingSystemVersion{ .major = major, .minor = minor, .patch = patch },
+    });
+}
+
+/// This extern struct matches the Cocoa headers for layout.
+const NSOperatingSystemVersion = extern struct {
+    major: i64,
+    minor: i64,
+    patch: i64,
+};
+```
+
+## Usage
+
+Add this repository to your `build.zig.zon` file. Then:
+
+```zig
+pub fn build(b: *std.build.Builder) !void {
+  // ... other stuff
+
+  exe.root_module.addImport("objc", b.dependency("zig_objc", .{
+    .target = target,
+    .optimize = optimize,
+  }).module("objc"));
+}
+```
+
+Note that `zig-objc` will find and link to headers from the target SDK
+(macOS, iOS, etc.) automatically by finding your Xcode installation. If
+Xcode is not installed, you can add it manually but you must set the
+`-Dadd-paths=false` flag.
+
+**`zig-objc` only works with released versions of Zig.** We don't support
+nightly versions because the Zig compiler is still changing too much.
+
+## Documentation
+
+Read the source code, it is well commented. If something isn't clear, please
+open an issue and I'll enhance the source code. Some familiarity with
+Objective-C concepts is expected for understanding the doc comments.

--- a/packages/zig_objc/build.zig
+++ b/packages/zig_objc/build.zig
@@ -26,9 +26,9 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         }),
     });
-    tests.linkSystemLibrary("objc");
-    tests.linkFramework("Foundation");
-    tests.linkFramework("AppKit"); // Required by 'tagged pointer' test.
+    tests.root_module.linkSystemLibrary("objc", .{});
+    tests.root_module.linkFramework("Foundation", .{});
+    tests.root_module.linkFramework("AppKit", .{}); // Required by 'tagged pointer' test.
     try addAppleSDK(b, tests.root_module);
     b.installArtifact(tests);
 

--- a/packages/zig_objc/build.zig
+++ b/packages/zig_objc/build.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+    const add_paths = b.option(
+        bool,
+        "add-paths",
+        "add apple SDK paths from Xcode installation",
+    ) orelse true;
+
+    const objc = b.addModule("objc", .{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    if (add_paths) try addAppleSDK(b, objc);
+    objc.linkSystemLibrary("objc", .{});
+    objc.linkFramework("Foundation", .{});
+
+    const tests = b.addTest(.{
+        .name = "objc-test",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    tests.linkSystemLibrary("objc");
+    tests.linkFramework("Foundation");
+    tests.linkFramework("AppKit"); // Required by 'tagged pointer' test.
+    try addAppleSDK(b, tests.root_module);
+    b.installArtifact(tests);
+
+    const test_step = b.step("test", "Run tests");
+    const tests_run = b.addRunArtifact(tests);
+    test_step.dependOn(&tests_run.step);
+}
+
+/// Add the SDK framework, include, and library paths to the given module.
+/// The module target is used to determine the SDK to use so it must have
+/// a resolved target.
+///
+/// The Apple SDK is determined based on the build target and found using
+/// xcrun, so it requires a valid Xcode installation.
+pub fn addAppleSDK(b: *std.Build, m: *std.Build.Module) !void {
+    // The cache. This always uses b.allocator and never frees memory
+    // (which is idiomatic for a Zig build exe).
+    const Cache = struct {
+        const Key = struct {
+            arch: std.Target.Cpu.Arch,
+            os: std.Target.Os.Tag,
+            abi: std.Target.Abi,
+        };
+
+        var map: std.AutoHashMapUnmanaged(Key, ?[]const u8) = .{};
+    };
+
+    const target = m.resolved_target.?.result;
+    const gop = try Cache.map.getOrPut(b.allocator, .{
+        .arch = target.cpu.arch,
+        .os = target.os.tag,
+        .abi = target.abi,
+    });
+
+    // This executes `xcrun` to get the SDK path. We don't want to execute
+    // this multiple times so we cache the value.
+    if (!gop.found_existing) {
+        gop.value_ptr.* = std.zig.system.darwin.getSdk(
+            b.allocator,
+            b.graph.io,
+            &m.resolved_target.?.result,
+        );
+    }
+
+    // The active SDK we want to use
+    const path = gop.value_ptr.* orelse return switch (target.os.tag) {
+        // Return a more descriptive error. Before we just returned the
+        // generic error but this was confusing a lot of community members.
+        // It costs us nothing in the build script to return something better.
+        .macos => error.XcodeMacOSSDKNotFound,
+        .ios => error.XcodeiOSSDKNotFound,
+        .tvos => error.XcodeTVOSSDKNotFound,
+        .watchos => error.XcodeWatchOSSDKNotFound,
+        else => error.XcodeAppleSDKNotFound,
+    };
+    m.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ path, "/System/Library/Frameworks" }) });
+    m.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ path, "/usr/include" }) });
+    m.addLibraryPath(.{ .cwd_relative = b.pathJoin(&.{ path, "/usr/lib" }) });
+}

--- a/packages/zig_objc/build.zig.zon
+++ b/packages/zig_objc/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .name = .zig_objc,
+    .version = "0.0.0",
+    .fingerprint = 0x8a91772ba7d2bf22,
+    .paths = .{
+        "src/",
+        "build.zig",
+        "build.zig.zon",
+        "README.md",
+        "LICENSE",
+    },
+    .dependencies = .{},
+}

--- a/packages/zig_objc/flake.lock
+++ b/packages/zig_objc/flake.lock
@@ -1,0 +1,146 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1759233736,
+        "narHash": "sha256-xv9wRPGkBfaMil8j2N7Q9LTn9rTiIX3egAGVWnx6Di4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6a976061fb5305de938de2571af78755a7ec09ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1708161998,
+        "narHash": "sha256-6KnemmUorCvlcAvGziFosAVkrlWZGIc6UNT9GUYr0jQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "84d981bae8b5e783b3b548de505b22880559515f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "zig": "zig"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1759192380,
+        "narHash": "sha256-0BWJgt4OSzxCESij5oo8WLWrPZ+1qLp8KUQe32QeV4Q=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "0bcd1401ed43d10f10cbded49624206553e92f57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/packages/zig_objc/flake.nix
+++ b/packages/zig_objc/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "Objective-C runtime bindings for Zig";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/release-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    zig.url = "github:mitchellh/zig-overlay";
+
+    # Used for shell.nix
+    flake-compat = {
+      url = github:edolstra/flake-compat;
+      flake = false;
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  } @ inputs: let
+    overlays = [
+      # Other overlays
+      (final: prev: {
+        zigpkgs = inputs.zig.packages.${prev.system};
+      })
+    ];
+
+    # Our supported systems are the same supported systems as the Zig binaries
+    systems = builtins.attrNames inputs.zig.packages;
+  in
+    flake-utils.lib.eachSystem systems (
+      system: let
+        pkgs = import nixpkgs {inherit overlays system;};
+      in rec {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            zigpkgs."0.15.1"
+          ];
+        };
+
+        # For compatibility with older versions of the `nix` binary
+        devShell = self.devShells.${system}.default;
+      }
+    );
+}

--- a/packages/zig_objc/shell.nix
+++ b/packages/zig_objc/shell.nix
@@ -1,0 +1,12 @@
+(import
+  (
+    let
+      flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat;
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
+        sha256 = flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;})
+.shellNix

--- a/packages/zig_objc/src/autorelease.zig
+++ b/packages/zig_objc/src/autorelease.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+
+pub const AutoreleasePool = opaque {
+    /// Create a new autorelease pool. To clean it up, call deinit.
+    pub inline fn init() *AutoreleasePool {
+        return @ptrCast(objc_autoreleasePoolPush().?);
+    }
+
+    pub inline fn deinit(self: *AutoreleasePool) void {
+        objc_autoreleasePoolPop(self);
+    }
+};
+
+// I'm not sure if these are internal or not... they aren't in any headers,
+// but its how autorelease pools are implemented.
+extern "c" fn objc_autoreleasePoolPush() ?*anyopaque;
+extern "c" fn objc_autoreleasePoolPop(?*anyopaque) void;

--- a/packages/zig_objc/src/block.zig
+++ b/packages/zig_objc/src/block.zig
@@ -1,0 +1,329 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const objc = @import("main.zig");
+
+// We have to use the raw C allocator for all heap allocation in here
+// because the objc runtime expects `malloc` to be used. If you don't use
+// malloc you'll get segfaults because the objc runtime will try to free
+// the memory with `free`.
+const alloc = std.heap.raw_c_allocator;
+
+/// Creates a new block type with captured (closed over) values.
+///
+/// The CapturesArg is the a struct of captured values that will become
+/// available to the block. The Args is a tuple of types that are additional
+/// invocation-time arguments to the function. The Return param is the return
+/// type of the function.
+///
+/// Within the CapturesArg, only `objc.c.id` values will be automatically
+/// memory managed (retained and released) when the block is copied.
+/// If you are passing through NSObjects, you should use the `objc.c.id`
+/// type and recreate a richer Zig type on the other side.
+///
+/// The function that must be implemented is available as the `Fn` field.
+/// The first argument to the function is always a pointer to the `Context`
+/// type (see field in the struct). This has the captured values.
+///
+/// The captures struct is always available as the `Captures` field which
+/// makes it easy to use an inline type definition for the argument and
+/// reference the type in a named fashion later.
+///
+/// The returned block type can be initialized and invoked multiple times
+/// for different captures and arguments.
+///
+/// See the tests for an example.
+pub fn Block(
+    comptime CapturesArg: type,
+    comptime Args: anytype,
+    comptime Return: type,
+) type {
+    return struct {
+        const Self = @This();
+        const captures_info = @typeInfo(Captures).@"struct";
+        const InvokeFn = FnType(anyopaque);
+        const descriptor: Descriptor = .{
+            .reserved = 0,
+            .size = @sizeOf(Context),
+            .copy_helper = &descCopyHelper,
+            .dispose_helper = &descDisposeHelper,
+            .signature = &objc.comptimeEncode(InvokeFn),
+        };
+
+        /// This is the function type that is called back.
+        pub const Fn = FnType(Context);
+
+        /// The captures type, so it can be easily referenced again.
+        pub const Captures = CapturesArg;
+
+        /// This is the block context sent as the first paramter to the function.
+        pub const Context = BlockContext(Captures, InvokeFn);
+
+        /// Create a new block context. The block context is what is passed
+        /// (by reference) to functions that request a block.
+        ///
+        /// Note that if the captures contain reference types (like
+        /// NSObject), they will NOT be retained/released UNTIL the block
+        /// is copied. A block copy happens automatically when the block
+        /// is copied to a function that expects a block in ObjC.
+        ///
+        /// If you want to manualy copy a block, you can use the `copy`
+        /// function but you must pair it with a `dispose` function. This
+        /// should only be done for blocks that are not passed to external
+        /// functions where the runtime will automatically copy them (C,
+        /// C++, ObjC, etc.).
+        pub fn init(captures: Captures, func: *const Fn) Context {
+            // The block starts as a stack-allocated block. We let the
+            // runtime copy it to the heap. It doesn't seem to be advisable
+            // to allocate it on the heap directly since the way refcounting
+            // is done and so on is all private API.
+            var ctx: Context = undefined;
+            ctx.isa = NSConcreteStackBlock;
+            ctx.flags = .{
+                .copy_dispose = true,
+                .stret = @typeInfo(Return) == .@"struct",
+                .signature = true,
+            };
+            ctx.invoke = @ptrCast(func);
+            ctx.descriptor = &descriptor;
+            inline for (captures_info.fields) |field| {
+                @field(ctx, field.name) = @field(captures, field.name);
+            }
+
+            return ctx;
+        }
+
+        /// Invoke the block with the given arguments. The arguments are
+        /// the arguments to pass to the function beyond the captured scope.
+        pub fn invoke(ctx: *const Context, args: anytype) Return {
+            return @call(
+                .auto,
+                ctx.invoke,
+                .{ctx} ++ args,
+            );
+        }
+
+        /// Copies the given context by either literally copying it
+        /// to the heap or increasing the reference count. This must be
+        /// paired with a `release` call to release the block.
+        pub fn copy(ctx: *const Context) Allocator.Error!*Context {
+            const copied = _Block_copy(@ptrCast(@alignCast(ctx))) orelse
+                return error.OutOfMemory;
+            return @ptrCast(@alignCast(copied));
+        }
+
+        /// Release a copied block context. This must only be called on
+        /// contexts returned by the `copy` function. If you pass a block
+        /// context that was not copied, this will crash.
+        pub fn release(ctx: *const Context) void {
+            assert(@intFromPtr(ctx.isa) == @intFromPtr(NSConcreteMallocBlock));
+            _Block_release(@ptrCast(@alignCast(ctx)));
+        }
+
+        fn descCopyHelper(src: *anyopaque, dst: *anyopaque) callconv(.c) void {
+            const real_src: *Context = @ptrCast(@alignCast(src));
+            const real_dst: *Context = @ptrCast(@alignCast(dst));
+            inline for (captures_info.fields) |field| {
+                if (field.type == objc.c.id) {
+                    _Block_object_assign(
+                        @ptrCast(&@field(real_dst, field.name)),
+                        @field(real_src, field.name),
+                        .object,
+                    );
+                }
+            }
+        }
+
+        fn descDisposeHelper(src: *anyopaque) callconv(.c) void {
+            const real_src: *Context = @ptrCast(@alignCast(src));
+            inline for (captures_info.fields) |field| {
+                if (field.type == objc.c.id) {
+                    _Block_object_dispose(
+                        @field(real_src, field.name),
+                        .object,
+                    );
+                }
+            }
+        }
+
+        /// Creates a function type for the invocation function, but alters
+        /// the first arg. The first arg is a pointer so from an ABI perspective
+        /// this is always the same and can be safely casted.
+        fn FnType(comptime ContextArg: type) type {
+            var params: [Args.len + 1]std.builtin.Type.Fn.Param = undefined;
+            params[0] = .{ .is_generic = false, .is_noalias = false, .type = *const ContextArg };
+            for (Args, 1..) |Arg, i| {
+                params[i] = .{ .is_generic = false, .is_noalias = false, .type = Arg };
+            }
+
+            return @Type(.{
+                .@"fn" = .{
+                    .calling_convention = .c,
+                    .is_generic = false,
+                    .is_var_args = false,
+                    .return_type = Return,
+                    .params = &params,
+                },
+            });
+        }
+    };
+}
+
+/// This is the type of a block structure that is passed as the first
+/// argument to any block invocation. See Block.
+fn BlockContext(comptime Captures: type, comptime InvokeFn: type) type {
+    const captures_info = @typeInfo(Captures).@"struct";
+    var fields: [captures_info.fields.len + 5]std.builtin.Type.StructField = undefined;
+    fields[0] = .{
+        .name = "isa",
+        .type = ?*anyopaque,
+        .default_value_ptr = null,
+        .is_comptime = false,
+        .alignment = @alignOf(*anyopaque),
+    };
+    fields[1] = .{
+        .name = "flags",
+        .type = BlockFlags,
+        .default_value_ptr = null,
+        .is_comptime = false,
+        .alignment = @alignOf(c_int),
+    };
+    fields[2] = .{
+        .name = "reserved",
+        .type = c_int,
+        .default_value_ptr = null,
+        .is_comptime = false,
+        .alignment = @alignOf(c_int),
+    };
+    fields[3] = .{
+        .name = "invoke",
+        .type = *const InvokeFn,
+        .default_value_ptr = null,
+        .is_comptime = false,
+        .alignment = @typeInfo(*const InvokeFn).pointer.alignment,
+    };
+    fields[4] = .{
+        .name = "descriptor",
+        .type = *const Descriptor,
+        .default_value_ptr = null,
+        .is_comptime = false,
+        .alignment = @alignOf(*Descriptor),
+    };
+
+    for (captures_info.fields, 5..) |capture, i| {
+        switch (capture.type) {
+            comptime_int => @compileError("capture should not be a comptime_int, try using @as"),
+            comptime_float => @compileError("capture should not be a comptime_float, try using @as"),
+            else => {},
+        }
+
+        fields[i] = .{
+            .name = capture.name,
+            .type = capture.type,
+            .default_value_ptr = null,
+            .is_comptime = false,
+            .alignment = capture.alignment,
+        };
+    }
+
+    return @Type(.{
+        .@"struct" = .{
+            .layout = .@"extern",
+            .fields = &fields,
+            .decls = &.{},
+            .is_tuple = false,
+        },
+    });
+}
+
+// Pointer to opaque instead of anyopaque: https://github.com/ziglang/zig/issues/18461
+const NSConcreteStackBlock = @extern(*opaque {}, .{ .name = "_NSConcreteStackBlock" });
+const NSConcreteMallocBlock = @extern(*opaque {}, .{ .name = "_NSConcreteMallocBlock" });
+
+// https://github.com/llvm/llvm-project/blob/734d31a464e204db699c1cf9433494926deb2aa2/compiler-rt/lib/BlocksRuntime/Block_private.h#L101-L108
+const BlockFieldFlags = enum(c_int) {
+    object = 3, // BLOCK_FIELD_IS_OBJECT
+    block = 7, // BLOCK_FIELD_IS_BLOCK
+    byref = 8, // BLOCK_FIELD_IS_BYREF
+    weak = 16, // BLOCK_FIELD_IS_WEAK
+    byref_caller = 128, // BLOCK_BYREF_CALLER
+};
+
+extern "c" fn _Block_copy(src: *const anyopaque) callconv(.c) ?*anyopaque;
+extern "c" fn _Block_release(src: *const anyopaque) callconv(.c) void;
+extern "c" fn _Block_object_assign(dst: *anyopaque, src: *const anyopaque, flag: BlockFieldFlags) void;
+extern "c" fn _Block_object_dispose(src: *const anyopaque, flag: BlockFieldFlags) void;
+
+const Descriptor = extern struct {
+    reserved: c_ulong = 0,
+    size: c_ulong,
+    copy_helper: *const fn (dst: *anyopaque, src: *anyopaque) callconv(.c) void,
+    dispose_helper: *const fn (src: *anyopaque) callconv(.c) void,
+    signature: ?[*:0]const u8,
+};
+
+const BlockFlags = packed struct(c_int) {
+    _unused: u23 = 0,
+    noescape: bool = false,
+    _unused_2: u1 = 0,
+    copy_dispose: bool = false,
+    ctor: bool = false,
+    _unused_3: u1 = 0,
+    global: bool = false,
+    stret: bool = false,
+    signature: bool = false,
+    _unused_4: u1 = 0,
+};
+
+test "Block" {
+    const AddBlock = Block(struct {
+        x: i32,
+        y: i32,
+    }, .{}, i32);
+
+    const captures: AddBlock.Captures = .{
+        .x = 2,
+        .y = 3,
+    };
+
+    var block: AddBlock.Context = AddBlock.init(captures, (struct {
+        fn addFn(block: *const AddBlock.Context) callconv(.c) i32 {
+            return block.x + block.y;
+        }
+    }).addFn);
+
+    const ret = AddBlock.invoke(&block, .{});
+    try std.testing.expectEqual(@as(i32, 5), ret);
+
+    // Try copy and release
+    const copied = try AddBlock.copy(&block);
+    AddBlock.release(copied);
+}
+
+test "Block copy objc id" {
+    // Create an object, refcount 1
+    const NSObject = objc.getClass("NSObject").?;
+    const obj = NSObject.msgSend(
+        objc.Object,
+        objc.Sel.registerName("alloc"),
+        .{},
+    );
+    _ = obj.msgSend(objc.Object, objc.Sel.registerName("init"), .{});
+
+    const TestBlock = Block(struct {
+        id: objc.c.id,
+    }, .{}, i32);
+
+    var block = TestBlock.init(.{
+        .id = obj.value,
+    }, (struct {
+        fn addFn(block: *const TestBlock.Context) callconv(.c) i32 {
+            _ = block;
+            return 0;
+        }
+    }).addFn);
+
+    // Try copy and release
+    const copied = try TestBlock.copy(&block);
+    TestBlock.release(copied);
+}

--- a/packages/zig_objc/src/c.zig
+++ b/packages/zig_objc/src/c.zig
@@ -1,0 +1,24 @@
+pub const c = @cImport({
+    @cInclude("objc/runtime.h");
+    @cInclude("objc/message.h");
+});
+
+/// On some targets, Objective-C uses `i8` instead of `bool`.
+/// This helper casts a target value type to `bool`.
+pub fn boolResult(result: c.BOOL) bool {
+    return switch (c.BOOL) {
+        bool => result,
+        i8 => result == 1,
+        else => @compileError("unexpected boolean type"),
+    };
+}
+
+/// On some targets, Objective-C uses `i8` instead of `bool`.
+/// This helper casts a `bool` value to the target value type.
+pub fn boolParam(param: bool) c.BOOL {
+    return switch (c.BOOL) {
+        bool => param,
+        i8 => @intFromBool(param),
+        else => @compileError("unexpected boolean type"),
+    };
+}

--- a/packages/zig_objc/src/class.zig
+++ b/packages/zig_objc/src/class.zig
@@ -1,0 +1,223 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const cpkg = @import("c.zig");
+const c = cpkg.c;
+const boolResult = cpkg.boolResult;
+const objc = @import("main.zig");
+const MsgSend = @import("msg_send.zig").MsgSend;
+
+pub const Class = struct {
+    value: c.Class,
+
+    // Implement msgSend
+    const msg_send = MsgSend(Class);
+    pub const msgSend = msg_send.msgSend;
+    pub const msgSendSuper = msg_send.msgSendSuper;
+
+    // Returns a property with a given name of a given class.
+    pub fn getProperty(self: Class, name: [:0]const u8) ?objc.Property {
+        return objc.Property{
+            .value = c.class_getProperty(self.value, name.ptr) orelse return null,
+        };
+    }
+
+    /// Describes the properties declared by a class. This must be freed.
+    pub fn copyPropertyList(self: Class) []objc.Property {
+        var count: c_uint = undefined;
+        const list = @as([*c]objc.Property, @ptrCast(c.class_copyPropertyList(self.value, &count)));
+        if (count == 0) return list[0..0];
+        return list[0..count];
+    }
+
+    /// Describes the protocols adopted by a class. This must be freed.
+    pub fn copyProtocolList(self: Class) []objc.Protocol {
+        var count: c_uint = undefined;
+        const list = @as([*c]objc.Protocol, @ptrCast(c.class_copyProtocolList(self.value, &count)));
+        if (count == 0) return list[0..0];
+        return list[0..count];
+    }
+
+    pub fn isMetaClass(self: Class) bool {
+        return boolResult(c.class_isMetaClass(self.value));
+    }
+
+    pub fn getInstanceSize(self: Class) usize {
+        return c.class_getInstanceSize(self.value);
+    }
+
+    pub fn respondsToSelector(self: Class, sel: objc.Sel) bool {
+        return boolResult(c.class_respondsToSelector(self.value, sel.value));
+    }
+
+    pub fn conformsToProtocol(self: Class, protocol: objc.Protocol) bool {
+        return boolResult(c.class_conformsToProtocol(self.value, &protocol.value));
+    }
+
+    // currently only allows for overriding methods previously defined, e.g. by a superclass.
+    // imp should be a function with C calling convention
+    // whose first two arguments are a `c.id` and a `c.SEL`.
+    pub fn replaceMethod(self: Class, name: [:0]const u8, imp: anytype) void {
+        const fn_info = @typeInfo(@TypeOf(imp)).@"fn";
+        assert(std.meta.eql(fn_info.calling_convention, std.builtin.CallingConvention.c));
+        assert(fn_info.is_var_args == false);
+        assert(fn_info.params.len >= 2);
+        assert(fn_info.params[0].type == c.id);
+        assert(fn_info.params[1].type == c.SEL);
+        _ = c.class_replaceMethod(self.value, objc.sel(name).value, @ptrCast(&imp), null);
+    }
+
+    // allows adding new methods; returns true on success.
+    // imp should be a function with C calling convention
+    // whose first two arguments are a `c.id` and a `c.SEL`.
+    pub fn addMethod(self: Class, name: [:0]const u8, imp: anytype) bool {
+        const Fn = @TypeOf(imp);
+        const fn_info = @typeInfo(Fn).@"fn";
+        assert(std.meta.eql(fn_info.calling_convention, std.builtin.CallingConvention.c));
+        assert(fn_info.is_var_args == false);
+        assert(fn_info.params.len >= 2);
+        assert(fn_info.params[0].type == c.id);
+        assert(fn_info.params[1].type == c.SEL);
+        const encoding = comptime objc.comptimeEncode(Fn);
+        return boolResult(c.class_addMethod(
+            self.value,
+            objc.sel(name).value,
+            @ptrCast(&imp),
+            &encoding,
+        ));
+    }
+
+    // only call this function between allocateClassPair and registerClassPair
+    // this adds an Ivar of type `id`.
+    pub fn addIvar(self: Class, name: [:0]const u8) bool {
+        // The return type is i8 when we're cross compiling, unsure why.
+        const result = c.class_addIvar(self.value, name, @sizeOf(c.id), @alignOf(c.id), "@");
+        return boolResult(result);
+    }
+};
+
+pub fn getClass(name: [:0]const u8) ?Class {
+    return .{ .value = c.objc_getClass(name.ptr) orelse return null };
+}
+
+pub fn getMetaClass(name: [:0]const u8) ?Class {
+    return .{ .value = c.objc_getMetaClass(name) orelse return null };
+}
+
+// begin by calling this function, then call registerClassPair on the result when you are finished
+pub fn allocateClassPair(superclass: ?Class, name: [:0]const u8) ?Class {
+    return .{ .value = c.objc_allocateClassPair(
+        if (superclass) |cls| cls.value else null,
+        name.ptr,
+        0,
+    ) orelse return null };
+}
+
+pub fn registerClassPair(class: Class) void {
+    c.objc_registerClassPair(class.value);
+}
+
+pub fn disposeClassPair(class: Class) void {
+    c.objc_disposeClassPair(class.value);
+}
+
+test "getClass" {
+    const testing = std.testing;
+    const NSObject = getClass("NSObject");
+    try testing.expect(NSObject != null);
+    try testing.expect(getClass("NoWay") == null);
+}
+
+test "msgSend" {
+    const testing = std.testing;
+    const NSObject = getClass("NSObject").?;
+
+    // Should work with primitives
+    const id = NSObject.msgSend(c.id, "alloc", .{});
+    try testing.expect(id != null);
+    {
+        const obj: objc.Object = .{ .value = id };
+        obj.msgSend(void, "dealloc", .{});
+    }
+
+    // Should work with our wrappers
+    const obj = NSObject.msgSend(objc.Object, "alloc", .{});
+    try testing.expect(obj.value != null);
+    obj.msgSend(void, "dealloc", .{});
+}
+
+test "getProperty" {
+    const testing = std.testing;
+    const NSObject = getClass("NSObject").?;
+
+    try testing.expect(NSObject.getProperty("className") != null);
+    try testing.expect(NSObject.getProperty("nope") == null);
+}
+
+test "copyProperyList" {
+    const testing = std.testing;
+    const NSObject = getClass("NSObject").?;
+
+    const list = NSObject.copyPropertyList();
+    defer objc.free(list);
+    try testing.expect(list.len > 0);
+}
+
+test "allocatecClassPair and replaceMethod" {
+    const testing = std.testing;
+    const NSObject = getClass("NSObject").?;
+    var my_object = allocateClassPair(NSObject, "my_object").?;
+    my_object.replaceMethod("hash", struct {
+        fn inner(target: c.id, sel: c.SEL) callconv(.c) u64 {
+            _ = sel;
+            _ = target;
+            return 69;
+        }
+    }.inner);
+    registerClassPair(my_object);
+    defer disposeClassPair(my_object);
+    const object: objc.Object = .{
+        .value = my_object.msgSend(c.id, "alloc", .{}),
+    };
+    defer object.msgSend(void, "dealloc", .{});
+    try testing.expectEqual(@as(u64, 69), object.msgSend(u64, "hash", .{}));
+}
+
+test "Ivars" {
+    const testing = std.testing;
+    const NSObject = getClass("NSObject").?;
+    var my_object = allocateClassPair(NSObject, "my_object").?;
+    try testing.expectEqual(true, my_object.addIvar("my_ivar"));
+    registerClassPair(my_object);
+    defer disposeClassPair(my_object);
+    const object: objc.Object = .{
+        .value = my_object.msgSend(c.id, "alloc", .{}),
+    };
+    defer object.msgSend(void, "dealloc", .{});
+    const NSString = getClass("NSString").?;
+    const my_string = NSString.msgSend(objc.Object, "stringWithUTF8String:", .{"69---nice"});
+    defer my_string.msgSend(void, "dealloc", .{});
+    object.setInstanceVariable("my_ivar", my_string);
+    const my_ivar = object.getInstanceVariable("my_ivar");
+    const slice = std.mem.sliceTo(my_ivar.getProperty([*c]const u8, "UTF8String"), 0);
+    try testing.expectEqualSlices(u8, "69---nice", slice);
+}
+
+test "addMethod" {
+    const testing = std.testing;
+    const My_Class = setup: {
+        const My_Class = allocateClassPair(objc.getClass("NSObject").?, "my_class").?;
+        defer registerClassPair(My_Class);
+        std.debug.assert(My_Class.addMethod("my_addition", struct {
+            fn imp(target: objc.c.id, sel: objc.c.SEL, a: i32, b: i32) callconv(.c) i32 {
+                _ = sel;
+                _ = target;
+                return a + b;
+            }
+        }.imp));
+        break :setup My_Class;
+    };
+    const result = My_Class.msgSend(objc.Object, "alloc", .{})
+        .msgSend(objc.Object, "init", .{})
+        .msgSend(i32, "my_addition", .{ @as(i32, 2), @as(i32, 3) });
+    try testing.expectEqual(@as(i32, 5), result);
+}

--- a/packages/zig_objc/src/encoding.zig
+++ b/packages/zig_objc/src/encoding.zig
@@ -1,0 +1,405 @@
+const std = @import("std");
+const objc = @import("main.zig");
+const c = @import("c.zig").c;
+const assert = std.debug.assert;
+const testing = std.testing;
+
+/// how much space do we need to encode this type?
+fn comptimeN(comptime T: type) usize {
+    comptime {
+        const encoding = objc.Encoding.init(T);
+
+        // Figure out how much space we need
+        var stream: std.io.Writer.Discarding = .init(&.{});
+        stream.writer.print("{f}", .{encoding}) catch unreachable;
+        return stream.count;
+    }
+}
+
+/// Encode a type into a comptime string.
+pub fn comptimeEncode(comptime T: type) [comptimeN(T):0]u8 {
+    comptime {
+        const encoding = objc.Encoding.init(T);
+
+        // Build our final signature
+        var buf: [comptimeN(T) + 1]u8 = undefined;
+        var fbs: std.io.Writer = .fixed(buf[0 .. buf.len - 1]);
+        fbs.print("{f}", .{encoding}) catch unreachable;
+        buf[buf.len - 1] = 0;
+
+        return buf[0 .. buf.len - 1 :0].*;
+    }
+}
+
+/// Encoding union which parses type information and turns it into Obj-C
+/// runtime Type Encodings.
+///
+/// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+pub const Encoding = union(enum) {
+    char,
+    int,
+    short,
+    long,
+    longlong,
+    uchar,
+    uint,
+    ushort,
+    ulong,
+    ulonglong,
+    float,
+    double,
+    bool,
+    void,
+    char_string,
+    object,
+    class,
+    selector,
+    array: struct { arr_type: type, len: usize },
+    structure: struct { struct_type: type, show_type_spec: bool },
+    @"union": struct { union_type: type, show_type_spec: bool },
+    bitfield: u32,
+    pointer: struct { ptr_type: type, size: std.builtin.Type.Pointer.Size },
+    function: std.builtin.Type.Fn,
+    unknown,
+
+    pub fn init(comptime T: type) Encoding {
+        return switch (T) {
+            i8, c_char => .char,
+            c_short => .short,
+            i32, c_int => .int,
+            c_long => .long,
+            i64, c_longlong => .longlong,
+            u8 => .uchar,
+            c_ushort => .ushort,
+            u32, c_uint => .uint,
+            c_ulong => .ulong,
+            u64, c_ulonglong => .ulonglong,
+            f32 => .float,
+            f64 => .double,
+            bool => .bool,
+            void, anyopaque => .void,
+            [*c]u8, [*c]const u8 => .char_string,
+            c.SEL, objc.Sel => .selector,
+            c.Class, objc.Class => .class,
+            c.id, objc.Object => .object,
+            else => switch (@typeInfo(T)) {
+                .@"opaque" => .void,
+                .@"enum" => |m| .init(m.tag_type),
+                .array => |arr| .{ .array = .{ .len = arr.len, .arr_type = arr.child } },
+                .@"struct" => |m| switch (m.layout) {
+                    .@"packed" => .init(m.backing_integer.?),
+                    else => .{ .structure = .{ .struct_type = T, .show_type_spec = true } },
+                },
+                .@"union" => .{ .@"union" = .{
+                    .union_type = T,
+                    .show_type_spec = true,
+                } },
+                .optional => |m| switch (@typeInfo(m.child)) {
+                    .pointer => |ptr| .{ .pointer = .{ .ptr_type = m.child, .size = ptr.size } },
+                    else => @compileError("unsupported non-pointer optional type: " ++ @typeName(T)),
+                },
+                .pointer => |ptr| .{ .pointer = .{ .ptr_type = T, .size = ptr.size } },
+                .@"fn" => |fn_info| .{ .function = fn_info },
+                else => @compileError("unsupported type: " ++ @typeName(T)),
+            },
+        };
+    }
+
+    pub fn format(
+        comptime self: Encoding,
+        writer: *std.io.Writer,
+    ) !void {
+        switch (self) {
+            .char => try writer.writeAll("c"),
+            .int => try writer.writeAll("i"),
+            .short => try writer.writeAll("s"),
+            .long => try writer.writeAll("l"),
+            .longlong => try writer.writeAll("q"),
+            .uchar => try writer.writeAll("C"),
+            .uint => try writer.writeAll("I"),
+            .ushort => try writer.writeAll("S"),
+            .ulong => try writer.writeAll("L"),
+            .ulonglong => try writer.writeAll("Q"),
+            .float => try writer.writeAll("f"),
+            .double => try writer.writeAll("d"),
+            .bool => try writer.writeAll("B"),
+            .void => try writer.writeAll("v"),
+            .char_string => try writer.writeAll("*"),
+            .object => try writer.writeAll("@"),
+            .class => try writer.writeAll("#"),
+            .selector => try writer.writeAll(":"),
+            .array => |a| {
+                try writer.print("[{}", .{a.len});
+                const encode_type = init(a.arr_type);
+                try encode_type.format(writer);
+                try writer.writeAll("]");
+            },
+            .structure => |s| {
+                const struct_info = @typeInfo(s.struct_type);
+                assert(struct_info.@"struct".layout == .@"extern");
+
+                // Strips the fully qualified type name to leave just the
+                // type name. Used in naming the Struct in an encoding.
+                var type_name_iter = std.mem.splitBackwardsScalar(u8, @typeName(s.struct_type), '.');
+                const type_name = type_name_iter.first();
+                try writer.print("{{{s}", .{type_name});
+
+                // if the encoding should show the internal type specification
+                // of the struct (determined by levels of pointer indirection)
+                if (s.show_type_spec) {
+                    try writer.writeAll("=");
+                    inline for (struct_info.@"struct".fields) |field| {
+                        const field_encode = init(field.type);
+                        try field_encode.format(writer);
+                    }
+                }
+
+                try writer.writeAll("}");
+            },
+            .@"union" => |u| {
+                const union_info = @typeInfo(u.union_type);
+                assert(union_info.@"union".layout == .@"extern");
+
+                // Strips the fully qualified type name to leave just the
+                // type name. Used in naming the Union in an encoding
+                var type_name_iter = std.mem.splitBackwardsScalar(u8, @typeName(u.union_type), '.');
+                const type_name = type_name_iter.first();
+                try writer.print("({s}", .{type_name});
+
+                // if the encoding should show the internal type specification
+                // of the Union (determined by levels of pointer indirection)
+                if (u.show_type_spec) {
+                    try writer.writeAll("=");
+                    inline for (union_info.@"union".fields) |field| {
+                        const field_encode = init(field.type);
+                        try field_encode.format(writer);
+                    }
+                }
+
+                try writer.writeAll(")");
+            },
+            .bitfield => |b| try writer.print("b{}", .{b}), // not sure if needed from Zig -> Obj-C
+            .pointer => |p| {
+                switch (p.size) {
+                    .one => {
+                        // get the pointer info (count of levels of direction
+                        // and the underlying type)
+                        const pointer_info = indirectionCountAndType(p.ptr_type);
+                        for (0..pointer_info.indirection_levels) |_| {
+                            try writer.writeAll("^");
+                        }
+
+                        // create a new Encoding union from the pointers child
+                        // type, giving an encoding of the underlying pointer type
+                        comptime var encoding = init(pointer_info.child);
+
+                        // if the indirection levels are greater than 1, for
+                        // certain types that means getting rid of it's
+                        // internal type specification
+                        //
+                        // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100
+                        if (pointer_info.indirection_levels > 1) {
+                            switch (encoding) {
+                                .structure => |*s| s.show_type_spec = false,
+                                .@"union" => |*u| u.show_type_spec = false,
+                                else => {},
+                            }
+                        }
+
+                        // call this format function again, this time with the child type encoding
+                        try encoding.format(writer);
+                    },
+                    else => @compileError("Pointer size not supported for encoding"),
+                }
+            },
+            .function => |fn_info| {
+                assert(std.meta.eql(fn_info.calling_convention, std.builtin.CallingConvention.c));
+
+                // Return type is first in a method encoding
+                const ret_type_enc = init(fn_info.return_type.?);
+                try ret_type_enc.format(writer);
+                inline for (fn_info.params) |param| {
+                    const param_enc = init(param.type.?);
+                    try param_enc.format(writer);
+                }
+            },
+            .unknown => {},
+        }
+    }
+};
+
+/// This comptime function gets the levels of indirection from a type. If the type is a pointer type it
+/// returns the underlying type from the pointer (the child) by walking the pointer to that child.
+/// Returns the type and 0 for count if the type isn't a pointer
+fn indirectionCountAndType(comptime T: type) struct {
+    child: type,
+    indirection_levels: comptime_int,
+} {
+    var WalkType = T;
+    var count: usize = 0;
+    while (@typeInfo(WalkType) == .pointer) : (count += 1) {
+        WalkType = @typeInfo(WalkType).pointer.child;
+    }
+
+    return .{ .child = WalkType, .indirection_levels = count };
+}
+
+fn encodingMatchesType(comptime T: type, expected_encoding: []const u8) !void {
+    var buf: [200]u8 = undefined;
+    const enc = Encoding.init(T);
+    const enc_string = try std.fmt.bufPrint(&buf, "{f}", .{enc});
+    try testing.expectEqualStrings(expected_encoding, enc_string);
+}
+
+test "i8 to Encoding.char encoding" {
+    try encodingMatchesType(i8, "c");
+}
+
+test "c_char to Encoding.char encoding" {
+    try encodingMatchesType(c_char, "c");
+}
+
+test "c_short to Encoding.short encoding" {
+    try encodingMatchesType(c_short, "s");
+}
+
+test "c_int to Encoding.int encoding" {
+    try encodingMatchesType(c_int, "i");
+}
+
+test "c_long to Encoding.long encoding" {
+    try encodingMatchesType(c_long, "l");
+}
+
+test "c_longlong to Encoding.longlong encoding" {
+    try encodingMatchesType(c_longlong, "q");
+}
+
+test "u8 to Encoding.uchar encoding" {
+    try encodingMatchesType(u8, "C");
+}
+
+test "c_ushort to Encoding.ushort encoding" {
+    try encodingMatchesType(c_ushort, "S");
+}
+
+test "c_uint to Encoding.uint encoding" {
+    try encodingMatchesType(c_uint, "I");
+}
+
+test "c_ulong to Encoding.ulong encoding" {
+    try encodingMatchesType(c_ulong, "L");
+}
+
+test "c_ulonglong to Encoding.ulonglong encoding" {
+    try encodingMatchesType(c_ulonglong, "Q");
+}
+
+test "f32 to Encoding.float encoding" {
+    try encodingMatchesType(f32, "f");
+}
+
+test "f64 to Encoding.double encoding" {
+    try encodingMatchesType(f64, "d");
+}
+
+test "[4]i8 to Encoding.array encoding" {
+    try encodingMatchesType([4]i8, "[4c]");
+}
+
+test "*u8 to Encoding.pointer encoding" {
+    try encodingMatchesType(*u8, "^C");
+}
+
+test "**u8 to Encoding.pointer encoding" {
+    try encodingMatchesType(**u8, "^^C");
+}
+
+test "?*u8 to Encoding.pointer encoding" {
+    try encodingMatchesType(?*u8, "^C");
+}
+
+test "Enum(c_uint) to Encoding.uint encoding" {
+    const TestEnum = enum(c_uint) {};
+    try encodingMatchesType(TestEnum, "I");
+}
+
+test "TestPackedStruct to Encoding.uint encoding" {
+    const TestPackedStruct = packed struct(u32) {
+        _: u32,
+    };
+    try encodingMatchesType(TestPackedStruct, "I");
+}
+
+test "*TestStruct to Encoding.pointer encoding" {
+    const TestStruct = extern struct {
+        float: f32,
+        char: u8,
+    };
+    try encodingMatchesType(*TestStruct, "^{TestStruct=fC}");
+}
+
+test "**TestStruct to Encoding.pointer encoding" {
+    const TestStruct = extern struct {
+        float: f32,
+        char: u8,
+    };
+    try encodingMatchesType(**TestStruct, "^^{TestStruct}");
+}
+
+test "*TestStruct with 2 level indirection NestedStruct to Encoding.pointer encoding" {
+    const NestedStruct = extern struct {
+        char: i8,
+    };
+    const TestStruct = extern struct {
+        float: f32,
+        char: u8,
+        nested: **NestedStruct,
+    };
+    try encodingMatchesType(*TestStruct, "^{TestStruct=fC^^{NestedStruct}}");
+}
+
+test "*TestOpaque to Encoding.pointer encoding" {
+    const TestOpaque = opaque {};
+    try encodingMatchesType(*TestOpaque, "^v");
+}
+
+test "?*TestOpaque to Encoding.pointer encoding" {
+    const TestOpaque = opaque {};
+    try encodingMatchesType(?*TestOpaque, "^v");
+}
+
+test "Union to Encoding.union encoding" {
+    const TestUnion = extern union {
+        int: c_int,
+        short: c_short,
+        long: c_long,
+    };
+    try encodingMatchesType(TestUnion, "(TestUnion=isl)");
+}
+
+test "*Union to Encoding.union encoding" {
+    const TestUnion = extern union {
+        int: c_int,
+        short: c_short,
+        long: c_long,
+    };
+    try encodingMatchesType(*TestUnion, "^(TestUnion=isl)");
+}
+
+test "**Union to Encoding.union encoding" {
+    const TestUnion = extern union {
+        int: c_int,
+        short: c_short,
+        long: c_long,
+    };
+    try encodingMatchesType(**TestUnion, "^^(TestUnion)");
+}
+
+test "Fn to Encoding.function encoding" {
+    const test_fn = struct {
+        fn add(_: c.id, _: c.SEL, _: i8) callconv(.c) void {}
+    };
+
+    try encodingMatchesType(@TypeOf(test_fn.add), "v@:c");
+}

--- a/packages/zig_objc/src/iterator.zig
+++ b/packages/zig_objc/src/iterator.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const objc = @import("main.zig");
+
+// From <Foundation/NSEnumerator.h>.
+const NSFastEnumerationState = extern struct {
+    state: c_ulong = 0,
+    itemsPtr: ?[*]objc.c.id = null,
+    mutationsPtr: ?*c_ulong = null,
+    extra: [5]c_ulong = [_]c_ulong{0} ** 5,
+};
+
+/// An iterator that uses the fast enumeration protocol[1] to iterate over
+/// objects in an Objective-C collection. This can be used with any object
+/// that conforms to the `NSFastEnumeration` protocol.
+///
+/// [1]: Nhttps://developer.apple.com/documentation/foundation/nsfastenumeration
+pub const Iterator = struct {
+    object: objc.Object,
+    sel: objc.Sel,
+    state: NSFastEnumerationState = .{},
+    initial_mutations_value: ?c_ulong = null,
+    // Clang compiles `for…in` loops with a size 16 buffer.
+    buffer: [16]objc.c.id = [_]objc.c.id{null} ** 16,
+    slice: []const objc.c.id = &.{},
+
+    pub fn init(object: objc.Object) Iterator {
+        return .{
+            .object = object,
+            .sel = objc.sel("countByEnumeratingWithState:objects:count:"),
+        };
+    }
+
+    pub fn next(self: *Iterator) ?objc.Object {
+        if (self.slice.len == 0) {
+            // Ask for some more objects.
+            const count = self.object.msgSend(c_ulong, self.sel, .{
+                &self.state,
+                &self.buffer,
+                self.buffer.len,
+            });
+            if (self.initial_mutations_value) |value| {
+                // Call the mutation handler if the mutations value has
+                // changed since the start of iteration.
+                if (value != self.state.mutationsPtr.?.*) {
+                    objc.c.objc_enumerationMutation(self.object.value);
+                }
+            } else {
+                self.initial_mutations_value = self.state.mutationsPtr.?.*;
+            }
+            self.slice = self.state.itemsPtr.?[0..count];
+        }
+
+        if (self.slice.len == 0) return null;
+
+        const first = self.slice[0];
+        self.slice = self.slice[1..];
+        return objc.Object.fromId(first);
+    }
+};
+
+test "NSArray iteration" {
+    const testing = std.testing;
+    const NSArray = objc.getClass("NSMutableArray").?;
+    const NSNumber = objc.getClass("NSNumber").?;
+    const array = NSArray.msgSend(
+        objc.Object,
+        "arrayWithCapacity:",
+        .{@as(c_ulong, 10)},
+    );
+    defer array.release();
+    for (0..@as(c_int, 10)) |i| {
+        const i_number = NSNumber.msgSend(objc.Object, "numberWithInt:", .{i});
+        defer i_number.release();
+        array.msgSend(void, "addObject:", .{i_number});
+    }
+    var result: c_int = 0;
+    var iter = array.iterate();
+    while (iter.next()) |elem| {
+        result = (result * 10) + elem.getProperty(c_int, "intValue");
+    }
+    try testing.expectEqual(123456789, result);
+}
+
+test "NSDictionary iteration" {
+    const testing = std.testing;
+    const NSMutableDictionary = objc.getClass("NSMutableDictionary").?;
+    const NSNumber = objc.getClass("NSNumber").?;
+    const dict = NSMutableDictionary.msgSend(
+        objc.Object,
+        "dictionaryWithCapacity:",
+        .{@as(c_ulong, 100)},
+    );
+    defer dict.release();
+    for (0..@as(c_int, 100)) |i| {
+        const i_number = NSNumber.msgSend(objc.Object, "numberWithInt:", .{i});
+        defer i_number.release();
+        dict.msgSend(void, "setValue:forKey:", .{
+            i_number,
+            i_number.getProperty(objc.Object, "stringValue"),
+        });
+    }
+    var result: c_int = 0;
+    var iter = dict.iterate();
+    while (iter.next()) |key| {
+        const value = dict.msgSend(objc.Object, "valueForKey:", .{key});
+        result += value.getProperty(c_int, "intValue");
+    }
+    try testing.expectEqual(4950, result);
+}

--- a/packages/zig_objc/src/main.zig
+++ b/packages/zig_objc/src/main.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+const autorelease = @import("autorelease.zig");
+const block = @import("block.zig");
+const class = @import("class.zig");
+const encoding = @import("encoding.zig");
+const iterator = @import("iterator.zig");
+const object = @import("object.zig");
+const property = @import("property.zig");
+const protocol = @import("protocol.zig");
+const selpkg = @import("sel.zig");
+
+pub const c = @import("c.zig").c;
+pub const AutoreleasePool = autorelease.AutoreleasePool;
+pub const Block = block.Block;
+pub const Class = class.Class;
+pub const getClass = class.getClass;
+pub const getMetaClass = class.getMetaClass;
+pub const allocateClassPair = class.allocateClassPair;
+pub const registerClassPair = class.registerClassPair;
+pub const disposeClassPair = class.disposeClassPair;
+pub const Encoding = encoding.Encoding;
+pub const comptimeEncode = encoding.comptimeEncode;
+pub const Iterator = iterator.Iterator;
+pub const Object = object.Object;
+pub const Property = property.Property;
+pub const Protocol = protocol.Protocol;
+pub const getProtocol = protocol.getProtocol;
+pub const sel = selpkg.sel;
+pub const Sel = selpkg.Sel;
+
+/// This just calls the C allocator free. Some things need to be freed
+/// and this is how they can be freed for objc.
+pub inline fn free(ptr: anytype) void {
+    std.heap.c_allocator.free(ptr);
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/packages/zig_objc/src/msg_send.zig
+++ b/packages/zig_objc/src/msg_send.zig
@@ -1,0 +1,244 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+const c = @import("c.zig").c;
+const objc = @import("main.zig");
+
+/// Returns a struct that implements the msgSend function for type T.
+pub fn MsgSend(comptime T: type) type {
+    // 1. T should be a struct
+    // 2. T should have a field "value" that can be an "id" (same size)
+
+    return struct {
+        /// Invoke a selector on the target, i.e. an instance method on an
+        /// object or a class method on a class. The args should be a tuple.
+        pub fn msgSend(
+            target: T,
+            comptime Return: type,
+            sel_raw: anytype,
+            args: anytype,
+        ) Return {
+            // Our one special-case: If the return type is our own Object
+            // type then we wrap it.
+            const is_object = Return == objc.Object;
+
+            // Our actual return value is an "id" if we are using one of
+            // our built-in types (see above). Otherwise, we trust the caller.
+            const RealReturn = if (is_object) c.id else Return;
+
+            // We accept multiple types for sel but we need to turn it into
+            // an objc.sel ultimately.
+            const sel: objc.Sel = switch (@TypeOf(sel_raw)) {
+                objc.Sel => sel_raw,
+                else => objc.sel(sel_raw),
+            };
+
+            // Build our function type and call it
+            const Fn = MsgSendFn(RealReturn, @TypeOf(target.value), @TypeOf(args));
+            const msg_send_fn = comptime msgSendPtr(RealReturn, false);
+            const msg_send_ptr: *const Fn = @ptrCast(msg_send_fn);
+            const result = @call(.auto, msg_send_ptr, .{ target.value, sel.value } ++ args);
+
+            if (!is_object) return result;
+            return .{ .value = result };
+        }
+
+        /// Invoke a selector on the superclass.
+        pub fn msgSendSuper(
+            target: T,
+            superclass: objc.Class,
+            comptime Return: type,
+            sel_raw: anytype,
+            args: anytype,
+        ) Return {
+            // See msgSend for in depth comments on all of this. This is
+            // effectively the same logic.
+            const is_object = Return == objc.Object;
+            const RealReturn = if (is_object) c.id else Return;
+            const sel: objc.Sel = switch (@TypeOf(sel_raw)) {
+                objc.Sel => sel_raw,
+                else => objc.sel(sel_raw),
+            };
+
+            const Fn = MsgSendFn(RealReturn, *c.objc_super, @TypeOf(args));
+            const msg_send_fn = comptime msgSendPtr(RealReturn, true);
+            const msg_send_ptr: *const Fn = @ptrCast(msg_send_fn);
+            var super: c.objc_super = .{
+                .receiver = target.value,
+                .class = superclass.value,
+            };
+            const result = @call(.auto, msg_send_ptr, .{ &super, sel.value } ++ args);
+
+            if (!is_object) return result;
+            return .{ .value = result };
+        }
+
+        /// Returns the objc_msgSend or objc_msgSendSuper pointer for the
+        /// given return type.
+        fn msgSendPtr(
+            comptime Return: type,
+            comptime super: bool,
+        ) *const fn () callconv(.c) void {
+            // See objc/message.h. The high-level is that depending on the
+            // target architecture and return type, we must use a different
+            // objc_msgSend function.
+            return switch (builtin.target.cpu.arch) {
+                // Aarch64 uses objc_msgSend for everything. Hurray!
+                .aarch64 => if (super) &c.objc_msgSendSuper else &c.objc_msgSend,
+
+                // x86_64 depends on the return type...
+                .x86_64 => switch (@typeInfo(Return)) {
+                    // Most types use objc_msgSend
+                    inline .int,
+                    .bool,
+                    .@"enum",
+                    .pointer,
+                    .void,
+                    => if (super) &c.objc_msgSendSuper else &c.objc_msgSend,
+
+                    .optional => |opt| opt: {
+                        assert(@typeInfo(opt.child) == .pointer);
+                        break :opt if (super) &c.objc_msgSendSuper else &c.objc_msgSend;
+                    },
+
+                    // Structs must use objc_msgSend_stret.
+                    // NOTE: This is probably WAY more complicated... we only
+                    // call this if the struct is NOT returned as a register.
+                    // And that depends on the size of the struct. But I don't
+                    // know what the breakpoint actually is for that. This SO
+                    // answer says 16 bytes so I'm going to use that but I have
+                    // no idea...
+                    .@"struct" => blk: {
+                        if (@sizeOf(Return) > 16) {
+                            break :blk if (super)
+                                &c.objc_msgSendSuper_stret
+                            else
+                                &c.objc_msgSend_stret;
+                        } else {
+                            break :blk if (super)
+                                &c.objc_msgSendSuper
+                            else
+                                &c.objc_msgSend;
+                        }
+                    },
+
+                    // Floats use objc_msgSend_fpret for f64 on x86_64,
+                    // but normal msgSend for other bit sizes. i386 has
+                    // more complex rules but we don't support i386 at the time
+                    // of this comment and probably never will since all i386
+                    // Apple models are discontinued at this point.
+                    .float => |float| switch (float.bits) {
+                        64 => if (super) &c.objc_msgSendSuper_fpret else &c.objc_msgSend_fpret,
+                        else => if (super) &c.objc_msgSendSuper else &c.objc_msgSend,
+                    },
+
+                    // Otherwise we log in case we need to add a new case above
+                    else => {
+                        @compileLog(@typeInfo(Return));
+                        @compileError("unsupported return type for objc runtime on x86_64");
+                    },
+                },
+
+                else => @compileError("unsupported objc architecture"),
+            };
+        }
+    };
+}
+
+/// This returns a function body type for `obj_msgSend` that matches
+/// the given return type, target type, and arguments tuple type.
+///
+/// obj_msgSend is a really interesting function, because it doesn't act
+/// like a typical function. You have to call it with the C ABI as if you're
+/// calling the true target function, not as a varargs C function. Therefore
+/// you have to cast obj_msgSend to a function pointer type of the final
+/// destination function, then call that.
+///
+/// Example: you have an ObjC function like this:
+///
+///     @implementation Foo
+///     - (void)log: (float)x { /* stuff */ }
+///
+/// If you call it like this, it won't work (you'll get garbage):
+///
+///     objc_msgSend(obj, @selector(log:), (float)PI);
+///
+/// You have to call it like this:
+///
+///     ((void (*)(id, SEL, float))objc_msgSend)(obj, @selector(log:), M_PI);
+///
+/// This comptime function returns the function body type that can be used
+/// to cast and call for the proper C ABI behavior.
+fn MsgSendFn(
+    comptime Return: type,
+    comptime Target: type,
+    comptime Args: type,
+) type {
+    const argsInfo = @typeInfo(Args).@"struct";
+    assert(argsInfo.is_tuple);
+
+    // Target must always be an "id". Lots of types (Class, Object, etc.)
+    // are an "id" so we just make sure the sizes match for ABI reasons.
+    assert(@sizeOf(Target) == @sizeOf(c.id));
+
+    // Build up our argument types.
+    const Fn = std.builtin.Type.Fn;
+    const params: []Fn.Param = params: {
+        var acc: [argsInfo.fields.len + 2]Fn.Param = undefined;
+
+        // First argument is always the target and selector.
+        acc[0] = .{ .type = Target, .is_generic = false, .is_noalias = false };
+        acc[1] = .{ .type = c.SEL, .is_generic = false, .is_noalias = false };
+
+        // Remaining arguments depend on the args given, in the order given
+        for (argsInfo.fields, 0..) |field, i| {
+            acc[i + 2] = .{
+                .type = field.type,
+                .is_generic = false,
+                .is_noalias = false,
+            };
+        }
+
+        break :params &acc;
+    };
+
+    return @Type(.{
+        .@"fn" = .{
+            .calling_convention = .c,
+            .is_generic = false,
+            .is_var_args = false,
+            .return_type = Return,
+            .params = params,
+        },
+    });
+}
+
+test {
+    const testing = std.testing;
+    try testing.expectEqual(fn (
+        c.id,
+        c.SEL,
+    ) callconv(.c) u64, MsgSendFn(u64, c.id, @TypeOf(.{})));
+    try testing.expectEqual(fn (c.id, c.SEL, u16, u32) callconv(.c) u64, MsgSendFn(u64, c.id, @TypeOf(.{
+        @as(u16, 0),
+        @as(u32, 0),
+    })));
+}
+
+test "subClass" {
+    const Subclass = objc.allocateClassPair(objc.getClass("NSObject").?, "subclass").?;
+    defer objc.disposeClassPair(Subclass);
+    const str = struct {
+        fn inner(target: objc.c.id, sel: objc.c.SEL) callconv(.c) objc.c.id {
+            _ = sel;
+            const self = objc.Object.fromId(target);
+            self.msgSendSuper(objc.getClass("NSObject").?, void, "init", .{});
+            return target;
+        }
+    };
+    Subclass.replaceMethod("init", str.inner);
+    objc.registerClassPair(Subclass);
+    const subclass_obj = Subclass.msgSend(objc.Object, "alloc", .{});
+    defer subclass_obj.msgSend(void, "dealloc", .{});
+    subclass_obj.msgSend(void, "init", .{});
+}

--- a/packages/zig_objc/src/object.zig
+++ b/packages/zig_objc/src/object.zig
@@ -1,0 +1,220 @@
+const std = @import("std");
+const cpkg = @import("c.zig");
+const c = cpkg.c;
+const boolResult = cpkg.boolResult;
+const objc = @import("main.zig");
+const MsgSend = @import("msg_send.zig").MsgSend;
+const Iterator = @import("iterator.zig").Iterator;
+
+/// Object is an instance of a class.
+pub const Object = struct {
+    value: c.id,
+
+    // Implement msgSend
+    const msg_send = MsgSend(Object);
+    pub const msgSend = msg_send.msgSend;
+    pub const msgSendSuper = msg_send.msgSendSuper;
+
+    /// Convert a raw "id" into an Object. id must fit the size of the
+    /// normal C "id" type (i.e. a `usize`).
+    pub fn fromId(id: anytype) Object {
+        if (@sizeOf(@TypeOf(id)) != @sizeOf(c.id)) {
+            @compileError("invalid id type");
+        }
+
+        // Some pointers in Objective-C are "tagged pointers", which
+        // may be used for small objects and literals (NSNumber, NSString).
+        // It's an internal implementation detail that replaces heap
+        // allocation with direct encoding within the pointer itself.
+        // This may result in UNALIGNED POINTERS!
+        const ptr: c.id = blk: {
+            @setRuntimeSafety(false);
+            break :blk @ptrCast(@alignCast(id));
+        };
+
+        return .{ .value = ptr };
+    }
+
+    /// Returns the class of an object.
+    pub fn getClass(self: Object) ?objc.Class {
+        return objc.Class{
+            .value = c.object_getClass(self.value) orelse return null,
+        };
+    }
+
+    /// Returns the class name of a given object.
+    pub fn getClassName(self: Object) [:0]const u8 {
+        return std.mem.sliceTo(c.object_getClassName(self.value), 0);
+    }
+
+    /// Set a property. This is a helper around getProperty and is
+    /// strictly less performant than doing it manually. Consider doing
+    /// this manually if performance is critical.
+    pub fn setProperty(self: Object, comptime n: [:0]const u8, v: anytype) void {
+        const Class = self.getClass().?;
+        const setter = setter: {
+            // See getProperty for why we do this.
+            if (Class.getProperty(n)) |prop| {
+                if (prop.copyAttributeValue("S")) |val| {
+                    defer objc.free(val);
+                    break :setter objc.sel(val);
+                }
+            }
+
+            break :setter objc.sel(
+                "set" ++
+                    [1]u8{std.ascii.toUpper(n[0])} ++
+                    n[1..n.len] ++
+                    ":",
+            );
+        };
+
+        self.msgSend(void, setter, .{v});
+    }
+
+    /// Get a property. This is a helper around Class.getProperty and is
+    /// strictly less performant than doing it manually. Consider doing
+    /// this manually if performance is critical.
+    pub fn getProperty(self: Object, comptime T: type, comptime n: [:0]const u8) T {
+        const Class = self.getClass().?;
+        const getter = getter: {
+            // Sometimes a property is not a property because it has been
+            // overloaded or something. I've found numerous occasions the
+            // Apple docs are just wrong, so we try to read it as a property
+            // but if we can't then we just call it as-is.
+            if (Class.getProperty(n)) |prop| {
+                if (prop.copyAttributeValue("G")) |val| {
+                    defer objc.free(val);
+                    break :getter objc.sel(val);
+                }
+            }
+
+            break :getter objc.sel(n);
+        };
+
+        return self.msgSend(T, getter, .{});
+    }
+
+    pub fn copy(self: Object, size: usize) Object {
+        return fromId(c.object_copy(self.value, size));
+    }
+
+    pub fn dispose(self: Object) void {
+        c.object_dispose(self.value);
+    }
+
+    pub fn isClass(self: Object) bool {
+        return boolResult(c.object_isClass(self.value));
+    }
+
+    pub fn getInstanceVariable(self: Object, name: [:0]const u8) Object {
+        const ivar = c.object_getInstanceVariable(self.value, name, null);
+        return fromId(c.object_getIvar(self.value, ivar));
+    }
+
+    pub fn setInstanceVariable(self: Object, name: [:0]const u8, val: Object) void {
+        const ivar = c.object_getInstanceVariable(self.value, name, null);
+        c.object_setIvar(self.value, ivar, val.value);
+    }
+
+    pub fn retain(self: Object) Object {
+        return fromId(objc_retain(self.value));
+    }
+
+    pub fn release(self: Object) void {
+        objc_release(self.value);
+    }
+
+    /// Return an iterator for this object. The object must implement the
+    /// `NSFastEnumeration` protocol.
+    pub fn iterate(self: Object) Iterator {
+        return Iterator.init(self);
+    }
+};
+
+extern "c" fn objc_retain(objc.c.id) objc.c.id;
+extern "c" fn objc_release(objc.c.id) void;
+
+fn retainCount(obj: Object) c_ulong {
+    return obj.msgSend(c_ulong, objc.Sel.registerName("retainCount"), .{});
+}
+
+test {
+    const testing = std.testing;
+    const NSObject = objc.getClass("NSObject").?;
+
+    // Should work with our wrappers
+    const obj = NSObject.msgSend(objc.Object, objc.Sel.registerName("alloc"), .{});
+    try testing.expect(obj.value != null);
+    try testing.expectEqualStrings("NSObject", obj.getClassName());
+    obj.msgSend(void, objc.sel("dealloc"), .{});
+}
+
+test "retain object" {
+    const testing = std.testing;
+    const NSObject = objc.getClass("NSObject").?;
+
+    const obj = NSObject.msgSend(objc.Object, objc.Sel.registerName("alloc"), .{});
+    _ = obj.msgSend(objc.Object, objc.Sel.registerName("init"), .{});
+    try testing.expectEqual(@as(c_ulong, 1), retainCount(obj));
+
+    _ = obj.retain();
+    try testing.expectEqual(@as(c_ulong, 2), retainCount(obj));
+
+    obj.release();
+    try testing.expectEqual(@as(c_ulong, 1), retainCount(obj));
+
+    obj.msgSend(void, objc.sel("dealloc"), .{});
+}
+
+test "tagged pointer" {
+    const testing = std.testing;
+
+    // We can't force Objective-C to provide us with an unaligned tagged
+    // pointer, so we try several times using different classes. We use
+    // different classes instead of values, since pointers from the same
+    // class will have the same alignment during a single execution (aarch64).
+    const obj = blk: {
+        var Class = objc.getClass("NSNumber").?;
+        var sel = objc.Sel.registerName("numberWithChar:");
+        var obj = Class.msgSend(objc.Object, sel, .{@as(u8, @intCast(5))});
+
+        // We're only interested in an unaligned pointer.
+        if (!std.mem.isAligned(@intFromPtr(obj.value), @alignOf(usize))) break :blk obj;
+
+        Class = objc.getClass("NSString").?;
+        sel = objc.Sel.registerName("stringWithUTF8String:");
+        obj = Class.msgSend(objc.Object, sel, .{"foo"});
+        if (!std.mem.isAligned(@intFromPtr(obj.value), @alignOf(usize))) break :blk obj;
+
+        Class = objc.getClass("NSDate").?;
+        sel = objc.Sel.registerName("date");
+        obj = Class.msgSend(objc.Object, sel, .{});
+        if (!std.mem.isAligned(@intFromPtr(obj.value), @alignOf(usize))) break :blk obj;
+
+        const colors = [_][:0]const u8{
+            "clearColor",    "blackColor",  "blueColor",  "brownColor",     "cyanColor",
+            "darkGrayColor", "grayColor",   "greenColor", "lightGrayColor", "magentaColor",
+            "orangeColor",   "purpleColor", "redColor",   "whiteColor",     "yellowColor",
+        };
+
+        Class = objc.getClass("NSColor").?;
+        for (colors) |color| {
+            sel = objc.Sel.registerName(color);
+            obj = Class.msgSend(objc.Object, sel, .{});
+            if (!std.mem.isAligned(@intFromPtr(obj.value), @alignOf(usize))) break :blk obj;
+        }
+
+        // In the unlikely event that we don't find an unaligned tagged pointer.
+        std.log.warn("skipped 'tagged pointer' test because we couldn't find an unaligned tagged pointer", .{});
+        return error.SkipZigTest;
+    };
+
+    // A tagged object is not allocated on the heap and cannot be retained.
+    try testing.expect(retainCount(obj) != 1);
+
+    // `Object.fromId` must work even when the pointer is unaligned.
+    const obj_ptr = @intFromPtr(obj.value);
+    try testing.expect(!std.mem.isAligned(obj_ptr, @alignOf(usize)));
+    try testing.expect(std.meta.eql(obj, Object.fromId(obj.value)));
+}

--- a/packages/zig_objc/src/property.zig
+++ b/packages/zig_objc/src/property.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+const c = @import("c.zig").c;
+const objc = @import("main.zig");
+
+pub const Property = extern struct {
+    value: c.objc_property_t,
+
+    /// Returns the name of a property.
+    pub fn getName(self: Property) [:0]const u8 {
+        return std.mem.sliceTo(c.property_getName(self.value), 0);
+    }
+
+    /// Returns the value of a property attribute given the attribute name.
+    pub fn copyAttributeValue(self: Property, attr: [:0]const u8) ?[:0]u8 {
+        return std.mem.sliceTo(
+            c.property_copyAttributeValue(self.value, attr.ptr) orelse return null,
+            0,
+        );
+    }
+
+    comptime {
+        std.debug.assert(@sizeOf(@This()) == @sizeOf(c.objc_property_t));
+        std.debug.assert(@alignOf(@This()) == @alignOf(c.objc_property_t));
+    }
+};
+
+test {
+    // Critical properties because we ptrCast C pointers to this.
+    const testing = std.testing;
+    try testing.expect(@sizeOf(Property) == @sizeOf(c.objc_property_t));
+    try testing.expect(@alignOf(Property) == @alignOf(c.objc_property_t));
+}
+
+test {
+    const testing = std.testing;
+    const NSObject = objc.getClass("NSObject").?;
+
+    const prop = NSObject.getProperty("className").?;
+    try testing.expectEqualStrings("className", prop.getName());
+}

--- a/packages/zig_objc/src/protocol.zig
+++ b/packages/zig_objc/src/protocol.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const cpkg = @import("c.zig");
+const c = cpkg.c;
+const boolParam = cpkg.boolParam;
+const boolResult = cpkg.boolResult;
+const objc = @import("main.zig");
+
+pub const Protocol = extern struct {
+    value: *c.Protocol,
+
+    pub fn conformsToProtocol(self: Protocol, other: Protocol) bool {
+        return boolResult(c.protocol_conformsToProtocol(self.value, other.value));
+    }
+
+    pub fn isEqual(self: Protocol, other: Protocol) bool {
+        return boolResult(c.protocol_isEqual(self.value, other.value));
+    }
+
+    pub fn getName(self: Protocol) [:0]const u8 {
+        return std.mem.sliceTo(c.protocol_getName(self.value), 0);
+    }
+
+    pub fn getProperty(
+        self: Protocol,
+        name: [:0]const u8,
+        is_required: bool,
+        is_instance: bool,
+    ) ?objc.Property {
+        return .{ .value = c.protocol_getProperty(
+            self.value,
+            name,
+            boolParam(is_required),
+            boolParam(is_instance),
+        ) orelse return null };
+    }
+
+    comptime {
+        std.debug.assert(@sizeOf(@This()) == @sizeOf([*c]c.Protocol));
+        std.debug.assert(@alignOf(@This()) == @alignOf([*c]c.Protocol));
+    }
+};
+
+pub fn getProtocol(name: [:0]const u8) ?Protocol {
+    return .{ .value = c.objc_getProtocol(name) orelse return null };
+}
+
+test Protocol {
+    const testing = std.testing;
+    const fs_proto = getProtocol("NSFileManagerDelegate") orelse return error.ProtocolNotFound;
+    try testing.expectEqualStrings("NSFileManagerDelegate", fs_proto.getName());
+
+    const obj_proto = getProtocol("NSObject") orelse return error.ProtocolNotFound;
+    try testing.expect(fs_proto.conformsToProtocol(obj_proto));
+
+    const url_proto = getProtocol("NSURLSessionDelegate") orelse return error.ProtocolNotFound;
+    try testing.expect(!fs_proto.conformsToProtocol(url_proto));
+
+    const hash_prop = obj_proto.getProperty("hash", true, true) orelse return error.ProtocolPropertyNotFound;
+    try testing.expectEqualStrings("hash", hash_prop.getName());
+}

--- a/packages/zig_objc/src/sel.zig
+++ b/packages/zig_objc/src/sel.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const c = @import("c.zig").c;
+
+// Shorthand, equivalent to Sel.registerName
+pub inline fn sel(name: [:0]const u8) Sel {
+    return Sel.registerName(name);
+}
+
+pub const Sel = struct {
+    value: c.SEL,
+
+    /// Registers a method with the Objective-C runtime system, maps the
+    /// method name to a selector, and returns the selector value.
+    pub fn registerName(name: [:0]const u8) Sel {
+        return Sel{
+            .value = c.sel_registerName(name.ptr),
+        };
+    }
+
+    /// Returns the name of the method specified by a given selector.
+    pub fn getName(self: Sel) [:0]const u8 {
+        return std.mem.sliceTo(c.sel_getName(self.value), 0);
+    }
+};
+
+test {
+    const testing = std.testing;
+    const s = Sel.registerName("yo");
+    try testing.expectEqualStrings("yo", s.getName());
+}


### PR DESCRIPTION
## Summary
- updates vendored Apple SDK, Ghostty, zig_objc, and desktop filesystem calls for Zig 0.16 APIs
- vendors a patched zig_objc dependency path to avoid stale upstream Zig 0.15-era build APIs
- prevents macOS desktop builds from linking the Linux CEF helper client

## Verification
- SSH'd to the Mac mini on branch fix-macos-apple-sdk
- ran only `mise run dev` as requested
- compile/link completed and runtime reached: `opencode server listening on http://127.0.0.1:4096`
- stopped the dev process afterward with Ctrl-C to avoid leaving it running