### PR TITLE
Scale composer fonts with the display

### DIFF
--- a/packages/desktop/src/state.zig
+++ b/packages/desktop/src/state.zig
@@ -85,7 +85,7 @@ pub const PaletteModalTextFocus = enum {
     project_import,
 };
 
-const PALETTE_COMPOSER_FONT_SIZE: f32 = 16.0;
+const PALETTE_COMPOSER_FONT_SIZE: f32 = 22.0;
 const PALETTE_COMPOSER_TOOLBAR_FONT_SIZE: f32 = 15.0;
 const PALETTE_COMPOSER_ICON_FONT_SIZE: f32 = 18.0;
 const PALETTE_COMPOSER_TEXT_ADVANCE_SCALE: f32 = 1.0;
@@ -5558,9 +5558,13 @@ pub const AppState = struct {
 
     pub fn syncPaletteComposerControls(self: *AppState) void {
         self.palette_composer.setCallbacks(.{ .context = self, .on_event = paletteComposerPromptEvent, .get_clipboard = paletteComposerGetClipboard });
-        self.palette_composer.setFontMetrics(paletteComposerTextFontMetrics(PALETTE_COMPOSER_FONT_SIZE));
-        self.palette_composer.setToolbarFontMetrics(paletteEstimatedFontMetrics(PALETTE_COMPOSER_TOOLBAR_FONT_SIZE));
-        self.palette_composer.setIconFontMetrics(paletteEstimatedFontMetrics(PALETTE_COMPOSER_ICON_FONT_SIZE));
+        // Composer font sizes are CSS units in the comptime config but the
+        // runtime metrics need to be the actual pixel size, otherwise the
+        // placeholder + selectors render at fixed pixel sizes while everything
+        // else in the UI scales with the display — looks tiny on HiDPI.
+        self.palette_composer.setFontMetrics(paletteComposerTextFontMetrics(theme.scaledUi(PALETTE_COMPOSER_FONT_SIZE)));
+        self.palette_composer.setToolbarFontMetrics(paletteEstimatedFontMetrics(theme.scaledUi(PALETTE_COMPOSER_TOOLBAR_FONT_SIZE)));
+        self.palette_composer.setIconFontMetrics(paletteEstimatedFontMetrics(theme.scaledUi(PALETTE_COMPOSER_ICON_FONT_SIZE)));
         const thread = self.currentThread();
         const cursor_model = if (thread.provider == .cursor) self.cursorModelOptionForRef(thread.model_ref) else null;
         const show_fast_toggle = thread.provider == .codex or (cursor_model != null and cursor_model.?.cursor_fast_supported);


### PR DESCRIPTION
## Summary
The composer placeholder + selector pills looked visibly smaller than the surrounding chat transcript and sidebar on HiDPI laptops because their font sizes were passed to \`setFontMetrics\` raw, while every other size in the UI already goes through \`theme.scaledUi\`. Wrapping the three runtime metrics calls in \`theme.scaledUi\` puts the composer on the same display scale as the rest of the chrome.

Also bumps \`PALETTE_COMPOSER_FONT_SIZE\` from 16 → 22 so at 1× the prompt reads a touch larger than the transcript body beneath it.

## Test plan
- [ ] Open on a 1× display — placeholder + typed text sit comfortably above the transcript size
- [ ] Open on a HiDPI display — placeholder + selectors scale proportionally with the rest of the UI
- [ ] Selectors at 15pt still read crisply through the .ui font role

🤖 Generated with [Claude Code](https://claude.com/claude-code)