### PR TITLE
Fix macOS startup crash from tree-sitter UBSAN function trap

### DIFF
--- a/packages/zig_treesitter/build.zig
+++ b/packages/zig_treesitter/build.zig
@@ -8,6 +8,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
+        .sanitize_c = .off,
     });
     configureModule(b, module);
 
@@ -30,6 +31,7 @@ fn createRootModule(
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
+        .sanitize_c = .off,
     });
     configureModule(b, module);
     return module;


### PR DESCRIPTION
## Summary
- Disable `sanitize_c` on the `zig_treesitter` module so vendored grammar code is not compiled with `-fsanitize-c=trap`.

## Root cause
On `--release=safe`, Zig 0.16 compiles C with `-fsanitize-c=trap`, which includes the `-fsanitize=function` indirect-call type check. The vendored TypeScript grammar's `scanner.c` uses pre-C23 K&R-style empty parameter lists:

```c
void *tree_sitter_typescript_external_scanner_create() { return NULL; }
```

The tree-sitter runtime's `TSLanguage->external_scanner.scan` field is typed `bool (*)(void *, TSLexer *, const bool *)`. UBSAN's type-hash check treats `()` and `(void)` as different signatures and traps the moment the runtime invokes the external scanner through that pointer.

Repro: any persisted TypeScript fenced code block containing a template literal (e.g. `` `script-src 'self' 'nonce-${nonce}'` ``) — the external scanner fires on the backtick, traps, app crashes on startup while rendering the transcript.

Crash report frames:
```
ts_parser_parse → tree_sitter_typescript_external_scanner_scan
chat_markdown.appendMarkdownBlocks
state.AppState.transcriptMarkdownBodyView
chat_panel.renderTranscript
```

## Test plan
- [ ] Launch app on macOS with a TypeScript fence containing a template literal in the active thread.
- [ ] Verify markdown renders without trapping.
- [ ] Linux/Wayland build still launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)