### PR TITLE
Refine workspace terminal pane keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ If prompt sending fails, first check that the selected provider is installed, av
 
 Verde includes embedded terminal panes powered by Ghostty's `libghostty-vt` terminal engine.
 
-- Toggle the terminal with `CommandOrControl+J`. The terminal opens as a workspace pane and starts in the selected project's working directory.
 - Create a new chat thread with `CommandOrControl+T`, or split a terminal pane below the focused workspace pane with `CommandOrControl+Shift+T`.
+- Move between workspace panes with `Alt+Arrow` or `Ctrl+H/J/K/L`.
 - Workspace pane headers can split chat or terminal panes vertically (`C|`, `T|`) or horizontally (`C-`, `T-`), maximize or restore a pane, minimize it into the restore strip, or close it.
 - Drag the divider between workspace panes to resize the split.
-- Right-click inside a terminal pane to create normal shell tabs or launch-profile tabs for Claude, OpenCode, Codex, and Cursor.
-- Terminal-internal tabs and splits remain separate from workspace splits. The terminal keybinds below operate inside the focused terminal pane.
+- Right-click inside a terminal pane to create normal shell tabs, launch-profile tabs for Claude, OpenCode, Codex, and Cursor, or new workspace terminal panes around the focused pane.
+- Terminal-internal tabs remain inside the focused terminal pane. Terminal split actions create workspace terminal panes.
 - Per-terminal zoom works with `Ctrl+-` and `Ctrl+=` while the terminal is focused, and the chosen zoom is restored with the terminal layout.
 
 ## Config And State
@@ -132,20 +132,24 @@ Example config:
       "split_chat_horizontal": "CommandOrControl+Alt+Shift+C",
       "split_terminal_vertical": "CommandOrControl+Alt+J",
       "split_terminal_horizontal": "CommandOrControl+Shift+T",
+      "focus_up": ["Alt+Up", "Ctrl+K"],
+      "focus_down": ["Alt+Down", "Ctrl+J"],
+      "focus_left": ["Alt+Left", "Ctrl+H"],
+      "focus_right": ["Alt+Right", "Ctrl+L"],
       "toggle_maximize": "CommandOrControl+Alt+M",
       "minimize": "CommandOrControl+Alt+Minus"
     },
     "terminal": {
-      "toggle": "CommandOrControl+J",
+      "toggle": null,
       "new_tab": "CommandOrControl+Alt+T",
       "close": "CommandOrControl+Shift+W",
       "rename_tab": "CommandOrControl+Shift+R",
       "tab_previous": "CommandOrControl+Shift+PageUp",
       "tab_next": "CommandOrControl+Shift+PageDown",
-      "split_up": "CommandOrControl+Shift+Up",
-      "split_down": ["CommandOrControl+Shift+E", "CommandOrControl+Shift+Down"],
-      "split_left": "CommandOrControl+Shift+Left",
-      "split_right": ["CommandOrControl+Shift+O", "CommandOrControl+Shift+Right"],
+      "split_up": null,
+      "split_down": null,
+      "split_left": null,
+      "split_right": null,
       "focus_up": "CommandOrControl+Alt+Up",
       "focus_down": "CommandOrControl+Alt+Down",
       "focus_left": "CommandOrControl+Alt+Left",

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -57,9 +57,10 @@ Keep the CEF SDK in a persistent directory such as `$HOME/.cache/verde/cef-sdk`;
 
 ## Embedded Terminal
 
-The desktop shell includes a bottom-docked embedded terminal powered by Ghostty's `libghostty-vt`.
+The desktop shell includes embedded terminal panes powered by Ghostty's `libghostty-vt`.
 
-- Toggle it with `CommandOrControl+J`.
+- Create a terminal pane with `CommandOrControl+Shift+T`.
+- Move between workspace panes with `Alt+Arrow` or `Ctrl+H/J/K/L`.
 - It starts in the selected project's directory.
 - `Ctrl+-` and `Ctrl+=` adjust only the terminal font scale while the terminal is focused.
 
@@ -104,19 +105,23 @@ Config supports UI and terminal font size, keybind overrides, and the default ac
     "sidebar_hidden": "Alt+B",
     "browser": "Ctrl+B",
     "workspace": {
-      "split_terminal_horizontal": "CommandOrControl+Shift+T"
+      "split_terminal_horizontal": "CommandOrControl+Shift+T",
+      "focus_up": ["Alt+Up", "Ctrl+K"],
+      "focus_down": ["Alt+Down", "Ctrl+J"],
+      "focus_left": ["Alt+Left", "Ctrl+H"],
+      "focus_right": ["Alt+Right", "Ctrl+L"]
     },
     "terminal": {
-      "toggle": "CommandOrControl+J",
+      "toggle": null,
       "new_tab": "CommandOrControl+Alt+T",
       "close": "CommandOrControl+Shift+W",
       "rename_tab": "CommandOrControl+Shift+R",
       "tab_previous": "CommandOrControl+Shift+PageUp",
       "tab_next": "CommandOrControl+Shift+PageDown",
-      "split_up": "CommandOrControl+Shift+Up",
-      "split_down": ["CommandOrControl+Shift+E", "CommandOrControl+Shift+Down"],
-      "split_left": "CommandOrControl+Shift+Left",
-      "split_right": ["CommandOrControl+Shift+O", "CommandOrControl+Shift+Right"],
+      "split_up": null,
+      "split_down": null,
+      "split_left": null,
+      "split_right": null,
       "focus_up": "CommandOrControl+Alt+Up",
       "focus_down": "CommandOrControl+Alt+Down",
       "focus_left": "CommandOrControl+Alt+Left",

--- a/packages/desktop/src/keybinds.zig
+++ b/packages/desktop/src/keybinds.zig
@@ -768,9 +768,7 @@ fn cloneDefaultSidebarHiddenKeybinds(allocator: std.mem.Allocator) ![]Keybind {
 }
 
 fn cloneDefaultTerminalKeybinds(allocator: std.mem.Allocator) ![]Keybind {
-    return allocator.dupe(Keybind, &.{
-        try parseDefaultAccelerator("CommandOrControl+J"),
-    });
+    return cloneEmptyKeybinds(allocator);
 }
 
 fn cloneDefaultBrowserKeybinds(allocator: std.mem.Allocator) ![]Keybind {
@@ -840,29 +838,19 @@ fn cloneDefaultTerminalTabNextKeybinds(allocator: std.mem.Allocator) ![]Keybind 
 }
 
 fn cloneDefaultTerminalSplitUpKeybinds(allocator: std.mem.Allocator) ![]Keybind {
-    return allocator.dupe(Keybind, &.{
-        try parseDefaultAccelerator("CommandOrControl+Shift+Up"),
-    });
+    return cloneEmptyKeybinds(allocator);
 }
 
 fn cloneDefaultTerminalSplitDownKeybinds(allocator: std.mem.Allocator) ![]Keybind {
-    return allocator.dupe(Keybind, &.{
-        try parseDefaultAccelerator("CommandOrControl+Shift+E"),
-        try parseDefaultAccelerator("CommandOrControl+Shift+Down"),
-    });
+    return cloneEmptyKeybinds(allocator);
 }
 
 fn cloneDefaultTerminalSplitLeftKeybinds(allocator: std.mem.Allocator) ![]Keybind {
-    return allocator.dupe(Keybind, &.{
-        try parseDefaultAccelerator("CommandOrControl+Shift+Left"),
-    });
+    return cloneEmptyKeybinds(allocator);
 }
 
 fn cloneDefaultTerminalSplitRightKeybinds(allocator: std.mem.Allocator) ![]Keybind {
-    return allocator.dupe(Keybind, &.{
-        try parseDefaultAccelerator("CommandOrControl+Shift+O"),
-        try parseDefaultAccelerator("CommandOrControl+Shift+Right"),
-    });
+    return cloneEmptyKeybinds(allocator);
 }
 
 fn cloneDefaultTerminalFocusUpKeybinds(allocator: std.mem.Allocator) ![]Keybind {
@@ -892,24 +880,28 @@ fn cloneDefaultTerminalFocusRightKeybinds(allocator: std.mem.Allocator) ![]Keybi
 fn cloneDefaultWorkspaceFocusLeftKeybinds(allocator: std.mem.Allocator) ![]Keybind {
     return allocator.dupe(Keybind, &.{
         try parseDefaultAccelerator("Alt+Left"),
+        try parseDefaultAccelerator("Ctrl+H"),
     });
 }
 
 fn cloneDefaultWorkspaceFocusRightKeybinds(allocator: std.mem.Allocator) ![]Keybind {
     return allocator.dupe(Keybind, &.{
         try parseDefaultAccelerator("Alt+Right"),
+        try parseDefaultAccelerator("Ctrl+L"),
     });
 }
 
 fn cloneDefaultWorkspaceFocusUpKeybinds(allocator: std.mem.Allocator) ![]Keybind {
     return allocator.dupe(Keybind, &.{
         try parseDefaultAccelerator("Alt+Up"),
+        try parseDefaultAccelerator("Ctrl+K"),
     });
 }
 
 fn cloneDefaultWorkspaceFocusDownKeybinds(allocator: std.mem.Allocator) ![]Keybind {
     return allocator.dupe(Keybind, &.{
         try parseDefaultAccelerator("Alt+Down"),
+        try parseDefaultAccelerator("Ctrl+J"),
     });
 }
 
@@ -1349,6 +1341,52 @@ test "default terminal tab keybind uses primary alt t" {
     try std.testing.expect(config.terminal_new_tab[0].primary);
     try std.testing.expect(!config.terminal_new_tab[0].shift);
     try std.testing.expectEqual(sdl.Keycode.t, config.terminal_new_tab[0].key);
+}
+
+test "default terminal toggle has no keybind" {
+    var config = try NativeKeyboardConfig.load(std.testing.allocator);
+    defer config.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), config.toggle_terminal.len);
+}
+
+test "default terminal internal split keybinds are disabled" {
+    var config = try NativeKeyboardConfig.load(std.testing.allocator);
+    defer config.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), config.terminal_split_up.len);
+    try std.testing.expectEqual(@as(usize, 0), config.terminal_split_down.len);
+    try std.testing.expectEqual(@as(usize, 0), config.terminal_split_left.len);
+    try std.testing.expectEqual(@as(usize, 0), config.terminal_split_right.len);
+}
+
+test "default workspace focus supports alt arrows and ctrl hjkl" {
+    var config = try NativeKeyboardConfig.load(std.testing.allocator);
+    defer config.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), config.workspace_focus_left.len);
+    try std.testing.expect(config.workspace_focus_left[0].alt);
+    try std.testing.expectEqual(sdl.Keycode.left, config.workspace_focus_left[0].key);
+    try std.testing.expect(config.workspace_focus_left[1].ctrl);
+    try std.testing.expectEqual(sdl.Keycode.h, config.workspace_focus_left[1].key);
+
+    try std.testing.expectEqual(@as(usize, 2), config.workspace_focus_down.len);
+    try std.testing.expect(config.workspace_focus_down[0].alt);
+    try std.testing.expectEqual(sdl.Keycode.down, config.workspace_focus_down[0].key);
+    try std.testing.expect(config.workspace_focus_down[1].ctrl);
+    try std.testing.expectEqual(sdl.Keycode.j, config.workspace_focus_down[1].key);
+
+    try std.testing.expectEqual(@as(usize, 2), config.workspace_focus_up.len);
+    try std.testing.expect(config.workspace_focus_up[0].alt);
+    try std.testing.expectEqual(sdl.Keycode.up, config.workspace_focus_up[0].key);
+    try std.testing.expect(config.workspace_focus_up[1].ctrl);
+    try std.testing.expectEqual(sdl.Keycode.k, config.workspace_focus_up[1].key);
+
+    try std.testing.expectEqual(@as(usize, 2), config.workspace_focus_right.len);
+    try std.testing.expect(config.workspace_focus_right[0].alt);
+    try std.testing.expectEqual(sdl.Keycode.right, config.workspace_focus_right[0].key);
+    try std.testing.expect(config.workspace_focus_right[1].ctrl);
+    try std.testing.expectEqual(sdl.Keycode.l, config.workspace_focus_right[1].key);
 }
 
 test "default sidebar keybind uses primary plus s" {

--- a/packages/desktop/src/state.zig
+++ b/packages/desktop/src/state.zig
@@ -6487,6 +6487,15 @@ pub const AppState = struct {
         event: *const sdl.KeyboardEvent,
     ) bool {
         if (!self.canRouteTerminalInput()) return false;
+        if (keyboard.terminalActionForEvent(event)) |action| {
+            switch (action) {
+                .split_up => return self.splitFocusedWorkspacePaneWithTerminalPlacement(.horizontal, false),
+                .split_down => return self.splitFocusedWorkspacePaneWithTerminalPlacement(.horizontal, true),
+                .split_left => return self.splitFocusedWorkspacePaneWithTerminalPlacement(.vertical, false),
+                .split_right => return self.splitFocusedWorkspacePaneWithTerminalPlacement(.vertical, true),
+                else => {},
+            }
+        }
         var dock = self.currentProjectTerminalMutable();
         const handled = dock.handleKeyDown(self.allocator, keyboard, event);
         if (dock.consumeWorkspaceChange()) self.markDirty();
@@ -6630,6 +6639,15 @@ pub const AppState = struct {
         return true;
     }
 
+    pub fn clearCurrentProjectWorkspacePaneMaximized(self: *AppState) bool {
+        if (self.projects.items.len == 0) return false;
+        var layout = &self.projects.items[self.selected_project_index].workspace_layout;
+        if (layout.maximized_pane_id == null) return false;
+        layout.maximized_pane_id = null;
+        self.markDirty();
+        return true;
+    }
+
     pub fn closeCurrentProjectWorkspacePane(self: *AppState, pane_id: WorkspacePaneId) bool {
         if (self.projects.items.len == 0) return false;
         var project = &self.projects.items[self.selected_project_index];
@@ -6744,12 +6762,20 @@ pub const AppState = struct {
     }
 
     pub fn splitFocusedWorkspacePaneWithTerminalAxis(self: *AppState, axis: WorkspaceSplitAxis) bool {
+        return self.splitFocusedWorkspacePaneWithTerminalPlacement(axis, true);
+    }
+
+    pub fn splitFocusedWorkspacePaneWithTerminalPlacement(self: *AppState, axis: WorkspaceSplitAxis, new_after: bool) bool {
         if (self.projects.items.len == 0) return false;
         const pane_id = self.projects.items[self.selected_project_index].workspace_layout.focused_pane_id orelse return false;
-        return self.splitCurrentProjectWorkspacePaneWithTerminalAxis(pane_id, axis);
+        return self.splitCurrentProjectWorkspacePaneWithTerminalPlacement(pane_id, axis, new_after);
     }
 
     pub fn splitCurrentProjectWorkspacePaneWithTerminalAxis(self: *AppState, pane_id: WorkspacePaneId, axis: WorkspaceSplitAxis) bool {
+        return self.splitCurrentProjectWorkspacePaneWithTerminalPlacement(pane_id, axis, true);
+    }
+
+    pub fn splitCurrentProjectWorkspacePaneWithTerminalPlacement(self: *AppState, pane_id: WorkspacePaneId, axis: WorkspaceSplitAxis, new_after: bool) bool {
         if (self.projects.items.len == 0) return false;
         var layout = &self.projects.items[self.selected_project_index].workspace_layout;
         const target = layout.paneById(pane_id) orelse return false;
@@ -6773,7 +6799,7 @@ pub const AppState = struct {
             self.setSidebarNotice("Failed to create terminal pane.");
             return false;
         };
-        layout.splitPaneWithLeaf(self.allocator, pane_id, new_pane_id, axis, true) catch |err| {
+        layout.splitPaneWithLeaf(self.allocator, pane_id, new_pane_id, axis, new_after) catch |err| {
             log.err("failed to split terminal workspace pane: {s}", .{@errorName(err)});
             self.setSidebarNotice("Failed to split workspace.");
             return false;

--- a/packages/desktop/src/ui/terminal_panel.zig
+++ b/packages/desktop/src/ui/terminal_panel.zig
@@ -430,19 +430,19 @@ fn renderContextMenu(state: *app_state.AppState, dock: anytype, dock_rect: palet
         count += 1;
     } else {
         actions[count] = .split_up;
-        labels[count] = "Split Up";
+        labels[count] = "New Pane Above";
         enabled[count] = true;
         count += 1;
         actions[count] = .split_down;
-        labels[count] = "Split Down";
+        labels[count] = "New Pane Below";
         enabled[count] = true;
         count += 1;
         actions[count] = .split_left;
-        labels[count] = "Split Left";
+        labels[count] = "New Pane Left";
         enabled[count] = true;
         count += 1;
         actions[count] = .split_right;
-        labels[count] = "Split Right";
+        labels[count] = "New Pane Right";
         enabled[count] = true;
         count += 1;
         actions[count] = .close_pane;
@@ -485,6 +485,10 @@ fn renderContextMenu(state: *app_state.AppState, dock: anytype, dock_rect: palet
 }
 
 fn performContextMenuAction(state: *app_state.AppState, dock: anytype, action: TerminalContextMenuAction) void {
+    const focus_menu_dock_after = switch (action) {
+        .split_up, .split_down, .split_left, .split_right => false,
+        else => true,
+    };
     switch (action) {
         .new_tab => dock.createTab(state.allocator) catch |err| app_state.log.warn("failed to create terminal tab: {s}", .{@errorName(err)}),
         .new_claude_tab => dock.createTabWithProfile(state.allocator, .{ .kind = .claude, .label = "Claude" }) catch |err| app_state.log.warn("failed to create Claude terminal tab: {s}", .{@errorName(err)}),
@@ -496,13 +500,13 @@ fn performContextMenuAction(state: *app_state.AppState, dock: anytype, action: T
         },
         .rename_tab => if (dock.activeTab()) |tab| dock.beginRenameTab(tab.id),
         .close_tab => dock.closeTab(state.allocator, hit_cache.menu_tab_index) catch |err| app_state.log.warn("failed to close terminal tab: {s}", .{@errorName(err)}),
-        .split_up => dock.splitActivePane(state.allocator, .up) catch |err| app_state.log.warn("failed to split terminal pane up: {s}", .{@errorName(err)}),
-        .split_down => dock.splitActivePane(state.allocator, .down) catch |err| app_state.log.warn("failed to split terminal pane down: {s}", .{@errorName(err)}),
-        .split_left => dock.splitActivePane(state.allocator, .left) catch |err| app_state.log.warn("failed to split terminal pane left: {s}", .{@errorName(err)}),
-        .split_right => dock.splitActivePane(state.allocator, .right) catch |err| app_state.log.warn("failed to split terminal pane right: {s}", .{@errorName(err)}),
+        .split_up => _ = state.splitFocusedWorkspacePaneWithTerminalPlacement(.horizontal, false),
+        .split_down => _ = state.splitFocusedWorkspacePaneWithTerminalPlacement(.horizontal, true),
+        .split_left => _ = state.splitFocusedWorkspacePaneWithTerminalPlacement(.vertical, false),
+        .split_right => _ = state.splitFocusedWorkspacePaneWithTerminalPlacement(.vertical, true),
         .close_pane => dock.closeActivePaneOrTab(state.allocator) catch |err| app_state.log.warn("failed to close terminal pane: {s}", .{@errorName(err)}),
     }
-    focusTerminal(state);
+    if (focus_menu_dock_after) focusTerminal(state);
     if (dock.consumeWorkspaceChange()) state.markDirty();
 }
 

--- a/packages/desktop/src/ui/workspace_panes.zig
+++ b/packages/desktop/src/ui/workspace_panes.zig
@@ -89,12 +89,32 @@ pub fn focusPaneInDirection(state: *runtime.AppState, dir: FocusDirection) bool 
     if (pane_rect_count == 0) return false;
     if (state.projects.items.len == 0) return false;
     const current_id = state.projects.items[state.selected_project_index].workspace_layout.focused_pane_id orelse return false;
+    const maximized = state.currentProjectWorkspaceMaximizedPaneId() != null;
+    if (maximized) {
+        if (state.currentProjectWorkspaceRoot()) |root| {
+            var expanded_rects: [MAX_WORKSPACE_PANE_RECTS]WorkspacePaneRect = undefined;
+            var expanded_count: usize = 0;
+            collectNodePaneRects(root, pane_rects[0].rect, &expanded_rects, &expanded_count);
+            if (focusPaneInDirectionFromRects(state, current_id, dir, expanded_rects[0..expanded_count], true)) return true;
+        }
+        return state.clearCurrentProjectWorkspacePaneMaximized();
+    }
 
+    return focusPaneInDirectionFromRects(state, current_id, dir, pane_rects[0..pane_rect_count], false);
+}
+
+fn focusPaneInDirectionFromRects(
+    state: *runtime.AppState,
+    current_id: runtime.WorkspacePaneId,
+    dir: FocusDirection,
+    rects: []const WorkspacePaneRect,
+    clear_maximized: bool,
+) bool {
     var current_rect: ?palette.Rect = null;
     var i: usize = 0;
-    while (i < pane_rect_count) : (i += 1) {
-        if (pane_rects[i].pane_id == current_id) {
-            current_rect = pane_rects[i].rect;
+    while (i < rects.len) : (i += 1) {
+        if (rects[i].pane_id == current_id) {
+            current_rect = rects[i].rect;
             break;
         }
     }
@@ -106,8 +126,8 @@ pub fn focusPaneInDirection(state: *runtime.AppState, dir: FocusDirection) bool 
     var best_score: f32 = std.math.inf(f32);
 
     i = 0;
-    while (i < pane_rect_count) : (i += 1) {
-        const entry = pane_rects[i];
+    while (i < rects.len) : (i += 1) {
+        const entry = rects[i];
         if (entry.pane_id == current_id) continue;
         const ex = entry.rect.x + entry.rect.w * 0.5;
         const ey = entry.rect.y + entry.rect.h * 0.5;
@@ -138,9 +158,45 @@ pub fn focusPaneInDirection(state: *runtime.AppState, dir: FocusDirection) bool 
     }
 
     const target = best_id orelse return false;
+    if (clear_maximized) _ = state.clearCurrentProjectWorkspacePaneMaximized();
     _ = state.focusCurrentProjectWorkspacePane(target);
     state.markDirty();
     return true;
+}
+
+fn collectNodePaneRects(
+    node: *const runtime.WorkspaceNode,
+    rect: palette.Rect,
+    out: *[MAX_WORKSPACE_PANE_RECTS]WorkspacePaneRect,
+    count: *usize,
+) void {
+    if (count.* >= out.len) return;
+    switch (node.*) {
+        .leaf => |pane_id| {
+            out[count.*] = .{ .pane_id = pane_id, .rect = rect };
+            count.* += 1;
+        },
+        .split => |split| {
+            const gap = theme.scaledUi(1.0);
+            if (split.axis == .vertical) {
+                const first_w = @max(theme.scaledUi(180.0), rect.w * split.ratio - gap * 0.5);
+                const second_w = @max(theme.scaledUi(180.0), rect.w - first_w - gap);
+                const clamped_first_w = @max(theme.scaledUi(120.0), rect.w - second_w - gap);
+                const first_rect = palette.Rect{ .x = rect.x, .y = rect.y, .w = clamped_first_w, .h = rect.h };
+                const second_rect = palette.Rect{ .x = rect.x + clamped_first_w + gap, .y = rect.y, .w = @max(rect.w - clamped_first_w - gap, theme.scaledUi(120.0)), .h = rect.h };
+                collectNodePaneRects(split.first, first_rect, out, count);
+                collectNodePaneRects(split.second, second_rect, out, count);
+            } else {
+                const first_h = @max(theme.scaledUi(160.0), rect.h * split.ratio - gap * 0.5);
+                const second_h = @max(theme.scaledUi(120.0), rect.h - first_h - gap);
+                const clamped_first_h = @max(theme.scaledUi(120.0), rect.h - second_h - gap);
+                const first_rect = palette.Rect{ .x = rect.x, .y = rect.y, .w = rect.w, .h = clamped_first_h };
+                const second_rect = palette.Rect{ .x = rect.x, .y = rect.y + clamped_first_h + gap, .w = rect.w, .h = @max(rect.h - clamped_first_h - gap, theme.scaledUi(120.0)) };
+                collectNodePaneRects(split.first, first_rect, out, count);
+                collectNodePaneRects(split.second, second_rect, out, count);
+            }
+        },
+    }
 }
 
 fn rangesOverlap(a0: f32, a1: f32, b0: f32, b1: f32) bool {


### PR DESCRIPTION
## Summary
- remove the default Ctrl+J terminal toggle and add Ctrl+H/J/K/L pane navigation alongside Alt+Arrow
- make directional pane navigation unmaximize before moving focus, matching tmux-style behavior
- disable old terminal-internal split defaults and route configured/menu split actions to workspace terminal panes

## Validation
- git diff --check
- zig build -Doptimize=ReleaseSafe