### PR TITLE
Tolerate vtool failure on macOS x86_64 release

### DIFF
--- a/scripts/release/install-macos-local.sh
+++ b/scripts/release/install-macos-local.sh
@@ -36,11 +36,20 @@ set_macos_build_version() {
   local binary="$1"
   local patched="$binary.patched"
 
-  xcrun vtool \
+  # See packages/release/package-macos-app.sh for the rationale: Zig's
+  # MACOSX_DEPLOYMENT_TARGET already bakes the build-version load command,
+  # but `vtool -replace` can fail on x86_64 binaries that lack header
+  # padding. Treat the patch as best-effort.
+  if ! xcrun vtool \
     -set-build-version macos "$MACOS_MIN_VERSION" "$MACOS_SDK_VERSION" \
     -replace \
     -output "$patched" \
-    "$binary" >/dev/null
+    "$binary" >/dev/null 2>&1; then
+    echo "warning: vtool -replace could not patch $binary; keeping linker-emitted build-version" >&2
+    rm -f "$patched"
+    chmod 755 "$binary"
+    return 0
+  fi
   mv "$patched" "$binary"
   chmod 755 "$binary"
 }

--- a/scripts/release/package-macos-app.sh
+++ b/scripts/release/package-macos-app.sh
@@ -46,11 +46,23 @@ set_macos_build_version() {
   local binary="$1"
   local patched="$binary.patched"
 
-  xcrun vtool \
+  # Zig 0.16 emits LC_BUILD_VERSION when MACOSX_DEPLOYMENT_TARGET is set
+  # (which we export above), so the binary already advertises the right
+  # platform/SDK at link time. `vtool -replace` requires extra Mach-O
+  # header padding that Zig does not always reserve — notably on x86_64
+  # macOS — and fails with "not enough space to hold load commands".
+  # Treat the rewrite as best-effort: if it fails we keep Zig's own
+  # build-version, which is correct.
+  if ! xcrun vtool \
     -set-build-version macos "$MACOS_MIN_VERSION" "$MACOS_SDK_VERSION" \
     -replace \
     -output "$patched" \
-    "$binary" >/dev/null
+    "$binary" >/dev/null 2>&1; then
+    echo "warning: vtool -replace could not patch $binary; keeping linker-emitted build-version" >&2
+    rm -f "$patched"
+    chmod 755 "$binary"
+    return 0
+  fi
   mv "$patched" "$binary"
   chmod 755 "$binary"
 }


### PR DESCRIPTION
## Summary
The macOS x86_64 release job for v0.1.77 failed in \`scripts/release/package-macos-app.sh\` with:

\`\`\`
vtool error: …/Verde.app/Contents/MacOS/verde not enough space to hold load commands
\`\`\`

Zig 0.16 already writes an \`LC_BUILD_VERSION\` load command into the binary using the \`MACOSX_DEPLOYMENT_TARGET\` we export before invoking \`zig build\`, so the post-build \`vtool -replace\` is just a belt-and-suspenders patch. On x86_64 Mach-O output, Zig doesn't reserve enough header padding for vtool to rewrite the command, so the call aborts and tanks the whole macos-x86_64 matrix step. arm64 doesn't hit it because the layout there ends up with slack.

This makes \`set_macos_build_version\` best-effort: if \`vtool -replace\` errors, we log a warning and keep the linker-emitted load command (which is correct).

## Test plan
- [ ] Re-run the failing release job → completes through packaging
- [ ] Inspect the built binary on macOS: \`otool -l Verde.app/Contents/MacOS/verde | grep -A4 LC_BUILD_VERSION\` shows macOS 13.0 minimum
- [ ] arm64 release path keeps working (vtool succeeds there, command is rewritten as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)