### PR TITLE
Add live stack controls and CLI completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ verde app                     # Launch the desktop app explicitly
 verde --help                  # Show CLI help
 verde version [--json]        # Print version metadata
 verde capabilities [--json]   # Print supported CLI/live features
+verde completion <shell>      # Print shell completion script
 verde state <command>         # Read persisted state while the app is closed
 verde live <command>          # Control or inspect the running app
 ```
@@ -107,6 +108,39 @@ Use `--json` when scripting. Live IPC responses use a stable envelope:
 ```
 
 Errors return `ok: false` with an `error.code` and `error.message`.
+
+### Shell Completion
+
+`verde completion` prints static completion scripts for the supported shells.
+The generated completions cover command names, nested live-control commands,
+flags, and fixed flag values such as `--kind chat|terminal`,
+`--axis horizontal|vertical`, and `--decision approve|deny`.
+
+```bash
+verde completion bash
+verde completion zsh
+verde completion fish
+```
+
+Common install patterns:
+
+```bash
+# bash
+verde completion bash > ~/.local/share/bash-completion/completions/verde
+
+# zsh
+mkdir -p ~/.zfunc
+verde completion zsh > ~/.zfunc/_verde
+# Ensure ~/.zfunc is in fpath before compinit, for example:
+# fpath=(~/.zfunc $fpath)
+
+# fish
+verde completion fish > ~/.config/fish/completions/verde.fish
+```
+
+The first completion slice is intentionally static so tab completion stays fast
+and never depends on the desktop app being open. Dynamic project, pane, process,
+and thread completions can be layered on top of this later.
 
 ### Offline State Commands
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,176 @@ Common tasks:
 - `mise run build`: creates a local release-style build for the current platform.
 - `mise run dev-sdl-gpu`: runs with the SDL_GPU Palette renderer.
 
+## CLI And Live Control
+
+`verde` is both the desktop launcher and a CLI for reading persisted state or
+controlling a running desktop app. CLI-only commands run before SDL startup, so
+they can be used from scripts without opening a window.
+
+Top-level commands:
+
+```bash
+verde                         # Launch the desktop app
+verde app                     # Launch the desktop app explicitly
+verde --help                  # Show CLI help
+verde version [--json]        # Print version metadata
+verde capabilities [--json]   # Print supported CLI/live features
+verde state <command>         # Read persisted state while the app is closed
+verde live <command>          # Control or inspect the running app
+```
+
+Use `--json` when scripting. Live IPC responses use a stable envelope:
+
+```json
+{
+  "id": 1,
+  "ok": true,
+  "result": {}
+}
+```
+
+Errors return `ok: false` with an `error.code` and `error.message`.
+
+### Offline State Commands
+
+State commands read Verde's persisted SQLite state and do not require the app to
+be running.
+
+```bash
+verde state path [--json]
+verde state projects [--json]
+verde state panes --project <id|index|path|current> [--json]
+verde state threads --project <id|index|path|current> [--json]
+verde state transcript --project <id|index|path|current> --thread <index|provider-id> [--json]
+```
+
+- `path` prints the SDL pref path and `state.sqlite` location.
+- `projects` lists imported projects and the selected project.
+- `panes` prints the saved workspace layout and terminal dock state for a
+  project.
+- `threads` lists saved chat threads for a project.
+- `transcript` prints one saved chat transcript by thread index or provider
+  thread id.
+
+### Live Discovery Commands
+
+Live commands talk to the running desktop app over a current-user Unix socket at
+Verde's SDL pref path. Start the app normally first, for example with `verde` or
+from source with `mise run dev`.
+
+```bash
+verde live capabilities [--json]
+verde live status [--json]
+verde live projects [--json]
+verde live active [--json]
+verde live panes [--project <id|index|path|current>] [--json]
+verde live threads [--project <id|index|path|current>] [--json]
+verde live terminals [--project <id|index|path|current>] [--json]
+verde live processes [--json]
+verde live inspect --pane <pane-id> [--project <id|index|path|current>] [--json]
+verde live inspect --focused [--json]
+```
+
+- `capabilities` prints the live method list without requiring the app to be
+  running.
+- `status` returns protocol version, app pid, selected project, focused pane,
+  current pane graph, and terminal/process summary.
+- `projects` lists live projects.
+- `active` returns the current project and focused pane.
+- `panes`, `threads`, and `terminals` inspect one project.
+- `processes` returns the terminal-pane process graph currently available to
+  Verde.
+- `inspect` returns details for a specific pane or the focused pane.
+
+### Pane Control
+
+Workspace panes are the primary live-control target. Most commands return the
+updated pane graph so scripts can keep using the returned pane IDs.
+
+```bash
+verde live pane focus --pane <pane-id> [--project <id|index|path|current>] [--json]
+verde live pane focus --focused [--json]
+verde live pane split --pane <pane-id> --kind chat --axis horizontal [--json]
+verde live pane split --pane <pane-id> --kind terminal --axis vertical [--json]
+verde live pane resize --pane <pane-id> --first <pane-id> --second <pane-id> --axis horizontal --ratio 0.6 [--json]
+verde live pane minimize --pane <pane-id> [--json]
+verde live pane maximize --pane <pane-id> [--json]
+verde live pane restore --pane <pane-id> [--json]
+verde live pane close --pane <pane-id> [--json]
+```
+
+- `split` creates a chat or terminal workspace pane next to the target pane.
+  `--kind` accepts `chat` or `terminal`; `--axis` accepts `horizontal` or
+  `vertical`.
+- `resize` updates the split ratio between two sibling panes. `--ratio` is a
+  floating-point value such as `0.6`.
+- `minimize`, `maximize`, `restore`, and `close` match the pane header actions
+  in the UI.
+
+### Chat Control
+
+Chat commands resolve the target pane to its backing chat thread. They use the
+same draft, composer, send, stop, and approval paths as the UI.
+
+```bash
+verde live chat status --pane <pane-id> [--json]
+verde live chat status --focused [--json]
+verde live chat transcript --pane <pane-id> [--json]
+verde live chat draft set --pane <pane-id> --text "explain this failure" [--json]
+verde live chat draft append --pane <pane-id> --text "more detail" [--json]
+verde live chat send --pane <pane-id> --prompt "run the tests and fix failures" [--json]
+verde live chat send --pane <pane-id> "run the tests and fix failures" [--json]
+verde live chat followup --pane <pane-id> --prompt "then update docs" [--json]
+verde live chat stop --pane <pane-id> [--json]
+verde live chat approve --pane <pane-id> --decision approve [--json]
+verde live chat approve --pane <pane-id> --decision deny [--json]
+```
+
+- `status` returns thread title, provider, model, message count, send state, and
+  pending approval status.
+- `transcript` returns persisted messages for the pane's thread.
+- `draft set` replaces the current draft; `draft append` appends to it.
+- `send` sends `--prompt`, `--text`, or a trailing prompt argument. If no prompt
+  is supplied, it sends the current draft.
+- `followup` queues or steers a prompt while a send is active.
+- `stop` aborts the current send for that chat thread.
+- `approve` resolves the current pending approval. `--decision` accepts
+  `approve` or `deny`; `--call <id>` is accepted for future call-id targeting.
+
+### Terminal And Process Control
+
+Terminal commands resolve the target workspace pane to its terminal dock and
+write through the same active PTY input path as the UI.
+
+```bash
+verde live terminal write --pane <pane-id> --text $'cargo test\r' [--json]
+verde live terminal write --focused --text $'printf "ok\\n"\r' [--json]
+verde live process inspect --pane <pane-id> [--json]
+verde live process inspect --focused [--json]
+```
+
+- `terminal write` sends text to the active terminal tab/pane. Include `\r` when
+  you want to submit a shell command.
+- `process inspect` currently returns the same pane/terminal details as
+  `inspect` for a terminal pane. Process spawn, restart, and rename are reserved
+  for a later slice.
+
+### Selectors And Exit Codes
+
+- Use `--pane <id>` for deterministic automation.
+- Use `--focused` for interactive smoke tests.
+- Use `--project current` for the selected project, or pass a project index, id,
+  or path.
+- Chat commands require a chat pane. Terminal commands require a terminal pane.
+- Exit `0` means the CLI command parsed and, for live commands, received a live
+  response. Scripts should still check the JSON envelope's `ok` field.
+- Exit `1` means command failure before a structured live response, `2` invalid
+  arguments, `3` live server not running, and `4` offline state target not
+  found.
+- Live IPC request failures return JSON error codes such as `not_found`,
+  `invalid_request`, `invalid_target`, `rejected`, `unsupported`, or
+  `method_not_found`.
+
 ## Provider Notes
 
 - Codex threads use the local `codex` CLI and start `codex app-server` automatically when needed.

--- a/packages/desktop/AGENTS.md
+++ b/packages/desktop/AGENTS.md
@@ -12,6 +12,83 @@ zigdoc ghostty-vt.Terminal
 zigdoc vaxis.Window
 ```
 
+Use the repository `mise` tasks for desktop build/run verification:
+
+- `mise run build` for installable ReleaseSafe builds.
+- `mise run dev` for launching the desktop app during manual/live testing.
+
+Do not run `zig build`, `zig build run`, or the generated desktop binary directly for normal verification unless the user explicitly asks for a lower-level build command.
+
+## CLI And Live-Control Testing
+
+Use the new CLI surface to smoke-test Verde behavior from another shell while the desktop app is running.
+
+Basic workflow:
+
+1. Build/install the CLI with `mise run build`.
+2. Start the app with `mise run dev` and keep that process running.
+3. Wait until `verde live status --json` returns `ok: true`; exit code `3` means the app or live socket is not ready yet.
+4. Use `verde live active --json` or `verde live panes --project current --json` to find workspace pane IDs.
+5. Prefer `--json` for scripts and assertions. Use `jq` if available, but keep commands readable when reporting results.
+6. Close any test panes you create with `verde live pane close --pane <id> --json`.
+7. Stop the `mise run dev` app when verification is complete, then confirm no dev app process is still running.
+
+Useful read-only checks:
+
+```bash
+verde --help
+verde version --json
+verde capabilities --json
+verde state path --json
+verde state projects --json
+verde state panes --project current --json
+verde state threads --project current --json
+verde live capabilities --json
+verde live status --json
+verde live projects --json
+verde live active --json
+verde live panes --project current --json
+verde live threads --project current --json
+verde live terminals --project current --json
+verde live processes --json
+```
+
+Pane and terminal smoke test:
+
+```bash
+verde live pane split --pane <chat-pane-id> --kind terminal --axis vertical --json
+verde live terminal write --pane <terminal-pane-id> --text $'printf "verde-cli-smoke\\n"\r' --json
+verde live process inspect --pane <terminal-pane-id> --json
+verde live pane close --pane <terminal-pane-id> --json
+```
+
+Chat smoke test, only when it is acceptable to create a real thread/send:
+
+```bash
+verde live pane split --pane <chat-pane-id> --kind chat --axis horizontal --json
+verde live chat draft set --pane <new-chat-pane-id> --text "Reply with exactly: verde-live-smoke" --json
+verde live chat send --pane <new-chat-pane-id> --json
+verde live chat status --pane <new-chat-pane-id> --json
+verde live chat transcript --pane <new-chat-pane-id> --json
+verde live pane close --pane <new-chat-pane-id> --json
+```
+
+Selector rules:
+
+- Use `--pane <id>` for deterministic tests.
+- Use `--focused` only for interactive smoke tests where focus is part of what you are testing.
+- Use `--project current` unless the test intentionally targets another project by index, id, or path.
+- Chat commands require a chat workspace pane. Terminal commands require a terminal workspace pane.
+
+Expected exit codes:
+
+- `0`: CLI command parsed and, for live commands, received a live response.
+- `1`: command failed after argument parsing.
+- `2`: invalid CLI arguments.
+- `3`: live server is not running or not ready.
+- `4`: project/thread target not found for offline state commands.
+- Live IPC application errors are returned as JSON with `ok: false`; scripts must check the response body, not only the process exit code. Common `error.code` values are `not_found`, `invalid_target`, `rejected`, `unsupported`, and `method_not_found`.
+
 ## Common Zig Patterns
 
 These patterns reflect current Zig APIs and may differ from older documentation.

--- a/packages/desktop/AGENTS.md
+++ b/packages/desktop/AGENTS.md
@@ -39,6 +39,9 @@ Useful read-only checks:
 verde --help
 verde version --json
 verde capabilities --json
+verde completion bash
+verde completion zsh
+verde completion fish
 verde state path --json
 verde state projects --json
 verde state panes --project current --json
@@ -52,6 +55,14 @@ verde live threads --project current --json
 verde live terminals --project current --json
 verde live processes --json
 ```
+
+Shell completion is part of the CLI surface. Use `verde completion bash`,
+`verde completion zsh`, or `verde completion fish` to inspect the supported
+command tree from an agent shell. The completions are static by design: they
+complete commands, nested live-control groups, flags, and fixed values without
+requiring the desktop app or live socket. For automation, still use explicit
+commands with `--json`; completion output is a discovery aid, not an assertion
+format.
 
 Pane and terminal smoke test:
 

--- a/packages/desktop/src/cli.zig
+++ b/packages/desktop/src/cli.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const args = @import("cli_args.zig");
+const completion = @import("cli_completion.zig");
 const output = @import("cli_output.zig");
+const spec = @import("cli_spec.zig");
 const db_client = @import("db/client.zig");
 const db_types = @import("db/types.zig");
 
@@ -45,6 +47,10 @@ fn dispatchArgs(allocator: std.mem.Allocator, io: std.Io, argv: []const []const 
         try printCapabilities(allocator, out, parsed.json);
         return .handled;
     }
+    if (std.mem.eql(u8, parsed.command, "completion")) {
+        try handleCompletion(allocator, out, parsed.rest);
+        return .handled;
+    }
     if (std.mem.eql(u8, parsed.command, "state")) {
         try handleState(allocator, out, parsed.rest);
         return .handled;
@@ -71,6 +77,7 @@ fn printHelp(out: output.Output) !void {
         \\  verde --help                  Show this help
         \\  verde version [--json]        Print version metadata
         \\  verde capabilities [--json]   Print CLI capability metadata
+        \\  verde completion <shell>       Print shell completion script
         \\  verde state <command>         Read persisted state with the app closed
         \\  verde live <command>          Talk to the running app
         \\  verde mcp                     Run the stdio MCP bridge
@@ -97,6 +104,11 @@ fn printHelp(out: output.Output) !void {
         \\  process list|inspect|start|stop|restart|logs ...
         \\  stack status|start|stop|restart ...
         \\
+        \\Completion shells:
+        \\  bash
+        \\  zsh
+        \\  fish
+        \\
     , .{});
 }
 
@@ -117,20 +129,10 @@ fn printCapabilities(allocator: std.mem.Allocator, out: output.Output, json: boo
         .version = VERSION,
         .protocol_version = 1,
         .cli = .{
-            .state = &.{ "path", "projects", "panes", "threads", "transcript" },
-            .live = &.{
-                "status",         "capabilities",    "projects",       "panes",
-                "active",         "inspect",         "threads",        "terminals",
-                "processes",      "pane.focus",      "pane.split",     "pane.resize",
-                "pane.minimize",  "pane.maximize",   "pane.restore",   "pane.close",
-                "chat.status",    "chat.transcript", "chat.draft.set", "chat.draft.append",
-                "chat.send",      "chat.followup",   "chat.stop",      "chat.approve",
-                "terminal.write", "terminal.tail",   "terminal.screen", "process.list",
-                "process.inspect", "process.start",  "process.stop",   "process.restart",
-                "process.logs",   "stack.status",    "stack.start",    "stack.stop",
-                "stack.restart",
-            },
-            .encodings = &.{ "json", "jsonl" },
+            .state = spec.state_commands[0..],
+            .live = spec.live_capabilities[0..],
+            .completion = spec.shells[0..],
+            .encodings = spec.encodings[0..],
         },
         .ipc = .{
             .transport = "unix",
@@ -148,8 +150,38 @@ fn printCapabilities(allocator: std.mem.Allocator, out: output.Output, json: boo
         \\  protocol: 1
         \\  state: path, projects, panes, threads, transcript
         \\  live: status, projects, panes, pane control, chat control, terminal/process control
+        \\  completion: bash, zsh, fish
         \\  encodings: json, jsonl
         \\  terminal binary frames: no
+        \\
+    , .{});
+}
+
+fn handleCompletion(allocator: std.mem.Allocator, out: output.Output, argv: []const []const u8) !void {
+    if (args.hasFlag(argv, "--help") or args.hasFlag(argv, "-h")) {
+        try printCompletionHelp(out);
+        return;
+    }
+    const shell = args.positional(argv, 0) orelse {
+        try out.stderr("missing completion shell; expected bash, zsh, or fish\n", .{});
+        std.process.exit(2);
+    };
+    if (std.mem.eql(u8, shell, "help")) {
+        try printCompletionHelp(out);
+        return;
+    }
+    if (!try completion.print(allocator, out, shell)) {
+        try out.stderr("unsupported completion shell: {s}; expected bash, zsh, or fish\n", .{shell});
+        std.process.exit(2);
+    }
+}
+
+fn printCompletionHelp(out: output.Output) !void {
+    try out.stdout(
+        \\Usage:
+        \\  verde completion bash
+        \\  verde completion zsh
+        \\  verde completion fish
         \\
     , .{});
 }

--- a/packages/desktop/src/cli.zig
+++ b/packages/desktop/src/cli.zig
@@ -1,0 +1,941 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const args = @import("cli_args.zig");
+const output = @import("cli_output.zig");
+const db_client = @import("db/client.zig");
+const db_types = @import("db/types.zig");
+
+const VERSION = "0.0.0";
+const SOCKET_NAME = "verde.sock";
+
+pub const Result = enum {
+    handled,
+    launch_app,
+};
+
+pub fn dispatch(allocator: std.mem.Allocator, io: std.Io, process_args: std.process.Args) !Result {
+    var iterator = try std.process.Args.Iterator.initAllocator(process_args, allocator);
+    defer iterator.deinit();
+
+    var argv_list: std.ArrayList([]const u8) = .empty;
+    defer argv_list.deinit(allocator);
+    while (iterator.next()) |arg| {
+        try argv_list.append(allocator, arg);
+    }
+    const argv = argv_list.items;
+    return try dispatchArgs(allocator, io, argv);
+}
+
+fn dispatchArgs(allocator: std.mem.Allocator, io: std.Io, argv: []const []const u8) !Result {
+    if (argv.len <= 1) return .launch_app;
+
+    const out: output.Output = .{ .io = io };
+    const parsed = args.parse(argv);
+    if (std.mem.eql(u8, parsed.command, "app")) return .launch_app;
+    if (std.mem.eql(u8, parsed.command, "--help") or std.mem.eql(u8, parsed.command, "-h") or std.mem.eql(u8, parsed.command, "help")) {
+        try printHelp(out);
+        return .handled;
+    }
+    if (std.mem.eql(u8, parsed.command, "version")) {
+        try printVersion(allocator, out, parsed.json);
+        return .handled;
+    }
+    if (std.mem.eql(u8, parsed.command, "capabilities")) {
+        try printCapabilities(allocator, out, parsed.json);
+        return .handled;
+    }
+    if (std.mem.eql(u8, parsed.command, "state")) {
+        try handleState(allocator, out, parsed.rest);
+        return .handled;
+    }
+    if (std.mem.eql(u8, parsed.command, "live")) {
+        try handleLive(allocator, out, io, parsed.rest);
+        return .handled;
+    }
+    if (std.mem.eql(u8, parsed.command, "mcp")) {
+        try handleMcp(allocator, out, io);
+        return .handled;
+    }
+
+    try out.stderr("unknown verde command: {s}\n\n", .{parsed.command});
+    try printHelp(out);
+    std.process.exit(2);
+}
+
+fn printHelp(out: output.Output) !void {
+    try out.stdout(
+        \\Usage:
+        \\  verde                         Launch the desktop app
+        \\  verde app                     Launch the desktop app explicitly
+        \\  verde --help                  Show this help
+        \\  verde version [--json]        Print version metadata
+        \\  verde capabilities [--json]   Print CLI capability metadata
+        \\  verde state <command>         Read persisted state with the app closed
+        \\  verde live <command>          Talk to the running app
+        \\  verde mcp                     Run the stdio MCP bridge
+        \\
+        \\State commands:
+        \\  path
+        \\  projects [--json]
+        \\  panes --project <id|index|current> [--json]
+        \\  threads --project <id|index|current> [--json]
+        \\  transcript --project <id|index|current> --thread <index|provider-id> [--json]
+        \\
+        \\Live commands:
+        \\  status [--json]
+        \\  capabilities [--json]
+        \\  projects [--json]
+        \\  panes [--project <id|index|current>] [--json]
+        \\  active [--json]
+        \\  threads [--project <id|index|current>] [--json]
+        \\  terminals [--project <id|index|current>] [--json]
+        \\  inspect --pane <id> [--project <id|index|current>] [--json]
+        \\  pane focus|split|resize|minimize|maximize|restore|close ...
+        \\  chat status|transcript|send|followup|stop|approve|draft ...
+        \\  terminal write|tail|screen --pane <id> ...
+        \\  process list|inspect|start|stop|restart|logs ...
+        \\  stack status|start|stop|restart ...
+        \\
+    , .{});
+}
+
+fn printVersion(allocator: std.mem.Allocator, out: output.Output, json: bool) !void {
+    if (json) {
+        try out.jsonValue(allocator, .{
+            .name = "verde",
+            .version = VERSION,
+        });
+        return;
+    }
+    try out.stdout("verde {s}\n", .{VERSION});
+}
+
+fn printCapabilities(allocator: std.mem.Allocator, out: output.Output, json: bool) !void {
+    const caps = .{
+        .app = "verde",
+        .version = VERSION,
+        .protocol_version = 1,
+        .cli = .{
+            .state = &.{ "path", "projects", "panes", "threads", "transcript" },
+            .live = &.{
+                "status",         "capabilities",    "projects",       "panes",
+                "active",         "inspect",         "threads",        "terminals",
+                "processes",      "pane.focus",      "pane.split",     "pane.resize",
+                "pane.minimize",  "pane.maximize",   "pane.restore",   "pane.close",
+                "chat.status",    "chat.transcript", "chat.draft.set", "chat.draft.append",
+                "chat.send",      "chat.followup",   "chat.stop",      "chat.approve",
+                "terminal.write", "terminal.tail",   "terminal.screen", "process.list",
+                "process.inspect", "process.start",  "process.stop",   "process.restart",
+                "process.logs",   "stack.status",    "stack.start",    "stack.stop",
+                "stack.restart",
+            },
+            .encodings = &.{ "json", "jsonl" },
+        },
+        .ipc = .{
+            .transport = "unix",
+            .socket_name = SOCKET_NAME,
+            .terminal_binary_frames = false,
+            .mcp_bridge = true,
+        },
+    };
+    if (json) {
+        try out.jsonValue(allocator, caps);
+        return;
+    }
+    try out.stdout(
+        \\verde CLI capabilities
+        \\  protocol: 1
+        \\  state: path, projects, panes, threads, transcript
+        \\  live: status, projects, panes, pane control, chat control, terminal/process control
+        \\  encodings: json, jsonl
+        \\  terminal binary frames: no
+        \\
+    , .{});
+}
+
+fn handleState(allocator: std.mem.Allocator, out: output.Output, argv: []const []const u8) !void {
+    const command = args.positional(argv, 0) orelse {
+        try out.stderr("missing state command\n", .{});
+        std.process.exit(2);
+    };
+    const json = args.hasFlag(argv, "--json");
+    const pref_path = try prefPath(allocator);
+    defer allocator.free(pref_path);
+
+    if (std.mem.eql(u8, command, "path")) {
+        const db_path = try db_client.Client.pathForPrefPath(allocator, pref_path);
+        defer allocator.free(db_path);
+        if (json) {
+            try out.jsonValue(allocator, .{ .pref_path = pref_path, .state_path = db_path });
+        } else {
+            try out.stdout("{s}\n", .{db_path});
+        }
+        return;
+    }
+
+    var client = try db_client.Client.init(allocator, pref_path);
+    defer client.deinit();
+    var loaded = try client.load(allocator) orelse {
+        if (json) {
+            try out.jsonValue(allocator, .{ .projects = &.{} });
+        } else {
+            try out.stdout("No persisted Verde state found at {s}\n", .{client.path});
+        }
+        return;
+    };
+    defer loaded.deinit();
+
+    if (std.mem.eql(u8, command, "projects")) {
+        try writeStateProjects(allocator, out, loaded.value, json);
+    } else if (std.mem.eql(u8, command, "panes")) {
+        const project_index = try resolvePersistedProject(out, loaded.value, args.optionValue(argv, "--project") orelse "current");
+        try writeStatePanes(allocator, out, loaded.value, project_index, json);
+    } else if (std.mem.eql(u8, command, "threads")) {
+        const project_index = try resolvePersistedProject(out, loaded.value, args.optionValue(argv, "--project") orelse "current");
+        try writeStateThreads(allocator, out, loaded.value, project_index, json);
+    } else if (std.mem.eql(u8, command, "transcript")) {
+        const project_index = try resolvePersistedProject(out, loaded.value, args.optionValue(argv, "--project") orelse "current");
+        const thread_ref = args.optionValue(argv, "--thread") orelse {
+            try out.stderr("state transcript requires --thread\n", .{});
+            std.process.exit(2);
+        };
+        try writeStateTranscript(allocator, out, loaded.value, project_index, thread_ref, json);
+    } else {
+        try out.stderr("unknown state command: {s}\n", .{command});
+        std.process.exit(2);
+    }
+}
+
+fn handleLive(allocator: std.mem.Allocator, out: output.Output, io: std.Io, argv: []const []const u8) !void {
+    const command = args.positional(argv, 0) orelse {
+        try out.stderr("missing live command\n", .{});
+        std.process.exit(2);
+    };
+    const json = args.hasFlag(argv, "--json");
+    if (std.mem.eql(u8, command, "capabilities")) {
+        try printCapabilities(allocator, out, json);
+        return;
+    }
+    if (std.mem.eql(u8, command, "status") or
+        std.mem.eql(u8, command, "projects") or
+        std.mem.eql(u8, command, "active") or
+        std.mem.eql(u8, command, "processes"))
+    {
+        try sendLiveRequest(allocator, out, io, command, .{}, json);
+        return;
+    }
+    if (std.mem.eql(u8, command, "panes") or
+        std.mem.eql(u8, command, "threads") or
+        std.mem.eql(u8, command, "terminals"))
+    {
+        try sendLiveRequest(allocator, out, io, command, .{ .project = args.optionValue(argv, "--project") }, json);
+        return;
+    }
+    if (std.mem.eql(u8, command, "inspect")) {
+        try sendLiveRequest(allocator, out, io, "inspect", commonPaneParams(argv), json);
+        return;
+    }
+    if (std.mem.eql(u8, command, "pane")) {
+        try handleLivePane(allocator, out, io, argv, json);
+        return;
+    }
+    if (std.mem.eql(u8, command, "chat")) {
+        try handleLiveChat(allocator, out, io, argv, json);
+        return;
+    }
+    if (std.mem.eql(u8, command, "terminal")) {
+        try handleLiveTerminal(allocator, out, io, argv, json);
+        return;
+    }
+    if (std.mem.eql(u8, command, "process")) {
+        try handleLiveProcess(allocator, out, io, argv, json);
+        return;
+    }
+    if (std.mem.eql(u8, command, "stack")) {
+        try handleLiveStack(allocator, out, io, argv, json);
+        return;
+    }
+    try out.stderr("unknown live command: {s}\n", .{command});
+    std.process.exit(2);
+}
+
+fn handleLivePane(allocator: std.mem.Allocator, out: output.Output, io: std.Io, argv: []const []const u8, json: bool) !void {
+    const subcommand = args.positional(argv, 1) orelse {
+        try out.stderr("missing live pane command\n", .{});
+        std.process.exit(2);
+    };
+    if (std.mem.eql(u8, subcommand, "split")) {
+        try sendLiveRequest(allocator, out, io, "pane.split", .{
+            .project = args.optionValue(argv, "--project"),
+            .pane = try paneOption(out, argv),
+            .focused = args.hasFlag(argv, "--focused"),
+            .kind = args.optionValue(argv, "--kind") orelse "chat",
+            .axis = args.optionValue(argv, "--axis") orelse "horizontal",
+        }, json);
+        return;
+    }
+    if (std.mem.eql(u8, subcommand, "resize")) {
+        try sendLiveRequest(allocator, out, io, "pane.resize", .{
+            .project = args.optionValue(argv, "--project"),
+            .pane = try paneOption(out, argv),
+            .focused = args.hasFlag(argv, "--focused"),
+            .first = try requiredIntOption(out, argv, "--first"),
+            .second = try requiredIntOption(out, argv, "--second"),
+            .axis = args.optionValue(argv, "--axis") orelse "horizontal",
+            .ratio = try requiredFloatOption(out, argv, "--ratio"),
+        }, json);
+        return;
+    }
+    const method = try std.fmt.allocPrint(allocator, "pane.{s}", .{subcommand});
+    defer allocator.free(method);
+    try sendLiveRequest(allocator, out, io, method, commonPaneParams(argv), json);
+}
+
+fn handleLiveChat(allocator: std.mem.Allocator, out: output.Output, io: std.Io, argv: []const []const u8, json: bool) !void {
+    const subcommand = args.positional(argv, 1) orelse {
+        try out.stderr("missing live chat command\n", .{});
+        std.process.exit(2);
+    };
+    if (std.mem.eql(u8, subcommand, "draft")) {
+        const draft_command = args.positional(argv, 2) orelse {
+            try out.stderr("missing live chat draft command\n", .{});
+            std.process.exit(2);
+        };
+        const method = if (std.mem.eql(u8, draft_command, "set"))
+            "chat.draft.set"
+        else if (std.mem.eql(u8, draft_command, "append"))
+            "chat.draft.append"
+        else {
+            try out.stderr("unknown live chat draft command: {s}\n", .{draft_command});
+            std.process.exit(2);
+        };
+        try sendLiveRequest(allocator, out, io, method, .{
+            .project = args.optionValue(argv, "--project"),
+            .pane = try paneOption(out, argv),
+            .focused = args.hasFlag(argv, "--focused"),
+            .text = args.optionValue(argv, "--text") orelse trailingFreeArg(argv, 3) orelse "",
+        }, json);
+        return;
+    }
+    if (std.mem.eql(u8, subcommand, "send") or std.mem.eql(u8, subcommand, "followup")) {
+        const prompt = args.optionValue(argv, "--prompt") orelse args.optionValue(argv, "--text") orelse trailingFreeArg(argv, 2);
+        const method = if (std.mem.eql(u8, subcommand, "send")) "chat.send" else "chat.followup";
+        try sendLiveRequest(allocator, out, io, method, .{
+            .project = args.optionValue(argv, "--project"),
+            .pane = try paneOption(out, argv),
+            .focused = args.hasFlag(argv, "--focused"),
+            .prompt = prompt,
+        }, json);
+        return;
+    }
+    if (std.mem.eql(u8, subcommand, "approve")) {
+        try sendLiveRequest(allocator, out, io, "chat.approve", .{
+            .project = args.optionValue(argv, "--project"),
+            .pane = try paneOption(out, argv),
+            .focused = args.hasFlag(argv, "--focused"),
+            .call_id = args.optionValue(argv, "--call"),
+            .decision = args.optionValue(argv, "--decision") orelse "approve",
+        }, json);
+        return;
+    }
+    const method = try std.fmt.allocPrint(allocator, "chat.{s}", .{subcommand});
+    defer allocator.free(method);
+    try sendLiveRequest(allocator, out, io, method, commonPaneParams(argv), json);
+}
+
+fn handleLiveTerminal(allocator: std.mem.Allocator, out: output.Output, io: std.Io, argv: []const []const u8, json: bool) !void {
+    const subcommand = args.positional(argv, 1) orelse {
+        try out.stderr("missing live terminal command\n", .{});
+        std.process.exit(2);
+    };
+    if (std.mem.eql(u8, subcommand, "write")) {
+        try sendLiveRequest(allocator, out, io, "terminal.write", .{
+            .project = args.optionValue(argv, "--project"),
+            .pane = try paneOption(out, argv),
+            .focused = args.hasFlag(argv, "--focused"),
+            .text = args.optionValue(argv, "--text") orelse trailingFreeArg(argv, 2) orelse "",
+        }, json);
+        return;
+    }
+    if (std.mem.eql(u8, subcommand, "tail")) {
+        try sendLiveRequest(allocator, out, io, "terminal.tail", .{
+            .project = args.optionValue(argv, "--project"),
+            .pane = try paneOption(out, argv),
+            .focused = args.hasFlag(argv, "--focused"),
+            .lines = parseOptionalU32(args.optionValue(argv, "--lines")),
+        }, json);
+        return;
+    }
+    if (std.mem.eql(u8, subcommand, "screen")) {
+        try sendLiveRequest(allocator, out, io, "terminal.screen", commonPaneParams(argv), json);
+        return;
+    }
+    try out.stderr("unknown live terminal command: {s}\n", .{subcommand});
+    std.process.exit(2);
+}
+
+fn handleLiveProcess(allocator: std.mem.Allocator, out: output.Output, io: std.Io, argv: []const []const u8, json: bool) !void {
+    const subcommand = args.positional(argv, 1) orelse {
+        try out.stderr("missing live process command\n", .{});
+        std.process.exit(2);
+    };
+    if (std.mem.eql(u8, subcommand, "inspect")) {
+        try sendLiveRequest(allocator, out, io, "process.inspect", processParams(argv), json);
+        return;
+    }
+    if (std.mem.eql(u8, subcommand, "list") or
+        std.mem.eql(u8, subcommand, "start") or
+        std.mem.eql(u8, subcommand, "stop") or
+        std.mem.eql(u8, subcommand, "restart") or
+        std.mem.eql(u8, subcommand, "logs"))
+    {
+        const method = try std.fmt.allocPrint(allocator, "process.{s}", .{subcommand});
+        defer allocator.free(method);
+        try sendLiveRequest(allocator, out, io, method, processParams(argv), json);
+        return;
+    }
+    const method = try std.fmt.allocPrint(allocator, "process.{s}", .{subcommand});
+    defer allocator.free(method);
+    try sendLiveRequest(allocator, out, io, method, commonPaneParams(argv), json);
+}
+
+fn handleLiveStack(allocator: std.mem.Allocator, out: output.Output, io: std.Io, argv: []const []const u8, json: bool) !void {
+    const subcommand = args.positional(argv, 1) orelse {
+        try out.stderr("missing live stack command\n", .{});
+        std.process.exit(2);
+    };
+    if (std.mem.eql(u8, subcommand, "status") or
+        std.mem.eql(u8, subcommand, "start") or
+        std.mem.eql(u8, subcommand, "stop") or
+        std.mem.eql(u8, subcommand, "restart"))
+    {
+        const method = try std.fmt.allocPrint(allocator, "stack.{s}", .{subcommand});
+        defer allocator.free(method);
+        try sendLiveRequest(allocator, out, io, method, .{ .project = args.optionValue(argv, "--project") }, json);
+        return;
+    }
+    try out.stderr("unknown live stack command: {s}\n", .{subcommand});
+    std.process.exit(2);
+}
+
+fn sendLiveRequest(allocator: std.mem.Allocator, out: output.Output, io: std.Io, method: []const u8, params: anytype, json: bool) !void {
+    const response = sendLiveRequestAlloc(allocator, io, method, params, 1) catch |err| {
+        liveUnavailable(out, err);
+    };
+    defer allocator.free(response);
+    if (json) {
+        try out.stdout("{s}\n", .{response});
+    } else {
+        try printLiveResponse(out, response);
+    }
+}
+
+fn sendLiveRequestAlloc(allocator: std.mem.Allocator, _: std.Io, method: []const u8, params: anytype, request_id: u64) ![]u8 {
+    var threaded = std.Io.Threaded.init_single_threaded;
+    const live_io = threaded.io();
+    const pref_path = try prefPath(allocator);
+    defer allocator.free(pref_path);
+    const socket_path = try std.fs.path.join(allocator, &.{ pref_path, SOCKET_NAME });
+    defer allocator.free(socket_path);
+
+    var request_writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer request_writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &request_writer.writer, .options = .{} };
+    try s.beginObject();
+    try s.objectField("id");
+    try s.write(request_id);
+    try s.objectField("method");
+    try s.write(method);
+    try s.objectField("params");
+    try s.write(params);
+    try s.endObject();
+    const request_json = try request_writer.toOwnedSlice();
+    defer allocator.free(request_json);
+
+    const address = try std.Io.net.UnixAddress.init(socket_path);
+    const stream = try address.connect(live_io);
+    defer stream.close(live_io);
+
+    var write_buffer: [64 * 1024]u8 = undefined;
+    var writer = stream.writer(live_io, &write_buffer);
+    try writer.interface.writeAll(request_json);
+    try writer.interface.writeByte('\n');
+    try writer.interface.flush();
+
+    var read_buffer: [256 * 1024]u8 = undefined;
+    var reader = stream.reader(live_io, &read_buffer);
+    const line = try reader.interface.takeDelimiter('\n') orelse return error.ConnectionAborted;
+    const response = std.mem.trim(u8, line, "\r");
+    return try allocator.dupe(u8, response);
+}
+
+fn printLiveResponse(out: output.Output, response: []const u8) !void {
+    try out.stdout("{s}\n", .{response});
+}
+
+fn handleMcp(allocator: std.mem.Allocator, out: output.Output, io: std.Io) !void {
+    const stdin_file = std.Io.File.stdin();
+    var read_buffer: [256 * 1024]u8 = undefined;
+    var reader = stdin_file.reader(io, &read_buffer);
+    while (true) {
+        const maybe_line = try reader.interface.takeDelimiter('\n');
+        const raw_line = maybe_line orelse break;
+        const line = std.mem.trim(u8, raw_line, " \t\r");
+        if (line.len == 0) continue;
+        var parsed = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch |err| {
+            try mcpError(allocator, out, .null, -32700, @errorName(err));
+            continue;
+        };
+        defer parsed.deinit();
+        if (parsed.value != .object) {
+            try mcpError(allocator, out, .null, -32600, "request must be an object");
+            continue;
+        }
+        const id_value = parsed.value.object.get("id") orelse .null;
+        const method = jsonString(parsed.value.object.get("method") orelse .null) orelse {
+            try mcpError(allocator, out, id_value, -32600, "missing method");
+            continue;
+        };
+        const params = parsed.value.object.get("params") orelse .null;
+
+        if (std.mem.eql(u8, method, "initialize")) {
+            try mcpInitialize(allocator, out, id_value);
+        } else if (std.mem.eql(u8, method, "tools/list")) {
+            try mcpToolsList(allocator, out, id_value);
+        } else if (std.mem.eql(u8, method, "tools/call")) {
+            try mcpToolsCall(allocator, out, io, id_value, params);
+        } else if (std.mem.eql(u8, method, "notifications/initialized")) {
+            continue;
+        } else {
+            try mcpError(allocator, out, id_value, -32601, "method not found");
+        }
+    }
+}
+
+fn mcpInitialize(allocator: std.mem.Allocator, out: output.Output, id_value: std.json.Value) !void {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    defer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try mcpBeginResult(&s, id_value);
+    try s.beginObject();
+    try s.objectField("protocolVersion");
+    try s.write("2024-11-05");
+    try s.objectField("capabilities");
+    try s.beginObject();
+    try s.objectField("tools");
+    try s.beginObject();
+    try s.endObject();
+    try s.endObject();
+    try s.objectField("serverInfo");
+    try s.beginObject();
+    try s.objectField("name");
+    try s.write("verde");
+    try s.objectField("version");
+    try s.write(VERSION);
+    try s.endObject();
+    try s.endObject();
+    try s.endObject();
+    try out.stdout("{s}\n", .{writer.written()});
+}
+
+fn mcpToolsList(allocator: std.mem.Allocator, out: output.Output, id_value: std.json.Value) !void {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    defer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try mcpBeginResult(&s, id_value);
+    try s.beginObject();
+    try s.objectField("tools");
+    try s.beginArray();
+    try writeMcpTool(&s, "list_processes", "List configured Verde processes.");
+    try writeMcpTool(&s, "inspect_process", "Inspect a configured Verde process.");
+    try writeMcpTool(&s, "tail_process_logs", "Read recent output for a configured Verde process.");
+    try writeMcpTool(&s, "restart_process", "Restart a configured Verde process.");
+    try writeMcpTool(&s, "stop_process", "Stop a configured Verde process.");
+    try writeMcpTool(&s, "start_process", "Start a configured Verde process.");
+    try s.endArray();
+    try s.endObject();
+    try s.endObject();
+    try out.stdout("{s}\n", .{writer.written()});
+}
+
+fn writeMcpTool(s: *std.json.Stringify, name: []const u8, description: []const u8) !void {
+    try s.beginObject();
+    try s.objectField("name");
+    try s.write(name);
+    try s.objectField("description");
+    try s.write(description);
+    try s.objectField("inputSchema");
+    try s.beginObject();
+    try s.objectField("type");
+    try s.write("object");
+    try s.objectField("additionalProperties");
+    try s.write(true);
+    try s.endObject();
+    try s.endObject();
+}
+
+fn mcpToolsCall(allocator: std.mem.Allocator, out: output.Output, io: std.Io, id_value: std.json.Value, params: std.json.Value) !void {
+    if (params != .object) return try mcpError(allocator, out, id_value, -32602, "tools/call params must be an object");
+    const tool_name = jsonString(params.object.get("name") orelse .null) orelse
+        return try mcpError(allocator, out, id_value, -32602, "tools/call requires name");
+    const arguments = params.object.get("arguments") orelse .null;
+    const project = mcpArgString(arguments, "project");
+    const process_name = mcpArgString(arguments, "name");
+    const lines = mcpArgU32(arguments, "lines");
+
+    const response = blk: {
+        if (std.mem.eql(u8, tool_name, "list_processes")) {
+            break :blk sendLiveRequestAlloc(allocator, io, "processes", .{ .project = project }, 1);
+        }
+        if (std.mem.eql(u8, tool_name, "inspect_process")) {
+            const name = process_name orelse return try mcpError(allocator, out, id_value, -32602, "inspect_process requires name");
+            break :blk sendLiveRequestAlloc(allocator, io, "process.inspect", .{ .project = project, .name = name }, 1);
+        }
+        if (std.mem.eql(u8, tool_name, "tail_process_logs")) {
+            const name = process_name orelse return try mcpError(allocator, out, id_value, -32602, "tail_process_logs requires name");
+            break :blk sendLiveRequestAlloc(allocator, io, "process.logs", .{ .project = project, .name = name, .lines = lines }, 1);
+        }
+        if (std.mem.eql(u8, tool_name, "restart_process")) {
+            const name = process_name orelse return try mcpError(allocator, out, id_value, -32602, "restart_process requires name");
+            break :blk sendLiveRequestAlloc(allocator, io, "process.restart", .{ .project = project, .name = name }, 1);
+        }
+        if (std.mem.eql(u8, tool_name, "stop_process")) {
+            const name = process_name orelse return try mcpError(allocator, out, id_value, -32602, "stop_process requires name");
+            break :blk sendLiveRequestAlloc(allocator, io, "process.stop", .{ .project = project, .name = name }, 1);
+        }
+        if (std.mem.eql(u8, tool_name, "start_process")) {
+            const name = process_name orelse return try mcpError(allocator, out, id_value, -32602, "start_process requires name");
+            break :blk sendLiveRequestAlloc(allocator, io, "process.start", .{ .project = project, .name = name }, 1);
+        }
+        return try mcpError(allocator, out, id_value, -32602, "unknown tool");
+    } catch |err| {
+        return try mcpError(allocator, out, id_value, -32000, @errorName(err));
+    };
+    defer allocator.free(response);
+    try mcpToolTextResult(allocator, out, id_value, response);
+}
+
+fn mcpToolTextResult(allocator: std.mem.Allocator, out: output.Output, id_value: std.json.Value, text: []const u8) !void {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    defer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try mcpBeginResult(&s, id_value);
+    try s.beginObject();
+    try s.objectField("content");
+    try s.beginArray();
+    try s.beginObject();
+    try s.objectField("type");
+    try s.write("text");
+    try s.objectField("text");
+    try s.write(text);
+    try s.endObject();
+    try s.endArray();
+    try s.endObject();
+    try s.endObject();
+    try out.stdout("{s}\n", .{writer.written()});
+}
+
+fn mcpError(allocator: std.mem.Allocator, out: output.Output, id_value: std.json.Value, code: i32, message: []const u8) !void {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    defer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try s.beginObject();
+    try s.objectField("jsonrpc");
+    try s.write("2.0");
+    try s.objectField("id");
+    try writeJsonValue(&s, id_value);
+    try s.objectField("error");
+    try s.beginObject();
+    try s.objectField("code");
+    try s.write(code);
+    try s.objectField("message");
+    try s.write(message);
+    try s.endObject();
+    try s.endObject();
+    try out.stdout("{s}\n", .{writer.written()});
+}
+
+fn mcpBeginResult(s: *std.json.Stringify, id_value: std.json.Value) !void {
+    try s.beginObject();
+    try s.objectField("jsonrpc");
+    try s.write("2.0");
+    try s.objectField("id");
+    try writeJsonValue(s, id_value);
+    try s.objectField("result");
+}
+
+fn mcpArgString(arguments: std.json.Value, name: []const u8) ?[]const u8 {
+    if (arguments != .object) return null;
+    return jsonString(arguments.object.get(name) orelse .null);
+}
+
+fn mcpArgU32(arguments: std.json.Value, name: []const u8) ?u32 {
+    if (arguments != .object) return null;
+    const value = arguments.object.get(name) orelse .null;
+    return switch (value) {
+        .integer => |int| if (int >= 0) @intCast(int) else null,
+        .number_string => |text| std.fmt.parseInt(u32, text, 10) catch null,
+        else => null,
+    };
+}
+
+fn writeJsonValue(s: *std.json.Stringify, value: std.json.Value) !void {
+    switch (value) {
+        .integer => |v| try s.write(v),
+        .float => |v| try s.write(v),
+        .number_string => |v| try s.write(v),
+        .string => |v| try s.write(v),
+        .bool => |v| try s.write(v),
+        .null => try s.write(null),
+        else => try s.write(null),
+    }
+}
+
+fn jsonString(value: std.json.Value) ?[]const u8 {
+    return switch (value) {
+        .string => |text| text,
+        else => null,
+    };
+}
+
+fn liveUnavailable(out: output.Output, err: anyerror) noreturn {
+    out.stderr("verde live server is not running: {s}\n", .{@errorName(err)}) catch {};
+    std.process.exit(3);
+}
+
+fn commonPaneParams(argv: []const []const u8) struct { project: ?[]const u8, pane: ?u32, focused: bool } {
+    return .{
+        .project = args.optionValue(argv, "--project"),
+        .pane = parseOptionalU32(args.optionValue(argv, "--pane")),
+        .focused = args.hasFlag(argv, "--focused"),
+    };
+}
+
+fn processParams(argv: []const []const u8) struct { project: ?[]const u8, pane: ?u32, focused: bool, name: ?[]const u8, lines: ?u32 } {
+    return .{
+        .project = args.optionValue(argv, "--project"),
+        .pane = parseOptionalU32(args.optionValue(argv, "--pane")),
+        .focused = args.hasFlag(argv, "--focused"),
+        .name = args.optionValue(argv, "--name"),
+        .lines = parseOptionalU32(args.optionValue(argv, "--lines")),
+    };
+}
+
+fn paneOption(out: output.Output, argv: []const []const u8) !?u32 {
+    if (args.hasFlag(argv, "--focused")) return null;
+    const value = args.optionValue(argv, "--pane") orelse {
+        try out.stderr("missing --pane or --focused\n", .{});
+        std.process.exit(2);
+    };
+    return std.fmt.parseInt(u32, value, 10) catch {
+        try out.stderr("invalid --pane value: {s}\n", .{value});
+        std.process.exit(2);
+    };
+}
+
+fn requiredIntOption(out: output.Output, argv: []const []const u8, name: []const u8) !u32 {
+    const value = args.optionValue(argv, name) orelse {
+        try out.stderr("missing {s}\n", .{name});
+        std.process.exit(2);
+    };
+    return std.fmt.parseInt(u32, value, 10) catch {
+        try out.stderr("invalid {s} value: {s}\n", .{ name, value });
+        std.process.exit(2);
+    };
+}
+
+fn requiredFloatOption(out: output.Output, argv: []const []const u8, name: []const u8) !f32 {
+    const value = args.optionValue(argv, name) orelse {
+        try out.stderr("missing {s}\n", .{name});
+        std.process.exit(2);
+    };
+    return std.fmt.parseFloat(f32, value) catch {
+        try out.stderr("invalid {s} value: {s}\n", .{ name, value });
+        std.process.exit(2);
+    };
+}
+
+fn parseOptionalU32(value: ?[]const u8) ?u32 {
+    const raw = value orelse return null;
+    return std.fmt.parseInt(u32, raw, 10) catch null;
+}
+
+fn trailingFreeArg(argv: []const []const u8, positional_commands: usize) ?[]const u8 {
+    var seen_commands: usize = 0;
+    var skip_option_value = false;
+    var trailing: ?[]const u8 = null;
+    for (argv) |arg| {
+        if (skip_option_value) {
+            skip_option_value = false;
+            continue;
+        }
+        if (std.mem.startsWith(u8, arg, "--")) {
+            if (optionConsumesValue(arg)) skip_option_value = true;
+            continue;
+        }
+        if (seen_commands < positional_commands) {
+            seen_commands += 1;
+            continue;
+        }
+        trailing = arg;
+    }
+    return trailing;
+}
+
+fn optionConsumesValue(name: []const u8) bool {
+    return std.mem.eql(u8, name, "--project") or
+        std.mem.eql(u8, name, "--pane") or
+        std.mem.eql(u8, name, "--kind") or
+        std.mem.eql(u8, name, "--axis") or
+        std.mem.eql(u8, name, "--first") or
+        std.mem.eql(u8, name, "--second") or
+        std.mem.eql(u8, name, "--ratio") or
+        std.mem.eql(u8, name, "--text") or
+        std.mem.eql(u8, name, "--prompt") or
+        std.mem.eql(u8, name, "--call") or
+        std.mem.eql(u8, name, "--decision") or
+        std.mem.eql(u8, name, "--name") or
+        std.mem.eql(u8, name, "--lines") or
+        std.mem.eql(u8, name, "--thread");
+}
+
+fn writeStateProjects(allocator: std.mem.Allocator, out: output.Output, state: db_types.PersistedState, json: bool) !void {
+    if (json) {
+        try out.jsonValue(allocator, state.projects);
+        return;
+    }
+    try out.stdout("INDEX  ID  LABEL  PATH\n", .{});
+    for (state.projects, 0..) |project, index| {
+        try out.stdout("{d}  {s}  {s}  {s}\n", .{
+            index,
+            project.id orelse "",
+            project.label,
+            project.path,
+        });
+    }
+}
+
+fn writeStatePanes(allocator: std.mem.Allocator, out: output.Output, state: db_types.PersistedState, project_index: usize, json: bool) !void {
+    const project = state.projects[project_index];
+    if (json) {
+        try out.jsonValue(allocator, .{
+            .project = project.id orelse project.path,
+            .workspace_layout_json = project.workspace_layout_json,
+            .terminal_docks_json = project.terminal_docks_json,
+            .live = false,
+        });
+        return;
+    }
+    try out.stdout("Project: {s}\n", .{project.label});
+    if (project.workspace_layout_json) |layout| {
+        try out.stdout("{s}\n", .{layout});
+    } else {
+        try out.stdout("No persisted workspace layout.\n", .{});
+    }
+}
+
+fn writeStateThreads(allocator: std.mem.Allocator, out: output.Output, state: db_types.PersistedState, project_index: usize, json: bool) !void {
+    const project = state.projects[project_index];
+    const threads = project.threads orelse &.{};
+    if (json) {
+        try out.jsonValue(allocator, threads);
+        return;
+    }
+    try out.stdout("INDEX  PROVIDER_THREAD_ID  TITLE\n", .{});
+    for (threads, 0..) |thread, index| {
+        try out.stdout("{d}  {s}  {s}\n", .{ index, thread.provider_thread_id orelse "", thread.title });
+    }
+}
+
+fn writeStateTranscript(
+    allocator: std.mem.Allocator,
+    out: output.Output,
+    state: db_types.PersistedState,
+    project_index: usize,
+    thread_ref: []const u8,
+    json: bool,
+) !void {
+    const project = state.projects[project_index];
+    const threads = project.threads orelse &.{};
+    const thread_index = resolvePersistedThread(threads, thread_ref) orelse {
+        try out.stderr("thread not found: {s}\n", .{thread_ref});
+        std.process.exit(4);
+    };
+    const thread = threads[thread_index];
+    if (json) {
+        try out.jsonValue(allocator, .{
+            .project = project.id orelse project.path,
+            .thread_index = thread_index,
+            .thread = thread,
+        });
+        return;
+    }
+    try out.stdout("# {s}\n\n", .{thread.title});
+    for (thread.messages) |message| {
+        try out.stdout("## {s}\n{s}\n\n", .{ message.author, message.body });
+    }
+}
+
+fn resolvePersistedProject(out: output.Output, state: db_types.PersistedState, ref: []const u8) !usize {
+    if (state.projects.len == 0) {
+        try out.stderr("no projects in persisted state\n", .{});
+        std.process.exit(4);
+    }
+    if (std.mem.eql(u8, ref, "current")) return @min(state.selected_project_index, state.projects.len - 1);
+    if (std.fmt.parseInt(usize, ref, 10)) |index| {
+        if (index < state.projects.len) return index;
+    } else |_| {}
+    for (state.projects, 0..) |project, index| {
+        if (project.id) |id| {
+            if (std.mem.eql(u8, id, ref)) return index;
+        }
+        if (std.mem.eql(u8, project.path, ref)) return index;
+    }
+    try out.stderr("project not found: {s}\n", .{ref});
+    std.process.exit(4);
+}
+
+fn resolvePersistedThread(threads: []const db_types.PersistedThread, ref: []const u8) ?usize {
+    if (std.fmt.parseInt(usize, ref, 10)) |index| {
+        if (index < threads.len) return index;
+    } else |_| {}
+    for (threads, 0..) |thread, index| {
+        if (thread.provider_thread_id) |provider_thread_id| {
+            if (std.mem.eql(u8, provider_thread_id, ref)) return index;
+        }
+    }
+    return null;
+}
+
+fn prefPath(allocator: std.mem.Allocator) ![]u8 {
+    return switch (builtin.os.tag) {
+        .linux, .freebsd, .openbsd, .netbsd => blk: {
+            if (envVarOwned(allocator, "XDG_DATA_HOME")) |xdg| {
+                defer allocator.free(xdg);
+                break :blk try std.fs.path.join(allocator, &.{ xdg, "verde", "Native" });
+            } else |_| {}
+            const home = try envVarOwned(allocator, "HOME");
+            defer allocator.free(home);
+            break :blk try std.fs.path.join(allocator, &.{ home, ".local", "share", "verde", "Native" });
+        },
+        .macos => blk: {
+            const home = try envVarOwned(allocator, "HOME");
+            defer allocator.free(home);
+            break :blk try std.fs.path.join(allocator, &.{ home, "Library", "Application Support", "verde", "Native" });
+        },
+        else => try std.fs.path.join(allocator, &.{ ".", "verde", "Native" }),
+    };
+}
+
+fn envVarOwned(allocator: std.mem.Allocator, comptime name: [:0]const u8) ![]u8 {
+    const value_ptr = std.c.getenv(name.ptr) orelse return error.EnvironmentVariableNotFound;
+    return try allocator.dupe(u8, std.mem.sliceTo(value_ptr, 0));
+}
+
+test "cli args parse command and json flag" {
+    const argv = [_][]const u8{ "verde", "state", "projects", "--json" };
+    const parsed = args.parse(&argv);
+    try std.testing.expectEqualStrings("state", parsed.command);
+    try std.testing.expect(parsed.json);
+}

--- a/packages/desktop/src/cli_args.zig
+++ b/packages/desktop/src/cli_args.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+pub const Parsed = struct {
+    command: []const u8 = "",
+    rest: []const []const u8 = &.{},
+    json: bool = false,
+};
+
+pub fn parse(args: []const []const u8) Parsed {
+    if (args.len <= 1) return .{};
+    var parsed: Parsed = .{ .command = args[1], .rest = args[2..] };
+    parsed.json = hasFlag(parsed.rest, "--json");
+    return parsed;
+}
+
+pub fn hasFlag(args: []const []const u8, flag: []const u8) bool {
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, flag)) return true;
+    }
+    return false;
+}
+
+pub fn positional(args: []const []const u8, index: usize) ?[]const u8 {
+    var seen: usize = 0;
+    for (args) |arg| {
+        if (std.mem.startsWith(u8, arg, "--")) continue;
+        if (seen == index) return arg;
+        seen += 1;
+    }
+    return null;
+}
+
+pub fn optionValue(args: []const []const u8, name: []const u8) ?[]const u8 {
+    for (args, 0..) |arg, index| {
+        if (!std.mem.eql(u8, arg, name)) continue;
+        if (index + 1 >= args.len) return null;
+        return args[index + 1];
+    }
+    return null;
+}

--- a/packages/desktop/src/cli_completion.zig
+++ b/packages/desktop/src/cli_completion.zig
@@ -1,0 +1,383 @@
+const std = @import("std");
+
+const output = @import("cli_output.zig");
+const spec = @import("cli_spec.zig");
+
+pub fn print(allocator: std.mem.Allocator, out: output.Output, shell: []const u8) !bool {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    defer writer.deinit();
+
+    if (std.mem.eql(u8, shell, "bash")) {
+        try writeBash(&writer.writer);
+    } else if (std.mem.eql(u8, shell, "zsh")) {
+        try writeZsh(&writer.writer);
+    } else if (std.mem.eql(u8, shell, "fish")) {
+        try writeFish(&writer.writer);
+    } else {
+        return false;
+    }
+
+    try out.stdout("{s}", .{writer.written()});
+    return true;
+}
+
+fn writeWords(w: *std.Io.Writer, words: []const []const u8) !void {
+    for (words, 0..) |word, index| {
+        if (index > 0) try w.writeByte(' ');
+        try w.writeAll(word);
+    }
+}
+
+fn writeBash(w: *std.Io.Writer) !void {
+    try w.writeAll(
+        \\# bash completion for verde
+        \\_verde_completion() {
+        \\  local cur prev root sub third fourth
+        \\  COMPREPLY=()
+        \\  cur="${COMP_WORDS[COMP_CWORD]}"
+        \\  prev="${COMP_WORDS[COMP_CWORD-1]}"
+        \\  root="${COMP_WORDS[1]}"
+        \\  sub="${COMP_WORDS[2]}"
+        \\  third="${COMP_WORDS[3]}"
+        \\  fourth="${COMP_WORDS[4]}"
+        \\
+        \\  local top="
+    );
+    try writeWords(w, &spec.top_level_commands);
+    try w.writeAll("\"\n  local shells=\"");
+    try writeWords(w, &spec.shells);
+    try w.writeAll("\"\n  local state=\"");
+    try writeWords(w, &spec.state_commands);
+    try w.writeAll("\"\n  local live=\"");
+    try writeWords(w, &spec.live_commands);
+    try w.writeAll("\"\n  local pane=\"");
+    try writeWords(w, &spec.pane_commands);
+    try w.writeAll("\"\n  local chat=\"");
+    try writeWords(w, &spec.chat_commands);
+    try w.writeAll("\"\n  local draft=\"");
+    try writeWords(w, &spec.chat_draft_commands);
+    try w.writeAll("\"\n  local terminal=\"");
+    try writeWords(w, &spec.terminal_commands);
+    try w.writeAll("\"\n  local process=\"");
+    try writeWords(w, &spec.process_commands);
+    try w.writeAll("\"\n  local stack=\"");
+    try writeWords(w, &spec.stack_commands);
+    try w.writeAll("\"\n  local all_flags=\"");
+    try writeWords(w, &spec.all_flags);
+    try w.writeAll("\"\n  local json_flags=\"");
+    try writeWords(w, &spec.json_flags);
+    try w.writeAll("\"\n  local project_json_flags=\"");
+    try writeWords(w, &spec.project_json_flags);
+    try w.writeAll("\"\n  local pane_flags=\"");
+    try writeWords(w, &spec.pane_flags);
+    try w.writeAll("\"\n  local pane_split_flags=\"");
+    try writeWords(w, &spec.pane_split_flags);
+    try w.writeAll("\"\n  local pane_resize_flags=\"");
+    try writeWords(w, &spec.pane_resize_flags);
+    try w.writeAll("\"\n  local chat_draft_flags=\"");
+    try writeWords(w, &spec.chat_draft_flags);
+    try w.writeAll("\"\n  local chat_send_flags=\"");
+    try writeWords(w, &spec.chat_send_flags);
+    try w.writeAll("\"\n  local chat_approve_flags=\"");
+    try writeWords(w, &spec.chat_approve_flags);
+    try w.writeAll("\"\n  local terminal_write_flags=\"");
+    try writeWords(w, &spec.terminal_write_flags);
+    try w.writeAll("\"\n  local terminal_tail_flags=\"");
+    try writeWords(w, &spec.terminal_tail_flags);
+    try w.writeAll("\"\n  local process_flags=\"");
+    try writeWords(w, &spec.process_flags);
+    try w.writeAll("\"\n  local kind_values=\"");
+    try writeWords(w, &spec.kind_values);
+    try w.writeAll("\"\n  local axis_values=\"");
+    try writeWords(w, &spec.axis_values);
+    try w.writeAll("\"\n  local decision_values=\"");
+    try writeWords(w, &spec.decision_values);
+    try w.writeAll(
+        \\"
+        \\
+        \\  case "$prev" in
+        \\    --kind) COMPREPLY=( $(compgen -W "$kind_values" -- "$cur") ); return 0 ;;
+        \\    --axis) COMPREPLY=( $(compgen -W "$axis_values" -- "$cur") ); return 0 ;;
+        \\    --decision) COMPREPLY=( $(compgen -W "$decision_values" -- "$cur") ); return 0 ;;
+        \\    --project|--thread|--pane|--first|--second|--ratio|--text|--prompt|--call|--name|--lines) return 0 ;;
+        \\  esac
+        \\
+        \\  if [[ "$cur" == -* ]]; then
+        \\    case "$root" in
+        \\      "")
+        \\        COMPREPLY=( $(compgen -W "--help -h" -- "$cur") )
+        \\        ;;
+        \\      version|capabilities)
+        \\        COMPREPLY=( $(compgen -W "$json_flags" -- "$cur") )
+        \\        ;;
+        \\      state)
+        \\        case "$sub" in
+        \\          panes|threads) COMPREPLY=( $(compgen -W "$project_json_flags" -- "$cur") ) ;;
+        \\          transcript) COMPREPLY=( $(compgen -W "--project --thread --json" -- "$cur") ) ;;
+        \\          *) COMPREPLY=( $(compgen -W "$json_flags" -- "$cur") ) ;;
+        \\        esac
+        \\        ;;
+        \\      live)
+        \\        case "$sub" in
+        \\          panes|threads|terminals) COMPREPLY=( $(compgen -W "$project_json_flags" -- "$cur") ) ;;
+        \\          inspect) COMPREPLY=( $(compgen -W "$pane_flags" -- "$cur") ) ;;
+        \\          pane)
+        \\            case "$third" in
+        \\              split) COMPREPLY=( $(compgen -W "$pane_split_flags" -- "$cur") ) ;;
+        \\              resize) COMPREPLY=( $(compgen -W "$pane_resize_flags" -- "$cur") ) ;;
+        \\              *) COMPREPLY=( $(compgen -W "$pane_flags" -- "$cur") ) ;;
+        \\            esac
+        \\            ;;
+        \\          chat)
+        \\            case "$third" in
+        \\              draft) COMPREPLY=( $(compgen -W "$chat_draft_flags" -- "$cur") ) ;;
+        \\              send|followup) COMPREPLY=( $(compgen -W "$chat_send_flags" -- "$cur") ) ;;
+        \\              approve) COMPREPLY=( $(compgen -W "$chat_approve_flags" -- "$cur") ) ;;
+        \\              *) COMPREPLY=( $(compgen -W "$pane_flags" -- "$cur") ) ;;
+        \\            esac
+        \\            ;;
+        \\          terminal)
+        \\            case "$third" in
+        \\              write) COMPREPLY=( $(compgen -W "$terminal_write_flags" -- "$cur") ) ;;
+        \\              tail) COMPREPLY=( $(compgen -W "$terminal_tail_flags" -- "$cur") ) ;;
+        \\              *) COMPREPLY=( $(compgen -W "$pane_flags" -- "$cur") ) ;;
+        \\            esac
+        \\            ;;
+        \\          process) COMPREPLY=( $(compgen -W "$process_flags" -- "$cur") ) ;;
+        \\          stack) COMPREPLY=( $(compgen -W "$project_json_flags" -- "$cur") ) ;;
+        \\          *) COMPREPLY=( $(compgen -W "$json_flags" -- "$cur") ) ;;
+        \\        esac
+        \\        ;;
+        \\      *) COMPREPLY=( $(compgen -W "$all_flags" -- "$cur") ) ;;
+        \\    esac
+        \\    return 0
+        \\  fi
+        \\
+        \\  case "$COMP_CWORD:$root:$sub:$third" in
+        \\    1:*) COMPREPLY=( $(compgen -W "$top --help -h" -- "$cur") ) ;;
+        \\    2:completion:*) COMPREPLY=( $(compgen -W "$shells" -- "$cur") ) ;;
+        \\    2:state:*) COMPREPLY=( $(compgen -W "$state" -- "$cur") ) ;;
+        \\    2:live:*) COMPREPLY=( $(compgen -W "$live" -- "$cur") ) ;;
+        \\    3:live:pane:*) COMPREPLY=( $(compgen -W "$pane" -- "$cur") ) ;;
+        \\    3:live:chat:*) COMPREPLY=( $(compgen -W "$chat" -- "$cur") ) ;;
+        \\    3:live:terminal:*) COMPREPLY=( $(compgen -W "$terminal" -- "$cur") ) ;;
+        \\    3:live:process:*) COMPREPLY=( $(compgen -W "$process" -- "$cur") ) ;;
+        \\    3:live:stack:*) COMPREPLY=( $(compgen -W "$stack" -- "$cur") ) ;;
+        \\    4:live:chat:draft) COMPREPLY=( $(compgen -W "$draft" -- "$cur") ) ;;
+        \\  esac
+        \\}
+        \\complete -F _verde_completion verde
+        \\
+    );
+}
+
+fn writeZsh(w: *std.Io.Writer) !void {
+    try w.writeAll(
+        \\#compdef verde
+        \\# zsh completion for verde
+        \\_verde() {
+        \\  local cur prev root sub third fourth
+        \\  cur="${words[CURRENT]}"
+        \\  prev="${words[CURRENT-1]}"
+        \\  root="${words[2]}"
+        \\  sub="${words[3]}"
+        \\  third="${words[4]}"
+        \\  fourth="${words[5]}"
+        \\
+        \\  local top="
+    );
+    try writeWords(w, &spec.top_level_commands);
+    try w.writeAll("\"\n  local shells=\"");
+    try writeWords(w, &spec.shells);
+    try w.writeAll("\"\n  local state=\"");
+    try writeWords(w, &spec.state_commands);
+    try w.writeAll("\"\n  local live=\"");
+    try writeWords(w, &spec.live_commands);
+    try w.writeAll("\"\n  local pane=\"");
+    try writeWords(w, &spec.pane_commands);
+    try w.writeAll("\"\n  local chat=\"");
+    try writeWords(w, &spec.chat_commands);
+    try w.writeAll("\"\n  local draft=\"");
+    try writeWords(w, &spec.chat_draft_commands);
+    try w.writeAll("\"\n  local terminal=\"");
+    try writeWords(w, &spec.terminal_commands);
+    try w.writeAll("\"\n  local process=\"");
+    try writeWords(w, &spec.process_commands);
+    try w.writeAll("\"\n  local stack=\"");
+    try writeWords(w, &spec.stack_commands);
+    try w.writeAll("\"\n  local all_flags=\"");
+    try writeWords(w, &spec.all_flags);
+    try w.writeAll("\"\n  local json_flags=\"");
+    try writeWords(w, &spec.json_flags);
+    try w.writeAll("\"\n  local project_json_flags=\"");
+    try writeWords(w, &spec.project_json_flags);
+    try w.writeAll("\"\n  local pane_flags=\"");
+    try writeWords(w, &spec.pane_flags);
+    try w.writeAll("\"\n  local pane_split_flags=\"");
+    try writeWords(w, &spec.pane_split_flags);
+    try w.writeAll("\"\n  local pane_resize_flags=\"");
+    try writeWords(w, &spec.pane_resize_flags);
+    try w.writeAll("\"\n  local chat_draft_flags=\"");
+    try writeWords(w, &spec.chat_draft_flags);
+    try w.writeAll("\"\n  local chat_send_flags=\"");
+    try writeWords(w, &spec.chat_send_flags);
+    try w.writeAll("\"\n  local chat_approve_flags=\"");
+    try writeWords(w, &spec.chat_approve_flags);
+    try w.writeAll("\"\n  local terminal_write_flags=\"");
+    try writeWords(w, &spec.terminal_write_flags);
+    try w.writeAll("\"\n  local terminal_tail_flags=\"");
+    try writeWords(w, &spec.terminal_tail_flags);
+    try w.writeAll("\"\n  local process_flags=\"");
+    try writeWords(w, &spec.process_flags);
+    try w.writeAll("\"\n  local kind_values=\"");
+    try writeWords(w, &spec.kind_values);
+    try w.writeAll("\"\n  local axis_values=\"");
+    try writeWords(w, &spec.axis_values);
+    try w.writeAll("\"\n  local decision_values=\"");
+    try writeWords(w, &spec.decision_values);
+    try w.writeAll(
+        \\"
+        \\
+        \\  case "$prev" in
+        \\    --kind) compadd -- ${(s: :)kind_values}; return ;;
+        \\    --axis) compadd -- ${(s: :)axis_values}; return ;;
+        \\    --decision) compadd -- ${(s: :)decision_values}; return ;;
+        \\    --project|--thread|--pane|--first|--second|--ratio|--text|--prompt|--call|--name|--lines) return ;;
+        \\  esac
+        \\
+        \\  if [[ "$cur" == -* ]]; then
+        \\    case "$root" in
+        \\      "")
+        \\        compadd -- --help -h
+        \\        ;;
+        \\      version|capabilities)
+        \\        compadd -- ${(s: :)json_flags}
+        \\        ;;
+        \\      state)
+        \\        case "$sub" in
+        \\          panes|threads) compadd -- ${(s: :)project_json_flags} ;;
+        \\          transcript) compadd -- --project --thread --json ;;
+        \\          *) compadd -- ${(s: :)json_flags} ;;
+        \\        esac
+        \\        ;;
+        \\      live)
+        \\        case "$sub" in
+        \\          panes|threads|terminals) compadd -- ${(s: :)project_json_flags} ;;
+        \\          inspect) compadd -- ${(s: :)pane_flags} ;;
+        \\          pane)
+        \\            case "$third" in
+        \\              split) compadd -- ${(s: :)pane_split_flags} ;;
+        \\              resize) compadd -- ${(s: :)pane_resize_flags} ;;
+        \\              *) compadd -- ${(s: :)pane_flags} ;;
+        \\            esac
+        \\            ;;
+        \\          chat)
+        \\            case "$third" in
+        \\              draft) compadd -- ${(s: :)chat_draft_flags} ;;
+        \\              send|followup) compadd -- ${(s: :)chat_send_flags} ;;
+        \\              approve) compadd -- ${(s: :)chat_approve_flags} ;;
+        \\              *) compadd -- ${(s: :)pane_flags} ;;
+        \\            esac
+        \\            ;;
+        \\          terminal)
+        \\            case "$third" in
+        \\              write) compadd -- ${(s: :)terminal_write_flags} ;;
+        \\              tail) compadd -- ${(s: :)terminal_tail_flags} ;;
+        \\              *) compadd -- ${(s: :)pane_flags} ;;
+        \\            esac
+        \\            ;;
+        \\          process) compadd -- ${(s: :)process_flags} ;;
+        \\          stack) compadd -- ${(s: :)project_json_flags} ;;
+        \\          *) compadd -- ${(s: :)json_flags} ;;
+        \\        esac
+        \\        ;;
+        \\      *) compadd -- ${(s: :)all_flags} ;;
+        \\    esac
+        \\    return
+        \\  fi
+        \\
+        \\  case "$CURRENT:$root:$sub:$third" in
+        \\    2:*) compadd -- ${(s: :)top} --help -h ;;
+        \\    3:completion:*) compadd -- ${(s: :)shells} ;;
+        \\    3:state:*) compadd -- ${(s: :)state} ;;
+        \\    3:live:*) compadd -- ${(s: :)live} ;;
+        \\    4:live:pane:*) compadd -- ${(s: :)pane} ;;
+        \\    4:live:chat:*) compadd -- ${(s: :)chat} ;;
+        \\    4:live:terminal:*) compadd -- ${(s: :)terminal} ;;
+        \\    4:live:process:*) compadd -- ${(s: :)process} ;;
+        \\    4:live:stack:*) compadd -- ${(s: :)stack} ;;
+        \\    5:live:chat:draft) compadd -- ${(s: :)draft} ;;
+        \\  esac
+        \\}
+        \\_verde "$@"
+        \\
+    );
+}
+
+fn writeFish(w: *std.Io.Writer) !void {
+    try w.writeAll(
+        \\# fish completion for verde
+        \\complete -c verde -f
+        \\
+        \\function __verde_complete_after
+        \\    set -l tokens (commandline -opc)
+        \\    set -l expected $argv
+        \\    test (count $tokens) -eq (math (count $expected) + 1); or return 1
+        \\    test "$tokens[1]" = verde; or return 1
+        \\    for i in (seq (count $expected))
+        \\        set -l token_index (math $i + 1)
+        \\        test "$tokens[$token_index]" = "$expected[$i]"; or return 1
+        \\    end
+        \\end
+        \\
+        \\function __verde_prev_is
+        \\    set -l tokens (commandline -opc)
+        \\    test (count $tokens) -gt 1; and test "$tokens[-1]" = "$argv[1]"
+        \\end
+        \\
+        \\complete -c verde -n '__verde_complete_after' -a '
+    );
+    try writeWords(w, &spec.top_level_commands);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after completion' -a '");
+    try writeWords(w, &spec.shells);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after state' -a '");
+    try writeWords(w, &spec.state_commands);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after live' -a '");
+    try writeWords(w, &spec.live_commands);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after live pane' -a '");
+    try writeWords(w, &spec.pane_commands);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after live chat' -a '");
+    try writeWords(w, &spec.chat_commands);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after live chat draft' -a '");
+    try writeWords(w, &spec.chat_draft_commands);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after live terminal' -a '");
+    try writeWords(w, &spec.terminal_commands);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after live process' -a '");
+    try writeWords(w, &spec.process_commands);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after live stack' -a '");
+    try writeWords(w, &spec.stack_commands);
+    try w.writeAll("'\n\ncomplete -c verde -l json -d 'Print JSON output'\n");
+    try w.writeAll(
+        \\complete -c verde -l project -r -d 'Project id, index, path, or current'
+        \\complete -c verde -l thread -r -d 'Thread index or provider id'
+        \\complete -c verde -l pane -r -d 'Workspace pane id'
+        \\complete -c verde -l focused -d 'Use the focused pane'
+        \\complete -c verde -l first -r -d 'First sibling pane id'
+        \\complete -c verde -l second -r -d 'Second sibling pane id'
+        \\complete -c verde -l ratio -r -d 'Split ratio'
+        \\complete -c verde -l text -r -d 'Text argument'
+        \\complete -c verde -l prompt -r -d 'Prompt text'
+        \\complete -c verde -l call -r -d 'Approval call id'
+        \\complete -c verde -l name -r -d 'Configured process name'
+        \\complete -c verde -l lines -r -d 'Number of output lines'
+        \\complete -c verde -s h -l help -d 'Show help'
+        \\
+        \\complete -c verde -n '__verde_prev_is --kind' -a '
+    );
+    try writeWords(w, &spec.kind_values);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_prev_is --axis' -a '");
+    try writeWords(w, &spec.axis_values);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_prev_is --decision' -a '");
+    try writeWords(w, &spec.decision_values);
+    try w.writeAll("'\n");
+}

--- a/packages/desktop/src/cli_output.zig
+++ b/packages/desktop/src/cli_output.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+pub const Output = struct {
+    io: std.Io,
+
+    pub fn stdout(self: Output, comptime fmt: []const u8, args: anytype) !void {
+        const stdout_file = std.Io.File.stdout();
+        var buffer: [16 * 1024]u8 = undefined;
+        var writer = stdout_file.writerStreaming(self.io, &buffer);
+        defer writer.interface.flush() catch {};
+        try writer.interface.print(fmt, args);
+    }
+
+    pub fn stderr(self: Output, comptime fmt: []const u8, args: anytype) !void {
+        const stderr_file = std.Io.File.stderr();
+        var buffer: [4 * 1024]u8 = undefined;
+        var writer = stderr_file.writerStreaming(self.io, &buffer);
+        defer writer.interface.flush() catch {};
+        try writer.interface.print(fmt, args);
+    }
+
+    pub fn jsonValue(self: Output, allocator: std.mem.Allocator, value: anytype) !void {
+        const encoded = try std.json.Stringify.valueAlloc(allocator, value, .{});
+        defer allocator.free(encoded);
+        try self.stdout("{s}\n", .{encoded});
+    }
+};

--- a/packages/desktop/src/cli_spec.zig
+++ b/packages/desktop/src/cli_spec.zig
@@ -1,0 +1,150 @@
+const std = @import("std");
+
+pub const shells = [_][]const u8{ "bash", "zsh", "fish" };
+pub const encodings = [_][]const u8{ "json", "jsonl" };
+
+pub const top_level_commands = [_][]const u8{
+    "app",
+    "help",
+    "version",
+    "capabilities",
+    "state",
+    "live",
+    "mcp",
+    "completion",
+};
+
+pub const state_commands = [_][]const u8{
+    "path",
+    "projects",
+    "panes",
+    "threads",
+    "transcript",
+};
+
+pub const live_commands = [_][]const u8{
+    "status",
+    "capabilities",
+    "projects",
+    "panes",
+    "active",
+    "threads",
+    "terminals",
+    "processes",
+    "inspect",
+    "pane",
+    "chat",
+    "terminal",
+    "process",
+    "stack",
+};
+
+pub const live_capabilities = [_][]const u8{
+    "status",
+    "capabilities",
+    "projects",
+    "panes",
+    "active",
+    "inspect",
+    "threads",
+    "terminals",
+    "processes",
+    "pane.focus",
+    "pane.split",
+    "pane.resize",
+    "pane.minimize",
+    "pane.maximize",
+    "pane.restore",
+    "pane.close",
+    "chat.status",
+    "chat.transcript",
+    "chat.draft.set",
+    "chat.draft.append",
+    "chat.send",
+    "chat.followup",
+    "chat.stop",
+    "chat.approve",
+    "terminal.write",
+    "terminal.tail",
+    "terminal.screen",
+    "process.list",
+    "process.inspect",
+    "process.start",
+    "process.stop",
+    "process.restart",
+    "process.logs",
+    "stack.status",
+    "stack.start",
+    "stack.stop",
+    "stack.restart",
+};
+
+pub const pane_commands = [_][]const u8{
+    "focus",
+    "split",
+    "resize",
+    "minimize",
+    "maximize",
+    "restore",
+    "close",
+};
+
+pub const chat_commands = [_][]const u8{
+    "status",
+    "transcript",
+    "draft",
+    "send",
+    "followup",
+    "stop",
+    "approve",
+};
+
+pub const chat_draft_commands = [_][]const u8{ "set", "append" };
+
+pub const terminal_commands = [_][]const u8{ "write", "tail", "screen" };
+pub const process_commands = [_][]const u8{ "list", "inspect", "start", "stop", "restart", "logs" };
+pub const stack_commands = [_][]const u8{ "status", "start", "stop", "restart" };
+
+pub const all_flags = [_][]const u8{
+    "--help",
+    "-h",
+    "--json",
+    "--project",
+    "--thread",
+    "--pane",
+    "--focused",
+    "--kind",
+    "--axis",
+    "--first",
+    "--second",
+    "--ratio",
+    "--text",
+    "--prompt",
+    "--call",
+    "--decision",
+    "--name",
+    "--lines",
+};
+
+pub const json_flags = [_][]const u8{ "--json" };
+pub const project_json_flags = [_][]const u8{ "--project", "--json" };
+pub const pane_flags = [_][]const u8{ "--project", "--pane", "--focused", "--json" };
+pub const pane_split_flags = [_][]const u8{ "--project", "--pane", "--focused", "--kind", "--axis", "--json" };
+pub const pane_resize_flags = [_][]const u8{ "--project", "--pane", "--focused", "--first", "--second", "--axis", "--ratio", "--json" };
+pub const chat_draft_flags = [_][]const u8{ "--project", "--pane", "--focused", "--text", "--json" };
+pub const chat_send_flags = [_][]const u8{ "--project", "--pane", "--focused", "--prompt", "--text", "--json" };
+pub const chat_approve_flags = [_][]const u8{ "--project", "--pane", "--focused", "--call", "--decision", "--json" };
+pub const terminal_write_flags = [_][]const u8{ "--project", "--pane", "--focused", "--text", "--json" };
+pub const terminal_tail_flags = [_][]const u8{ "--project", "--pane", "--focused", "--lines", "--json" };
+pub const process_flags = [_][]const u8{ "--project", "--pane", "--focused", "--name", "--lines", "--json" };
+
+pub const kind_values = [_][]const u8{ "chat", "terminal" };
+pub const axis_values = [_][]const u8{ "horizontal", "vertical" };
+pub const decision_values = [_][]const u8{ "approve", "deny" };
+
+pub fn shellSupported(name: []const u8) bool {
+    for (shells) |shell| {
+        if (std.mem.eql(u8, name, shell)) return true;
+    }
+    return false;
+}

--- a/packages/desktop/src/ipc/server.zig
+++ b/packages/desktop/src/ipc/server.zig
@@ -1,0 +1,1097 @@
+const std = @import("std");
+
+const app_state = @import("../state.zig");
+const provider_types = @import("../provider_types.zig");
+
+pub const PROTOCOL_VERSION: u32 = 1;
+pub const SOCKET_NAME = "verde.sock";
+
+const Mutex = struct {
+    inner: std.atomic.Mutex = .unlocked,
+
+    fn lock(self: *Mutex) void {
+        while (!self.inner.tryLock()) std.atomic.spinLoopHint();
+    }
+
+    fn unlock(self: *Mutex) void {
+        self.inner.unlock();
+    }
+};
+
+const Condition = struct {
+    fn wait(_: *Condition, mutex: *Mutex) void {
+        mutex.unlock();
+        std.atomic.spinLoopHint();
+        mutex.lock();
+    }
+
+    fn broadcast(_: *Condition) void {}
+};
+
+const Command = struct {
+    request_json: []u8,
+    response_json: ?[]u8 = null,
+    done: bool = false,
+};
+
+pub const LiveServer = struct {
+    allocator: std.mem.Allocator,
+    path: []u8,
+    thread: ?std.Thread = null,
+    mutex: Mutex = .{},
+    condition: Condition = .{},
+    pending: std.ArrayList(*Command) = .empty,
+    shutdown: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator, pref_path: []const u8) !LiveServer {
+        const path = try std.fs.path.join(allocator, &.{ pref_path, SOCKET_NAME });
+        errdefer allocator.free(path);
+        return .{
+            .allocator = allocator,
+            .path = path,
+        };
+    }
+
+    pub fn start(self: *LiveServer) !void {
+        self.thread = try std.Thread.spawn(.{}, serverThreadMain, .{self});
+    }
+
+    pub fn deinit(self: *LiveServer) void {
+        self.mutex.lock();
+        self.shutdown = true;
+        self.condition.broadcast();
+        self.mutex.unlock();
+
+        wakeServer(self.path);
+        if (self.thread) |thread| thread.join();
+
+        for (self.pending.items) |command| {
+            self.allocator.free(command.request_json);
+            if (command.response_json) |response| self.allocator.free(response);
+            self.allocator.destroy(command);
+        }
+        self.pending.deinit(self.allocator);
+        deleteSocketPath(self.path);
+        self.allocator.free(self.path);
+        self.* = undefined;
+    }
+
+    pub fn processPending(self: *LiveServer, state: *app_state.AppState) bool {
+        var local: std.ArrayList(*Command) = .empty;
+        defer local.deinit(self.allocator);
+
+        self.mutex.lock();
+        while (self.pending.items.len > 0) {
+            const command = self.pending.orderedRemove(0);
+            local.append(self.allocator, command) catch {
+                command.response_json = errorResponseAlloc(self.allocator, null, "internal_error", "failed to drain live command") catch null;
+                command.done = true;
+                self.condition.broadcast();
+            };
+        }
+        self.mutex.unlock();
+
+        var handled = false;
+        for (local.items) |command| {
+            command.response_json = handleRequest(self.allocator, state, command.request_json) catch |err|
+                errorResponseAlloc(self.allocator, null, "internal_error", @errorName(err)) catch null;
+            command.done = true;
+            handled = true;
+        }
+
+        if (handled) {
+            self.mutex.lock();
+            self.condition.broadcast();
+            self.mutex.unlock();
+        }
+        return handled;
+    }
+
+    fn enqueueAndWait(self: *LiveServer, request_json: []u8) ![]u8 {
+        const command = try self.allocator.create(Command);
+        command.* = .{ .request_json = request_json };
+        errdefer self.allocator.destroy(command);
+
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.shutdown) return error.ShuttingDown;
+        try self.pending.append(self.allocator, command);
+        self.condition.broadcast();
+        while (!command.done and !self.shutdown) self.condition.wait(&self.mutex);
+        if (self.shutdown and !command.done) return error.ShuttingDown;
+
+        const response = command.response_json orelse try errorResponseAlloc(self.allocator, null, "internal_error", "missing response");
+        self.allocator.free(command.request_json);
+        self.allocator.destroy(command);
+        return response;
+    }
+};
+
+fn serverThreadMain(server: *LiveServer) void {
+    var threaded = std.Io.Threaded.init_single_threaded;
+    deleteSocketPath(server.path);
+
+    const address = std.Io.net.UnixAddress.init(server.path) catch return;
+    var listener = address.listen(threaded.io(), .{}) catch return;
+    defer listener.deinit(threaded.io());
+    defer deleteSocketPath(server.path);
+
+    while (true) {
+        server.mutex.lock();
+        const should_stop = server.shutdown;
+        server.mutex.unlock();
+        if (should_stop) break;
+
+        const stream = listener.accept(threaded.io()) catch |err| switch (err) {
+            error.WouldBlock, error.ConnectionAborted => continue,
+            else => break,
+        };
+        handleClient(server, threaded.io(), stream);
+    }
+}
+
+fn handleClient(server: *LiveServer, io: std.Io, stream: std.Io.net.Stream) void {
+    defer stream.close(io);
+    var read_buffer: [64 * 1024]u8 = undefined;
+    var reader = stream.reader(io, &read_buffer);
+    const line = reader.interface.takeDelimiter('\n') catch return orelse return;
+    const request_json = server.allocator.dupe(u8, std.mem.trim(u8, line, "\r")) catch return;
+    const response_json = server.enqueueAndWait(request_json) catch |err|
+        errorResponseAlloc(server.allocator, null, "server_unavailable", @errorName(err)) catch return;
+    defer server.allocator.free(response_json);
+
+    var write_buffer: [64 * 1024]u8 = undefined;
+    var writer = stream.writer(io, &write_buffer);
+    writer.interface.writeAll(response_json) catch return;
+    writer.interface.writeByte('\n') catch return;
+    writer.interface.flush() catch return;
+}
+
+fn handleRequest(allocator: std.mem.Allocator, state: *app_state.AppState, request_json: []const u8) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, request_json, .{});
+    defer parsed.deinit();
+    const root = parsed.value;
+    if (root != .object) return try errorResponseAlloc(allocator, null, "invalid_request", "request must be a JSON object");
+    const id_value = root.object.get("id") orelse .null;
+    const method = jsonString(root.object.get("method") orelse .null) orelse
+        return try errorResponseAlloc(allocator, id_value, "invalid_request", "missing method");
+    const params = root.object.get("params") orelse .null;
+
+    if (std.mem.eql(u8, method, "status")) return try statusResponse(allocator, id_value, state);
+    if (std.mem.eql(u8, method, "capabilities")) return try capabilitiesResponse(allocator, id_value);
+    if (std.mem.eql(u8, method, "projects")) return try projectsResponse(allocator, id_value, state);
+    if (std.mem.eql(u8, method, "panes")) return try panesResponse(allocator, id_value, state, params);
+    if (std.mem.eql(u8, method, "active")) return try activeResponse(allocator, id_value, state);
+    if (std.mem.eql(u8, method, "threads")) return try threadsResponse(allocator, id_value, state, params);
+    if (std.mem.eql(u8, method, "terminals")) return try terminalsResponse(allocator, id_value, state, params);
+    if (std.mem.eql(u8, method, "processes")) return try managedProcessesResponse(allocator, id_value, state, params);
+    if (std.mem.eql(u8, method, "inspect")) return try inspectResponse(allocator, id_value, state, params);
+    if (std.mem.startsWith(u8, method, "pane.")) return try paneCommandResponse(allocator, id_value, state, params, method["pane.".len..]);
+    if (std.mem.startsWith(u8, method, "chat.")) return try chatCommandResponse(allocator, id_value, state, params, method["chat.".len..]);
+    if (std.mem.startsWith(u8, method, "terminal.")) return try terminalCommandResponse(allocator, id_value, state, params, method["terminal.".len..]);
+    if (std.mem.startsWith(u8, method, "process.")) return try processCommandResponse(allocator, id_value, state, params, method["process.".len..]);
+    if (std.mem.startsWith(u8, method, "stack.")) return try stackCommandResponse(allocator, id_value, state, params, method["stack.".len..]);
+
+    return try errorResponseAlloc(allocator, id_value, "method_not_found", method);
+}
+
+fn statusResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.beginObject();
+    try s.objectField("protocol_version");
+    try s.write(PROTOCOL_VERSION);
+    try s.objectField("pid");
+    try s.write(std.c.getpid());
+    try s.objectField("project_count");
+    try s.write(state.projects.items.len);
+    try s.objectField("selected_project_index");
+    try s.write(state.selected_project_index);
+    try s.objectField("focused_pane_id");
+    if (state.projects.items.len > 0) {
+        if (state.projects.items[state.selected_project_index].workspace_layout.focused_pane_id) |pane_id| try s.write(pane_id) else try s.write(null);
+    } else {
+        try s.write(null);
+    }
+    try s.objectField("pending_send_count");
+    try s.write(state.pending_send_count);
+    try s.objectField("panes");
+    try writeSelectedProjectPanes(&s, state);
+    try s.objectField("terminals");
+    try writeTerminalsArray(&s, state, null);
+    try s.objectField("processes");
+    try writeManagedProcessesArray(&s, state, null);
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn capabilitiesResponse(allocator: std.mem.Allocator, id_value: std.json.Value) ![]u8 {
+    return try okValueResponse(allocator, id_value, .{
+        .protocol_version = PROTOCOL_VERSION,
+        .commands = &.{
+            "status",         "capabilities",    "projects",       "panes",
+            "active",         "inspect",         "threads",        "terminals",
+            "processes",      "pane.focus",      "pane.split",     "pane.resize",
+            "pane.minimize",  "pane.maximize",   "pane.restore",   "pane.close",
+            "chat.status",    "chat.transcript", "chat.draft.set", "chat.draft.append",
+            "chat.send",      "chat.followup",   "chat.stop",      "chat.approve",
+            "terminal.write", "terminal.tail",   "terminal.screen", "process.list",
+            "process.inspect", "process.start",  "process.stop",    "process.restart",
+            "process.logs",   "stack.status",    "stack.start",     "stack.stop",
+            "stack.restart",
+        },
+        .events = &.{},
+        .encodings = &.{"json"},
+        .terminal_binary_frames = false,
+        .mcp_bridge = true,
+        .auth = "local-user-socket",
+    });
+}
+
+fn projectsResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.beginObject();
+    try s.objectField("selected_project_index");
+    try s.write(state.selected_project_index);
+    try s.objectField("projects");
+    try s.beginArray();
+    for (state.projects.items, 0..) |project, index| {
+        try s.beginObject();
+        try s.objectField("index");
+        try s.write(index);
+        try s.objectField("id");
+        try s.write(project.id);
+        try s.objectField("label");
+        try s.write(project.label);
+        try s.objectField("path");
+        try s.write(project.path);
+        try s.objectField("archived");
+        try s.write(project.archived);
+        try s.objectField("thread_count");
+        try s.write(project.threads.items.len);
+        try s.objectField("pane_count");
+        try s.write(project.workspace_layout.panes.items.len);
+        try s.endObject();
+    }
+    try s.endArray();
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn panesResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value) ![]u8 {
+    const project_index = resolveProjectIndex(state, params) orelse
+        return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
+    return try panesResponseForProject(allocator, id_value, state, project_index);
+}
+
+fn panesResponseForProject(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, project_index: usize) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try writeProjectPanes(&s, state, project_index);
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn activeResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState) ![]u8 {
+    if (state.projects.items.len == 0) return try errorResponseAlloc(allocator, id_value, "not_found", "no projects");
+    const project = &state.projects.items[state.selected_project_index];
+    return try okValueResponse(allocator, id_value, .{
+        .project_index = state.selected_project_index,
+        .project_id = project.id,
+        .focused_pane_id = project.workspace_layout.focused_pane_id,
+        .maximized_pane_id = project.workspace_layout.maximized_pane_id,
+    });
+}
+
+fn threadsResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value) ![]u8 {
+    const project_index = resolveProjectIndex(state, params) orelse
+        return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
+    const project = &state.projects.items[project_index];
+
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.beginObject();
+    try s.objectField("project_index");
+    try s.write(project_index);
+    try s.objectField("selected_thread_index");
+    try s.write(project.selected_thread_index);
+    try s.objectField("threads");
+    try s.beginArray();
+    for (project.threads.items, 0..) |thread, index| {
+        try writeThreadSummary(&s, thread, index);
+    }
+    try s.endArray();
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn terminalsResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value) ![]u8 {
+    const project_index = resolveProjectIndexNullable(state, params);
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.beginObject();
+    try s.objectField("terminals");
+    try writeTerminalsArray(&s, state, project_index);
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn inspectResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value) ![]u8 {
+    const target = resolvePaneTarget(state, params) orelse
+        return try errorResponseAlloc(allocator, id_value, "not_found", "pane not found");
+    return try inspectPaneResponse(allocator, id_value, state, target.project_index, target.pane_id);
+}
+
+fn paneCommandResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value, command: []const u8) ![]u8 {
+    const target = resolvePaneTarget(state, params) orelse
+        return try errorResponseAlloc(allocator, id_value, "not_found", "pane not found");
+    state.selected_project_index = target.project_index;
+
+    var changed = false;
+    if (std.mem.eql(u8, command, "focus")) {
+        changed = state.focusCurrentProjectWorkspacePane(target.pane_id);
+    } else if (std.mem.eql(u8, command, "split")) {
+        const kind = stringParam(params, "kind") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "pane.split requires kind");
+        const axis = parseAxis(stringParam(params, "axis") orelse "horizontal") orelse
+            return try errorResponseAlloc(allocator, id_value, "invalid_request", "invalid split axis");
+        changed = if (std.mem.eql(u8, kind, "chat"))
+            state.splitCurrentProjectWorkspacePaneWithChatAxis(target.pane_id, axis)
+        else if (std.mem.eql(u8, kind, "terminal"))
+            state.splitCurrentProjectWorkspacePaneWithTerminalAxis(target.pane_id, axis)
+        else
+            return try errorResponseAlloc(allocator, id_value, "invalid_request", "invalid split kind");
+    } else if (std.mem.eql(u8, command, "resize")) {
+        const first: app_state.WorkspacePaneId = @intCast(intParam(params, "first") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "pane.resize requires first"));
+        const second: app_state.WorkspacePaneId = @intCast(intParam(params, "second") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "pane.resize requires second"));
+        const axis = parseAxis(stringParam(params, "axis") orelse "horizontal") orelse
+            return try errorResponseAlloc(allocator, id_value, "invalid_request", "invalid resize axis");
+        const ratio = floatParam(params, "ratio") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "pane.resize requires ratio");
+        state.resizeCurrentProjectWorkspaceSplit(first, second, axis, ratio);
+        changed = true;
+    } else if (std.mem.eql(u8, command, "minimize")) {
+        changed = state.minimizeCurrentProjectWorkspacePane(target.pane_id);
+    } else if (std.mem.eql(u8, command, "maximize")) {
+        const project = &state.projects.items[target.project_index];
+        changed = project.workspace_layout.maximized_pane_id == target.pane_id or state.toggleCurrentProjectWorkspacePaneMaximized(target.pane_id);
+    } else if (std.mem.eql(u8, command, "restore")) {
+        changed = state.restoreCurrentProjectWorkspacePane(target.pane_id);
+    } else if (std.mem.eql(u8, command, "close")) {
+        changed = state.closeCurrentProjectWorkspacePane(target.pane_id);
+    } else {
+        return try errorResponseAlloc(allocator, id_value, "method_not_found", command);
+    }
+
+    if (!changed) return try errorResponseAlloc(allocator, id_value, "rejected", "pane operation did not apply");
+    return try panesResponseForProject(allocator, id_value, state, target.project_index);
+}
+
+fn chatCommandResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value, command: []const u8) ![]u8 {
+    const target = resolvePaneTarget(state, params) orelse
+        return try errorResponseAlloc(allocator, id_value, "not_found", "chat pane not found");
+    state.selected_project_index = target.project_index;
+    if (!targetIsChat(state, target)) return try errorResponseAlloc(allocator, id_value, "invalid_target", "target pane is not a chat pane");
+
+    if (std.mem.eql(u8, command, "status")) return try chatStatusResponse(allocator, id_value, state, target.project_index, target.pane_id);
+    if (std.mem.eql(u8, command, "transcript")) return try chatTranscriptResponse(allocator, id_value, state, target.project_index, target.pane_id);
+
+    var accepted = false;
+    if (std.mem.eql(u8, command, "draft.set")) {
+        const text = stringParam(params, "text") orelse "";
+        accepted = try state.setWorkspaceChatPaneDraft(target.pane_id, text, false);
+    } else if (std.mem.eql(u8, command, "draft.append")) {
+        const text = stringParam(params, "text") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "chat.draft.append requires text");
+        accepted = try state.setWorkspaceChatPaneDraft(target.pane_id, text, true);
+    } else if (std.mem.eql(u8, command, "send")) {
+        accepted = try state.sendWorkspaceChatPanePrompt(target.pane_id, stringParam(params, "prompt"));
+    } else if (std.mem.eql(u8, command, "followup")) {
+        const prompt = stringParam(params, "prompt") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "chat.followup requires prompt");
+        accepted = try state.followupWorkspaceChatPanePrompt(target.pane_id, prompt);
+    } else if (std.mem.eql(u8, command, "stop")) {
+        accepted = state.stopWorkspaceChatPane(target.pane_id);
+    } else if (std.mem.eql(u8, command, "approve")) {
+        const decision = parseApprovalDecision(stringParam(params, "decision") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "chat.approve requires decision")) orelse
+            return try errorResponseAlloc(allocator, id_value, "invalid_request", "invalid approval decision");
+        accepted = state.approveWorkspaceChatPane(target.pane_id, decision);
+    } else {
+        return try errorResponseAlloc(allocator, id_value, "method_not_found", command);
+    }
+
+    if (!accepted) return try errorResponseAlloc(allocator, id_value, "rejected", "chat operation did not apply");
+    return try chatStatusResponse(allocator, id_value, state, target.project_index, target.pane_id);
+}
+
+fn terminalCommandResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value, command: []const u8) ![]u8 {
+    const target = resolvePaneTarget(state, params) orelse
+        return try errorResponseAlloc(allocator, id_value, "not_found", "terminal pane not found");
+    state.selected_project_index = target.project_index;
+    if (!targetIsTerminal(state, target)) return try errorResponseAlloc(allocator, id_value, "invalid_target", "target pane is not a terminal pane");
+
+    if (std.mem.eql(u8, command, "write")) {
+        const text = stringParam(params, "text") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "terminal.write requires text");
+        if (!try state.writeWorkspaceTerminalPane(target.pane_id, text)) return try errorResponseAlloc(allocator, id_value, "rejected", "terminal write did not apply");
+        return try inspectPaneResponse(allocator, id_value, state, target.project_index, target.pane_id);
+    }
+    if (std.mem.eql(u8, command, "tail")) {
+        const max_bytes = @as(usize, @intCast((intParam(params, "lines") orelse 200) * 240));
+        const output = (try state.terminalPaneOutputTail(target.pane_id, max_bytes)) orelse
+            return try errorResponseAlloc(allocator, id_value, "not_found", "terminal output not found");
+        defer state.allocator.free(output);
+        return try okValueResponse(allocator, id_value, .{
+            .project_index = target.project_index,
+            .pane_id = target.pane_id,
+            .truncated = output.len >= max_bytes,
+            .text = output,
+        });
+    }
+    if (std.mem.eql(u8, command, "screen")) {
+        const screen = (try state.terminalPaneScreenText(target.pane_id)) orelse
+            return try errorResponseAlloc(allocator, id_value, "not_found", "terminal screen not found");
+        defer state.allocator.free(screen);
+        return try okValueResponse(allocator, id_value, .{
+            .project_index = target.project_index,
+            .pane_id = target.pane_id,
+            .text = screen,
+        });
+    }
+    return try errorResponseAlloc(allocator, id_value, "method_not_found", command);
+}
+
+fn processCommandResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value, command: []const u8) ![]u8 {
+    if (std.mem.eql(u8, command, "inspect") and stringParam(params, "name") == null) {
+        const target = resolvePaneTarget(state, params) orelse
+            return try errorResponseAlloc(allocator, id_value, "not_found", "pane not found");
+        return try inspectPaneResponse(allocator, id_value, state, target.project_index, target.pane_id);
+    }
+    const project_index = resolveProjectIndex(state, params) orelse return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
+    if (std.mem.eql(u8, command, "list")) {
+        try state.refreshProjectStackConfig(project_index);
+        return try managedProcessesResponseForProject(allocator, id_value, state, project_index);
+    }
+    if (std.mem.eql(u8, command, "inspect")) {
+        const name = stringParam(params, "name") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "process.inspect requires --name or --pane");
+        _ = (try state.managedProcessByNameConst(project_index, name)) orelse
+            return try errorResponseAlloc(allocator, id_value, "not_found", "process not found");
+        return try managedProcessResponse(allocator, id_value, state, project_index, name);
+    }
+    if (std.mem.eql(u8, command, "start") or std.mem.eql(u8, command, "stop") or std.mem.eql(u8, command, "restart")) {
+        const name = stringParam(params, "name") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "process command requires --name");
+        const changed = if (std.mem.eql(u8, command, "start"))
+            try state.startManagedProcess(project_index, name)
+        else if (std.mem.eql(u8, command, "stop"))
+            try state.stopManagedProcess(project_index, name)
+        else
+            try state.restartManagedProcess(project_index, name);
+        if (!changed) return try errorResponseAlloc(allocator, id_value, "not_found", "process not found");
+        return try managedProcessResponse(allocator, id_value, state, project_index, name);
+    }
+    if (std.mem.eql(u8, command, "logs")) {
+        const name = stringParam(params, "name") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "process.logs requires --name");
+        const max_bytes = @as(usize, @intCast((intParam(params, "lines") orelse 200) * 240));
+        const output = (try state.managedProcessLogs(project_index, name, max_bytes)) orelse
+            return try errorResponseAlloc(allocator, id_value, "not_found", "process logs not found");
+        defer state.allocator.free(output);
+        return try okValueResponse(allocator, id_value, .{
+            .project_index = project_index,
+            .name = name,
+            .truncated = output.len >= max_bytes,
+            .text = output,
+        });
+    }
+    return try errorResponseAlloc(allocator, id_value, "method_not_found", command);
+}
+
+fn stackCommandResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value, command: []const u8) ![]u8 {
+    const project_index = resolveProjectIndex(state, params) orelse return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
+    if (std.mem.eql(u8, command, "status")) {
+        try state.refreshProjectStackConfig(project_index);
+        return try managedProcessesResponseForProject(allocator, id_value, state, project_index);
+    }
+    if (std.mem.eql(u8, command, "start") or std.mem.eql(u8, command, "stop") or std.mem.eql(u8, command, "restart")) {
+        const count = if (std.mem.eql(u8, command, "start"))
+            try state.startProjectStack(project_index)
+        else if (std.mem.eql(u8, command, "stop"))
+            try state.stopProjectStack(project_index)
+        else
+            try state.restartProjectStack(project_index);
+        _ = count;
+        return try managedProcessesResponseForProject(allocator, id_value, state, project_index);
+    }
+    return try errorResponseAlloc(allocator, id_value, "method_not_found", command);
+}
+
+const PaneTarget = struct {
+    project_index: usize,
+    pane_id: app_state.WorkspacePaneId,
+};
+
+fn resolvePaneTarget(state: *app_state.AppState, params: std.json.Value) ?PaneTarget {
+    const project_index = resolveProjectIndex(state, params) orelse return null;
+    const project = &state.projects.items[project_index];
+    if (boolParam(params, "focused") orelse false) {
+        const pane_id = project.workspace_layout.focused_pane_id orelse return null;
+        return .{ .project_index = project_index, .pane_id = pane_id };
+    }
+    const pane_id_raw = intParam(params, "pane") orelse intParam(params, "pane_id") orelse return null;
+    const pane_id: app_state.WorkspacePaneId = @intCast(pane_id_raw);
+    if (project.workspace_layout.paneById(pane_id) == null) return null;
+    return .{ .project_index = project_index, .pane_id = pane_id };
+}
+
+fn resolveProjectIndex(state: *app_state.AppState, params: std.json.Value) ?usize {
+    if (state.projects.items.len == 0) return null;
+    if (params == .object) {
+        if (jsonString(params.object.get("project") orelse .null)) |project_ref| {
+            if (std.mem.eql(u8, project_ref, "current")) return state.selected_project_index;
+            if (std.fmt.parseInt(usize, project_ref, 10)) |index| {
+                if (index < state.projects.items.len) return index;
+            } else |_| {}
+            for (state.projects.items, 0..) |project, index| {
+                if (std.mem.eql(u8, project.id, project_ref) or std.mem.eql(u8, project.path, project_ref)) return index;
+            }
+            return null;
+        }
+    }
+    return state.selected_project_index;
+}
+
+fn resolveProjectIndexNullable(state: *app_state.AppState, params: std.json.Value) ?usize {
+    if (params == .object and (params.object.get("project") != null)) return resolveProjectIndex(state, params);
+    return null;
+}
+
+fn targetIsChat(state: *app_state.AppState, target: PaneTarget) bool {
+    const pane = state.projects.items[target.project_index].workspace_layout.paneById(target.pane_id) orelse return false;
+    return pane.ref == .chat;
+}
+
+fn targetIsTerminal(state: *app_state.AppState, target: PaneTarget) bool {
+    const pane = state.projects.items[target.project_index].workspace_layout.paneById(target.pane_id) orelse return false;
+    return pane.ref == .terminal;
+}
+
+fn writeSelectedProjectPanes(s: *std.json.Stringify, state: *app_state.AppState) !void {
+    if (state.projects.items.len == 0) {
+        try s.write(null);
+        return;
+    }
+    try writeProjectPanes(s, state, state.selected_project_index);
+}
+
+fn writeProjectPanes(s: *std.json.Stringify, state: *app_state.AppState, project_index: usize) !void {
+    const project = &state.projects.items[project_index];
+    try s.beginObject();
+    try s.objectField("project_index");
+    try s.write(project_index);
+    try s.objectField("project_id");
+    try s.write(project.id);
+    try s.objectField("focused_pane_id");
+    if (project.workspace_layout.focused_pane_id) |pane_id| try s.write(pane_id) else try s.write(null);
+    try s.objectField("maximized_pane_id");
+    if (project.workspace_layout.maximized_pane_id) |pane_id| try s.write(pane_id) else try s.write(null);
+    try s.objectField("panes");
+    try s.beginArray();
+    for (project.workspace_layout.panes.items) |pane| {
+        try writePane(s, state, project_index, pane);
+    }
+    try s.endArray();
+    try s.endObject();
+}
+
+fn writePane(s: *std.json.Stringify, state: *app_state.AppState, project_index: usize, pane: app_state.WorkspacePane) !void {
+    const project = &state.projects.items[project_index];
+    try s.beginObject();
+    try s.objectField("pane_id");
+    try s.write(pane.id);
+    try s.objectField("minimized");
+    try s.write(pane.minimized);
+    try s.objectField("focused");
+    try s.write(project.workspace_layout.focused_pane_id != null and project.workspace_layout.focused_pane_id.? == pane.id);
+    try s.objectField("maximized");
+    try s.write(project.workspace_layout.maximized_pane_id != null and project.workspace_layout.maximized_pane_id.? == pane.id);
+    switch (pane.ref) {
+        .chat => |ref| {
+            try s.objectField("kind");
+            try s.write("chat");
+            try s.objectField("thread_index");
+            try s.write(ref.thread_index);
+            if (ref.thread_index < project.threads.items.len) {
+                const thread = &project.threads.items[ref.thread_index];
+                try s.objectField("thread_title");
+                try s.write(thread.title);
+                try s.objectField("provider");
+                try s.write(@tagName(thread.provider));
+                try s.objectField("model");
+                if (thread.model_ref) |model| try s.write(model) else try s.write(null);
+                try s.objectField("send_pending");
+                try s.write(thread.isSendPendingForUi());
+            }
+        },
+        .terminal => |ref| {
+            try s.objectField("kind");
+            try s.write("terminal");
+            try s.objectField("dock_id");
+            try s.write(ref.dock_id);
+            if (state.projectTerminalDock(project_index, ref.dock_id)) |dock| {
+                try s.objectField("running");
+                try s.write(dock.hasRunningSession());
+                try s.objectField("active_tab_index");
+                try s.write(dock.active_tab_index);
+                try s.objectField("tab_count");
+                try s.write(dock.tabs.items.len);
+                try s.objectField("cwd");
+                if (dock.cwd) |cwd| try s.write(cwd) else try s.write(null);
+            }
+        },
+    }
+    try s.endObject();
+}
+
+fn writeThreadSummary(s: *std.json.Stringify, thread: app_state.ChatThread, index: usize) !void {
+    try s.beginObject();
+    try s.objectField("index");
+    try s.write(index);
+    try s.objectField("title");
+    try s.write(thread.title);
+    try s.objectField("provider");
+    try s.write(@tagName(thread.provider));
+    try s.objectField("model");
+    if (thread.model_ref) |model| try s.write(model) else try s.write(null);
+    try s.objectField("provider_thread_id");
+    if (thread.provider_thread_id) |thread_id| try s.write(thread_id) else try s.write(null);
+    try s.objectField("message_count");
+    try s.write(thread.messages.items.len);
+    try s.objectField("send_pending");
+    try s.write(thread.isSendPendingForUi());
+    try s.endObject();
+}
+
+fn writeTerminalsArray(s: *std.json.Stringify, state: *app_state.AppState, maybe_project_index: ?usize) !void {
+    try s.beginArray();
+    for (state.projects.items, 0..) |project, project_index| {
+        if (maybe_project_index) |wanted| {
+            if (wanted != project_index) continue;
+        }
+        for (project.workspace_layout.panes.items) |pane| {
+            if (pane.ref != .terminal) continue;
+            const ref = pane.ref.terminal;
+            try s.beginObject();
+            try s.objectField("project_index");
+            try s.write(project_index);
+            try s.objectField("project_id");
+            try s.write(project.id);
+            try s.objectField("pane_id");
+            try s.write(pane.id);
+            try s.objectField("dock_id");
+            try s.write(ref.dock_id);
+            try s.objectField("minimized");
+            try s.write(pane.minimized);
+            if (state.projectTerminalDock(project_index, ref.dock_id)) |dock| {
+                try s.objectField("running");
+                try s.write(dock.hasRunningSession());
+                try s.objectField("active_tab_index");
+                try s.write(dock.active_tab_index);
+                try s.objectField("tab_count");
+                try s.write(dock.tabs.items.len);
+                try s.objectField("cwd");
+                if (dock.cwd) |cwd| try s.write(cwd) else try s.write(null);
+            }
+            for (project.managed_processes.items) |process| {
+                if (process.dock_id == null or process.dock_id.? != ref.dock_id) continue;
+                try s.objectField("process");
+                try s.beginObject();
+                try s.objectField("name");
+                try s.write(process.name);
+                try s.objectField("status");
+                try s.write(@tagName(process.status));
+                try s.endObject();
+                break;
+            }
+            try s.endObject();
+        }
+    }
+    try s.endArray();
+}
+
+fn managedProcessesResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value) ![]u8 {
+    const project_index = resolveProjectIndexNullable(state, params);
+    if (project_index) |index| {
+        if (index >= state.projects.items.len) return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
+        try state.refreshProjectStackConfig(index);
+    } else {
+        var index: usize = 0;
+        while (index < state.projects.items.len) : (index += 1) {
+            try state.refreshProjectStackConfig(index);
+        }
+    }
+
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.beginObject();
+    try s.objectField("processes");
+    try writeManagedProcessesArray(&s, state, project_index);
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn managedProcessesResponseForProject(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, project_index: usize) ![]u8 {
+    if (project_index >= state.projects.items.len) return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
+    state.refreshManagedProcessStatuses(project_index);
+
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.beginObject();
+    try s.objectField("project_index");
+    try s.write(project_index);
+    try s.objectField("project_id");
+    try s.write(state.projects.items[project_index].id);
+    try s.objectField("processes");
+    try writeManagedProcessesArray(&s, state, project_index);
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn managedProcessResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, project_index: usize, name: []const u8) ![]u8 {
+    if (project_index >= state.projects.items.len) return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
+    state.refreshManagedProcessStatuses(project_index);
+    const project = &state.projects.items[project_index];
+    const process = project.managedProcessByName(name) orelse
+        return try errorResponseAlloc(allocator, id_value, "not_found", "process not found");
+
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try writeManagedProcess(&s, state, project_index, process);
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn writeManagedProcessesArray(s: *std.json.Stringify, state: *app_state.AppState, maybe_project_index: ?usize) !void {
+    try s.beginArray();
+    for (state.projects.items, 0..) |*project, project_index| {
+        if (maybe_project_index) |wanted| {
+            if (wanted != project_index) continue;
+        }
+        state.refreshProjectStackConfig(project_index) catch {};
+        state.refreshManagedProcessStatuses(project_index);
+        for (project.managed_processes.items) |*process| {
+            try writeManagedProcess(s, state, project_index, process);
+        }
+    }
+    try s.endArray();
+}
+
+fn writeManagedProcess(s: *std.json.Stringify, state: *app_state.AppState, project_index: usize, process: *const app_state.ManagedProcess) !void {
+    const project = &state.projects.items[project_index];
+    try s.beginObject();
+    try s.objectField("project_index");
+    try s.write(project_index);
+    try s.objectField("project_id");
+    try s.write(project.id);
+    try s.objectField("name");
+    try s.write(process.name);
+    try s.objectField("kind");
+    try s.write(@tagName(process.kind));
+    try s.objectField("command");
+    try s.write(process.command);
+    try s.objectField("cwd");
+    try s.write(process.cwd);
+    try s.objectField("restart");
+    try s.write(@tagName(process.restart));
+    try s.objectField("status");
+    try s.write(@tagName(process.status));
+    try s.objectField("exit_code");
+    if (process.exit_code) |exit_code| try s.write(exit_code) else try s.write(null);
+    try s.objectField("signal");
+    if (process.signal) |signal| try s.write(signal) else try s.write(null);
+    try s.objectField("last_start_ms");
+    try s.write(process.last_start_ms);
+    try s.objectField("last_exit_ms");
+    try s.write(process.last_exit_ms);
+    try s.objectField("next_restart_ms");
+    try s.write(process.next_restart_ms);
+    try s.objectField("restart_count");
+    try s.write(process.restart_count);
+    try s.objectField("watch_trigger_count");
+    try s.write(process.watch_trigger_count);
+    try s.objectField("last_watch_scan_ms");
+    try s.write(process.last_watch_scan_ms);
+    try s.objectField("explicit_stop");
+    try s.write(process.explicit_stop);
+    try s.objectField("watch");
+    try s.beginArray();
+    for (process.watch.items) |pattern| try s.write(pattern);
+    try s.endArray();
+    try s.objectField("dock_id");
+    if (process.dock_id) |dock_id| try s.write(dock_id) else try s.write(null);
+    try s.objectField("pane_id");
+    if (process.pane_id) |pane_id| try s.write(pane_id) else try s.write(null);
+    try s.objectField("attention");
+    try s.write(process.status == .crashed);
+    if (process.dock_id) |dock_id| {
+        if (state.projectTerminalDock(project_index, dock_id)) |dock| {
+            try s.objectField("running");
+            try s.write(dock.hasRunningSession());
+            try s.objectField("active_tab_index");
+            try s.write(dock.active_tab_index);
+            try s.objectField("tab_count");
+            try s.write(dock.tabs.items.len);
+            try s.objectField("terminal_cwd");
+            if (dock.cwd) |cwd| try s.write(cwd) else try s.write(null);
+        }
+    }
+    try s.endObject();
+}
+
+fn chatStatusResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, project_index: usize, pane_id: app_state.WorkspacePaneId) ![]u8 {
+    const project = &state.projects.items[project_index];
+    const pane = project.workspace_layout.paneById(pane_id) orelse return try errorResponseAlloc(allocator, id_value, "not_found", "pane not found");
+    const ref = switch (pane.ref) {
+        .chat => |chat_ref| chat_ref,
+        else => return try errorResponseAlloc(allocator, id_value, "invalid_target", "target pane is not a chat pane"),
+    };
+    if (ref.thread_index >= project.threads.items.len) return try errorResponseAlloc(allocator, id_value, "not_found", "thread not found");
+    const thread = &project.threads.items[ref.thread_index];
+
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.beginObject();
+    try s.objectField("project_index");
+    try s.write(project_index);
+    try s.objectField("pane_id");
+    try s.write(pane_id);
+    try s.objectField("thread");
+    try writeThreadSummary(&s, thread.*, ref.thread_index);
+    try s.objectField("draft_len");
+    try s.write(std.mem.sliceTo(thread.draft_storage[0..], 0).len);
+    try s.objectField("pending_approval");
+    try writePendingApproval(&s, thread);
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn chatTranscriptResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, project_index: usize, pane_id: app_state.WorkspacePaneId) ![]u8 {
+    const project = &state.projects.items[project_index];
+    const pane = project.workspace_layout.paneById(pane_id) orelse return try errorResponseAlloc(allocator, id_value, "not_found", "pane not found");
+    const ref = switch (pane.ref) {
+        .chat => |chat_ref| chat_ref,
+        else => return try errorResponseAlloc(allocator, id_value, "invalid_target", "target pane is not a chat pane"),
+    };
+    if (ref.thread_index >= project.threads.items.len) return try errorResponseAlloc(allocator, id_value, "not_found", "thread not found");
+    const thread = &project.threads.items[ref.thread_index];
+
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.beginObject();
+    try s.objectField("project_index");
+    try s.write(project_index);
+    try s.objectField("pane_id");
+    try s.write(pane_id);
+    try s.objectField("thread_index");
+    try s.write(ref.thread_index);
+    try s.objectField("messages");
+    try s.beginArray();
+    for (thread.messages.items) |message| {
+        try s.beginObject();
+        try s.objectField("role");
+        try s.write(@tagName(message.role));
+        try s.objectField("author");
+        try s.write(message.author);
+        try s.objectField("body");
+        try s.write(message.body);
+        try s.endObject();
+    }
+    try s.endArray();
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn inspectPaneResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, project_index: usize, pane_id: app_state.WorkspacePaneId) ![]u8 {
+    const project = &state.projects.items[project_index];
+    const pane = project.workspace_layout.paneById(pane_id) orelse return try errorResponseAlloc(allocator, id_value, "not_found", "pane not found");
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try writePane(&s, state, project_index, pane.*);
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn writePendingApproval(s: *std.json.Stringify, thread: *const app_state.ChatThread) !void {
+    const send_state = thread.send_state;
+    send_state.mutex.lock();
+    defer send_state.mutex.unlock();
+    if (send_state.status != .pending or send_state.pending_approval == null) {
+        try s.write(null);
+        return;
+    }
+    const approval = send_state.pending_approval.?;
+    try s.beginObject();
+    try s.objectField("call_id");
+    try s.write(approval.call_id);
+    try s.objectField("title");
+    try s.write(approval.title);
+    try s.objectField("body");
+    try s.write(approval.body);
+    try s.endObject();
+}
+
+fn beginOk(s: *std.json.Stringify, id_value: std.json.Value) !void {
+    try s.beginObject();
+    try s.objectField("id");
+    try writeJsonValue(s, id_value);
+    try s.objectField("ok");
+    try s.write(true);
+}
+
+fn okValueResponse(allocator: std.mem.Allocator, id_value: std.json.Value, value: anytype) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.write(value);
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn errorResponseAlloc(allocator: std.mem.Allocator, id_value: ?std.json.Value, code: []const u8, message: []const u8) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try s.beginObject();
+    try s.objectField("id");
+    if (id_value) |value| try writeJsonValue(&s, value) else try s.write(null);
+    try s.objectField("ok");
+    try s.write(false);
+    try s.objectField("error");
+    try s.beginObject();
+    try s.objectField("code");
+    try s.write(code);
+    try s.objectField("message");
+    try s.write(message);
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn writeJsonValue(s: *std.json.Stringify, value: std.json.Value) !void {
+    switch (value) {
+        .integer => |v| try s.write(v),
+        .float => |v| try s.write(v),
+        .number_string => |v| try s.write(v),
+        .string => |v| try s.write(v),
+        .bool => |v| try s.write(v),
+        .null => try s.write(null),
+        else => try s.write(null),
+    }
+}
+
+fn stringParam(params: std.json.Value, name: []const u8) ?[]const u8 {
+    if (params != .object) return null;
+    return jsonString(params.object.get(name) orelse .null);
+}
+
+fn intParam(params: std.json.Value, name: []const u8) ?i64 {
+    if (params != .object) return null;
+    return jsonInt(params.object.get(name) orelse .null);
+}
+
+fn floatParam(params: std.json.Value, name: []const u8) ?f32 {
+    if (params != .object) return null;
+    const value = params.object.get(name) orelse .null;
+    return switch (value) {
+        .integer => |i| @floatFromInt(i),
+        .float => |f| @floatCast(f),
+        .number_string => |text| blk: {
+            if (std.fmt.parseFloat(f32, text)) |parsed| break :blk parsed else |_| break :blk null;
+        },
+        else => null,
+    };
+}
+
+fn boolParam(params: std.json.Value, name: []const u8) ?bool {
+    if (params != .object) return null;
+    return switch (params.object.get(name) orelse .null) {
+        .bool => |value| value,
+        else => null,
+    };
+}
+
+fn jsonString(value: std.json.Value) ?[]const u8 {
+    return switch (value) {
+        .string => |text| text,
+        else => null,
+    };
+}
+
+fn jsonInt(value: std.json.Value) ?i64 {
+    return switch (value) {
+        .integer => |int| int,
+        .number_string => |text| std.fmt.parseInt(i64, text, 10) catch null,
+        else => null,
+    };
+}
+
+fn parseAxis(value: []const u8) ?app_state.WorkspaceSplitAxis {
+    if (std.mem.eql(u8, value, "horizontal")) return .horizontal;
+    if (std.mem.eql(u8, value, "vertical")) return .vertical;
+    return null;
+}
+
+fn parseApprovalDecision(value: []const u8) ?provider_types.ApprovalDecision {
+    if (std.mem.eql(u8, value, "approve") or std.mem.eql(u8, value, "approved") or std.mem.eql(u8, value, "allow")) return .approve;
+    if (std.mem.eql(u8, value, "deny") or std.mem.eql(u8, value, "reject") or std.mem.eql(u8, value, "rejected")) return .deny;
+    return null;
+}
+
+fn deleteSocketPath(path: []const u8) void {
+    var threaded = std.Io.Threaded.init_single_threaded;
+    std.Io.Dir.deleteFileAbsolute(threaded.io(), path) catch {};
+}
+
+fn wakeServer(path: []const u8) void {
+    var threaded = std.Io.Threaded.init_single_threaded;
+    const address = std.Io.net.UnixAddress.init(path) catch return;
+    const stream = address.connect(threaded.io()) catch return;
+    stream.close(threaded.io());
+}

--- a/packages/desktop/src/ipc/server.zig
+++ b/packages/desktop/src/ipc/server.zig
@@ -484,23 +484,30 @@ fn processCommandResponse(allocator: std.mem.Allocator, id_value: std.json.Value
     }
     const project_index = resolveProjectIndex(state, params) orelse return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
     if (std.mem.eql(u8, command, "list")) {
-        try state.refreshProjectStackConfig(project_index);
+        if (try refreshStackConfigOrError(allocator, id_value, state, project_index)) |response| return response;
         return try managedProcessesResponseForProject(allocator, id_value, state, project_index);
     }
     if (std.mem.eql(u8, command, "inspect")) {
         const name = stringParam(params, "name") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "process.inspect requires --name or --pane");
-        _ = (try state.managedProcessByNameConst(project_index, name)) orelse
+        const process = state.managedProcessByNameConst(project_index, name) catch |err| switch (err) {
+            error.InvalidStackConfig => return try errorResponseAlloc(allocator, id_value, "invalid_stack_config", stackConfigErrorMessage(state, project_index, err)),
+            else => return err,
+        };
+        _ = process orelse
             return try errorResponseAlloc(allocator, id_value, "not_found", "process not found");
         return try managedProcessResponse(allocator, id_value, state, project_index, name);
     }
     if (std.mem.eql(u8, command, "start") or std.mem.eql(u8, command, "stop") or std.mem.eql(u8, command, "restart")) {
         const name = stringParam(params, "name") orelse return try errorResponseAlloc(allocator, id_value, "invalid_request", "process command requires --name");
-        const changed = if (std.mem.eql(u8, command, "start"))
-            try state.startManagedProcess(project_index, name)
+        const changed = (if (std.mem.eql(u8, command, "start"))
+            state.startManagedProcess(project_index, name)
         else if (std.mem.eql(u8, command, "stop"))
-            try state.stopManagedProcess(project_index, name)
+            state.stopManagedProcess(project_index, name)
         else
-            try state.restartManagedProcess(project_index, name);
+            state.restartManagedProcess(project_index, name)) catch |err| switch (err) {
+            error.InvalidStackConfig => return try errorResponseAlloc(allocator, id_value, "invalid_stack_config", stackConfigErrorMessage(state, project_index, err)),
+            else => return err,
+        };
         if (!changed) return try errorResponseAlloc(allocator, id_value, "not_found", "process not found");
         return try managedProcessResponse(allocator, id_value, state, project_index, name);
     }
@@ -523,16 +530,19 @@ fn processCommandResponse(allocator: std.mem.Allocator, id_value: std.json.Value
 fn stackCommandResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, params: std.json.Value, command: []const u8) ![]u8 {
     const project_index = resolveProjectIndex(state, params) orelse return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
     if (std.mem.eql(u8, command, "status")) {
-        try state.refreshProjectStackConfig(project_index);
+        if (try refreshStackConfigOrError(allocator, id_value, state, project_index)) |response| return response;
         return try managedProcessesResponseForProject(allocator, id_value, state, project_index);
     }
     if (std.mem.eql(u8, command, "start") or std.mem.eql(u8, command, "stop") or std.mem.eql(u8, command, "restart")) {
-        const count = if (std.mem.eql(u8, command, "start"))
-            try state.startProjectStack(project_index)
+        const count = (if (std.mem.eql(u8, command, "start"))
+            state.startProjectStack(project_index)
         else if (std.mem.eql(u8, command, "stop"))
-            try state.stopProjectStack(project_index)
+            state.stopProjectStack(project_index)
         else
-            try state.restartProjectStack(project_index);
+            state.restartProjectStack(project_index)) catch |err| switch (err) {
+            error.InvalidStackConfig => return try errorResponseAlloc(allocator, id_value, "invalid_stack_config", stackConfigErrorMessage(state, project_index, err)),
+            else => return err,
+        };
         _ = count;
         return try managedProcessesResponseForProject(allocator, id_value, state, project_index);
     }
@@ -644,6 +654,15 @@ fn writePane(s: *std.json.Stringify, state: *app_state.AppState, project_index: 
                 if (thread.model_ref) |model| try s.write(model) else try s.write(null);
                 try s.objectField("send_pending");
                 try s.write(thread.isSendPendingForUi());
+                const pending_approval = threadHasPendingApproval(thread);
+                try s.objectField("pending_approval");
+                try s.write(pending_approval);
+                try s.objectField("attention");
+                try s.write(pending_approval);
+                try s.objectField("attention_reasons");
+                try s.beginArray();
+                if (pending_approval) try s.write("pending_approval");
+                try s.endArray();
             }
         },
         .terminal => |ref| {
@@ -661,6 +680,11 @@ fn writePane(s: *std.json.Stringify, state: *app_state.AppState, project_index: 
                 try s.objectField("cwd");
                 if (dock.cwd) |cwd| try s.write(cwd) else try s.write(null);
             }
+            const attention = terminalDockHasAttention(project, ref.dock_id);
+            try s.objectField("attention");
+            try s.write(attention);
+            try s.objectField("attention_reasons");
+            try writeTerminalAttentionReasons(s, project, ref.dock_id);
         },
     }
     try s.endObject();
@@ -726,6 +750,11 @@ fn writeTerminalsArray(s: *std.json.Stringify, state: *app_state.AppState, maybe
                 try s.endObject();
                 break;
             }
+            const attention = terminalDockHasAttention(&project, ref.dock_id);
+            try s.objectField("attention");
+            try s.write(attention);
+            try s.objectField("attention_reasons");
+            try writeTerminalAttentionReasons(s, &project, ref.dock_id);
             try s.endObject();
         }
     }
@@ -736,11 +765,11 @@ fn managedProcessesResponse(allocator: std.mem.Allocator, id_value: std.json.Val
     const project_index = resolveProjectIndexNullable(state, params);
     if (project_index) |index| {
         if (index >= state.projects.items.len) return try errorResponseAlloc(allocator, id_value, "not_found", "project not found");
-        try state.refreshProjectStackConfig(index);
+        if (try refreshStackConfigOrError(allocator, id_value, state, index)) |response| return response;
     } else {
         var index: usize = 0;
         while (index < state.projects.items.len) : (index += 1) {
-            try state.refreshProjectStackConfig(index);
+            if (try refreshStackConfigOrError(allocator, id_value, state, index)) |response| return response;
         }
     }
 
@@ -771,6 +800,8 @@ fn managedProcessesResponseForProject(allocator: std.mem.Allocator, id_value: st
     try s.write(project_index);
     try s.objectField("project_id");
     try s.write(state.projects.items[project_index].id);
+    try s.objectField("stack_config_error");
+    if (state.projects.items[project_index].stack_config_error) |message| try s.write(message) else try s.write(null);
     try s.objectField("processes");
     try writeManagedProcessesArray(&s, state, project_index);
     try s.endObject();
@@ -845,6 +876,14 @@ fn writeManagedProcess(s: *std.json.Stringify, state: *app_state.AppState, proje
     try s.write(process.watch_trigger_count);
     try s.objectField("last_watch_scan_ms");
     try s.write(process.last_watch_scan_ms);
+    try s.objectField("last_watch_change_ms");
+    try s.write(process.last_watch_change_ms);
+    try s.objectField("pending_watch_restart_ms");
+    try s.write(process.pending_watch_restart_ms);
+    try s.objectField("watch_ready");
+    try s.write(process.watch_ready);
+    try s.objectField("watch_error_count");
+    try s.write(process.watch_error_count);
     try s.objectField("explicit_stop");
     try s.write(process.explicit_stop);
     try s.objectField("watch");
@@ -856,7 +895,12 @@ fn writeManagedProcess(s: *std.json.Stringify, state: *app_state.AppState, proje
     try s.objectField("pane_id");
     if (process.pane_id) |pane_id| try s.write(pane_id) else try s.write(null);
     try s.objectField("attention");
-    try s.write(process.status == .crashed);
+    try s.write(process.status == .crashed or process.pending_watch_restart_ms != 0);
+    try s.objectField("attention_reasons");
+    try s.beginArray();
+    if (process.status == .crashed) try s.write("process_crashed");
+    if (process.pending_watch_restart_ms != 0) try s.write("watch_restart_pending");
+    try s.endArray();
     if (process.dock_id) |dock_id| {
         if (state.projectTerminalDock(project_index, dock_id)) |dock| {
             try s.objectField("running");
@@ -870,6 +914,46 @@ fn writeManagedProcess(s: *std.json.Stringify, state: *app_state.AppState, proje
         }
     }
     try s.endObject();
+}
+
+fn refreshStackConfigOrError(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, project_index: usize) !?[]u8 {
+    state.refreshProjectStackConfig(project_index) catch |err| switch (err) {
+        error.InvalidStackConfig => return try errorResponseAlloc(allocator, id_value, "invalid_stack_config", stackConfigErrorMessage(state, project_index, err)),
+        else => return err,
+    };
+    return null;
+}
+
+fn stackConfigErrorMessage(state: *app_state.AppState, project_index: usize, err: anyerror) []const u8 {
+    if (project_index < state.projects.items.len) {
+        if (state.projects.items[project_index].stack_config_error) |message| return message;
+    }
+    return @errorName(err);
+}
+
+fn threadHasPendingApproval(thread: *const app_state.ChatThread) bool {
+    const send_state = thread.send_state;
+    if (!send_state.mutex.tryLock()) return true;
+    defer send_state.mutex.unlock();
+    return send_state.status == .pending and send_state.pending_approval != null;
+}
+
+fn terminalDockHasAttention(project: *const app_state.Project, dock_id: u32) bool {
+    for (project.managed_processes.items) |process| {
+        if (process.dock_id == null or process.dock_id.? != dock_id) continue;
+        if (process.status == .crashed or process.pending_watch_restart_ms != 0) return true;
+    }
+    return false;
+}
+
+fn writeTerminalAttentionReasons(s: *std.json.Stringify, project: *const app_state.Project, dock_id: u32) !void {
+    try s.beginArray();
+    for (project.managed_processes.items) |process| {
+        if (process.dock_id == null or process.dock_id.? != dock_id) continue;
+        if (process.status == .crashed) try s.write("process_crashed");
+        if (process.pending_watch_restart_ms != 0) try s.write("watch_restart_pending");
+    }
+    try s.endArray();
 }
 
 fn chatStatusResponse(allocator: std.mem.Allocator, id_value: std.json.Value, state: *app_state.AppState, project_index: usize, pane_id: app_state.WorkspacePaneId) ![]u8 {

--- a/packages/desktop/src/main.zig
+++ b/packages/desktop/src/main.zig
@@ -11,6 +11,8 @@ const app_config = @import("config.zig");
 const browser_runtime = @import("browser/mod.zig");
 const browser_texture = @import("browser/texture.zig");
 const chat_threads = @import("chat/threads.zig");
+const cli = @import("cli.zig");
+const live_ipc = @import("ipc/server.zig");
 const keybinds = @import("keybinds.zig");
 const profiler = @import("profiler.zig");
 const runtime_log = @import("runtime_log.zig");
@@ -120,6 +122,11 @@ fn mainInner(init: std.process.Init) !void {
         debug_allocator.allocator()
     else
         std.heap.smp_allocator;
+
+    switch (try cli.dispatch(allocator, init.io, init.minimal.args)) {
+        .handled => return,
+        .launch_app => {},
+    }
 
     _ = SDL_SetHint("SDL_VIDEO_WAYLAND_SCALE_TO_DISPLAY", "1");
     try sdl.setAppMetadata("verde Native", "0.0.0", "com.verde.native");
@@ -272,6 +279,18 @@ fn mainInner(init: std.process.Init) !void {
     state.openBrowserOnLaunchIfRequested();
     state.startOpencodeModelOptionsRefresh();
     state.startCursorModelOptionsRefresh();
+    var live_server: ?live_ipc.LiveServer = live_ipc.LiveServer.init(allocator, storage.pref_path) catch |err| blk: {
+        log.warn("failed to initialize live-control server: {s}", .{@errorName(err)});
+        break :blk null;
+    };
+    if (live_server) |*server| {
+        server.start() catch |err| {
+            log.warn("failed to start live-control server: {s}", .{@errorName(err)});
+            server.deinit();
+            live_server = null;
+        };
+    }
+    defer if (live_server) |*server| server.deinit();
     var keyboard = try keybinds.NativeKeyboardConfig.load(allocator);
     defer keyboard.deinit();
 
@@ -328,6 +347,9 @@ fn mainInner(init: std.process.Init) !void {
                 app_state.pollTerminals();
             }
         }.run, .{&state});
+        if (live_server) |*server| {
+            if (server.processPending(&state)) needs_render = true;
+        }
 
         var observed_fb_width: c_int = 0;
         var observed_fb_height: c_int = 0;

--- a/packages/desktop/src/stack.zig
+++ b/packages/desktop/src/stack.zig
@@ -1,0 +1,220 @@
+//! Project-local managed stack config parsing.
+
+const std = @import("std");
+
+pub const CONFIG_FILENAMES = [_][]const u8{ "verde.yml", "verde.yaml" };
+
+pub const ProcessKind = enum {
+    process,
+    agent,
+};
+
+pub const RestartPolicy = enum {
+    manual,
+    on_crash,
+    always,
+};
+
+pub const ProcessDefinition = struct {
+    name: []u8,
+    kind: ProcessKind,
+    command: []u8,
+    cwd: []u8,
+    restart: RestartPolicy,
+    watch: std.ArrayList([]u8) = .empty,
+
+    pub fn deinit(self: *ProcessDefinition, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.command);
+        allocator.free(self.cwd);
+        for (self.watch.items) |pattern| allocator.free(pattern);
+        self.watch.deinit(allocator);
+    }
+};
+
+pub const Config = struct {
+    path: []u8,
+    processes: std.ArrayList(ProcessDefinition) = .empty,
+
+    pub fn deinit(self: *Config, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+        for (self.processes.items) |*process| process.deinit(allocator);
+        self.processes.deinit(allocator);
+    }
+};
+
+const Section = enum {
+    none,
+    processes,
+    agents,
+};
+
+pub fn loadFromProject(allocator: std.mem.Allocator, project_path: []const u8) !?Config {
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+
+    for (CONFIG_FILENAMES) |file_name| {
+        const path = try std.fs.path.join(allocator, &.{ project_path, file_name });
+        errdefer allocator.free(path);
+        const content = std.Io.Dir.cwd().readFileAlloc(threaded.io(), path, allocator, .limited(256 * 1024)) catch |err| switch (err) {
+            error.FileNotFound => {
+                allocator.free(path);
+                continue;
+            },
+            else => return err,
+        };
+        defer allocator.free(content);
+
+        const config = try parse(allocator, content, path);
+        allocator.free(path);
+        return config;
+    }
+    return null;
+}
+
+pub fn parse(allocator: std.mem.Allocator, content: []const u8, source_path: []const u8) !Config {
+    var config: Config = .{ .path = try allocator.dupe(u8, source_path) };
+    errdefer config.deinit(allocator);
+
+    var section: Section = .none;
+    var current_index: ?usize = null;
+    var in_watch_list = false;
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw_line| {
+        const line_without_comment = stripYamlComment(raw_line);
+        const line = std.mem.trim(u8, line_without_comment, " \t\r");
+        if (std.mem.trim(u8, line, " \t\r").len == 0) continue;
+
+        const indent = leadingSpaces(line);
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+
+        if (indent == 0) {
+            current_index = null;
+            in_watch_list = false;
+            if (std.mem.eql(u8, trimmed, "processes:")) {
+                section = .processes;
+            } else if (std.mem.eql(u8, trimmed, "agents:")) {
+                section = .agents;
+            } else {
+                section = .none;
+            }
+            continue;
+        }
+
+        if ((section == .processes or section == .agents) and indent == 2 and std.mem.endsWith(u8, trimmed, ":")) {
+            const raw_name = std.mem.trim(u8, trimmed[0 .. trimmed.len - 1], " \t\r\"'");
+            if (raw_name.len == 0) return error.InvalidStackConfig;
+            try config.processes.append(allocator, .{
+                .name = try allocator.dupe(u8, raw_name),
+                .kind = if (section == .agents) .agent else .process,
+                .command = try allocator.dupe(u8, ""),
+                .cwd = try allocator.dupe(u8, "."),
+                .restart = if (section == .agents) .manual else .manual,
+                .watch = .empty,
+            });
+            current_index = config.processes.items.len - 1;
+            in_watch_list = false;
+            continue;
+        }
+
+        const index = current_index orelse continue;
+        var process = &config.processes.items[index];
+        if (indent >= 4 and in_watch_list and std.mem.startsWith(u8, trimmed, "-")) {
+            const value = try parseScalarAlloc(allocator, std.mem.trim(u8, trimmed[1..], " \t\r"));
+            errdefer allocator.free(value);
+            try process.watch.append(allocator, value);
+            continue;
+        }
+
+        if (indent < 4) continue;
+        const colon_index = std.mem.indexOfScalar(u8, trimmed, ':') orelse continue;
+        const key = std.mem.trim(u8, trimmed[0..colon_index], " \t\r");
+        const raw_value = std.mem.trim(u8, trimmed[colon_index + 1 ..], " \t\r");
+        in_watch_list = std.mem.eql(u8, key, "watch");
+
+        if (std.mem.eql(u8, key, "command")) {
+            const value = try parseScalarAlloc(allocator, raw_value);
+            allocator.free(process.command);
+            process.command = value;
+        } else if (std.mem.eql(u8, key, "cwd")) {
+            const value = try parseScalarAlloc(allocator, raw_value);
+            allocator.free(process.cwd);
+            process.cwd = value;
+        } else if (std.mem.eql(u8, key, "restart")) {
+            process.restart = parseRestart(raw_value) orelse return error.InvalidStackConfig;
+        }
+    }
+
+    var index: usize = 0;
+    while (index < config.processes.items.len) {
+        if (std.mem.trim(u8, config.processes.items[index].command, " \t\r").len != 0) {
+            index += 1;
+            continue;
+        }
+        var removed = config.processes.orderedRemove(index);
+        removed.deinit(allocator);
+    }
+
+    return config;
+}
+
+fn stripYamlComment(line: []const u8) []const u8 {
+    var in_single = false;
+    var in_double = false;
+    for (line, 0..) |byte, index| {
+        if (byte == '\'' and !in_double) in_single = !in_single;
+        if (byte == '"' and !in_single) in_double = !in_double;
+        if (byte == '#' and !in_single and !in_double) return line[0..index];
+    }
+    return line;
+}
+
+fn leadingSpaces(line: []const u8) usize {
+    var count: usize = 0;
+    while (count < line.len and line[count] == ' ') : (count += 1) {}
+    return count;
+}
+
+fn parseScalarAlloc(allocator: std.mem.Allocator, raw_value: []const u8) ![]u8 {
+    var value = std.mem.trim(u8, raw_value, " \t\r");
+    if (value.len >= 2 and ((value[0] == '"' and value[value.len - 1] == '"') or (value[0] == '\'' and value[value.len - 1] == '\''))) {
+        value = value[1 .. value.len - 1];
+    }
+    return allocator.dupe(u8, value);
+}
+
+fn parseRestart(raw_value: []const u8) ?RestartPolicy {
+    const value = std.mem.trim(u8, raw_value, " \t\r\"'");
+    if (std.mem.eql(u8, value, "manual")) return .manual;
+    if (std.mem.eql(u8, value, "on_crash")) return .on_crash;
+    if (std.mem.eql(u8, value, "always")) return .always;
+    return null;
+}
+
+test "parse verde stack config" {
+    const content =
+        \\version: 1
+        \\processes:
+        \\  web:
+        \\    command: "npm run dev"
+        \\    cwd: "."
+        \\    restart: on_crash
+        \\    watch:
+        \\      - "src/**"
+        \\agents:
+        \\  codex:
+        \\    command: "codex"
+        \\
+    ;
+    var config = try parse(std.testing.allocator, content, "verde.yml");
+    defer config.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 2), config.processes.items.len);
+    try std.testing.expectEqualStrings("web", config.processes.items[0].name);
+    try std.testing.expectEqual(ProcessKind.process, config.processes.items[0].kind);
+    try std.testing.expectEqual(RestartPolicy.on_crash, config.processes.items[0].restart);
+    try std.testing.expectEqualStrings("src/**", config.processes.items[0].watch.items[0]);
+    try std.testing.expectEqualStrings("codex", config.processes.items[1].name);
+    try std.testing.expectEqual(ProcessKind.agent, config.processes.items[1].kind);
+}

--- a/packages/desktop/src/stack.zig
+++ b/packages/desktop/src/stack.zig
@@ -83,11 +83,10 @@ pub fn parse(allocator: std.mem.Allocator, content: []const u8, source_path: []c
     var lines = std.mem.splitScalar(u8, content, '\n');
     while (lines.next()) |raw_line| {
         const line_without_comment = stripYamlComment(raw_line);
-        const line = std.mem.trim(u8, line_without_comment, " \t\r");
-        if (std.mem.trim(u8, line, " \t\r").len == 0) continue;
+        if (std.mem.trim(u8, line_without_comment, " \t\r").len == 0) continue;
 
-        const indent = leadingSpaces(line);
-        const trimmed = std.mem.trim(u8, line, " \t\r");
+        const indent = leadingSpaces(line_without_comment);
+        const trimmed = std.mem.trim(u8, line_without_comment, " \t\r");
 
         if (indent == 0) {
             current_index = null;

--- a/packages/desktop/src/state.zig
+++ b/packages/desktop/src/state.zig
@@ -13,6 +13,7 @@ const db_types = @import("db/types.zig");
 const fff = @import("fff.zig");
 const keybinds = @import("keybinds.zig");
 const runtime_log = @import("runtime_log.zig");
+const stack_config = @import("stack.zig");
 const stb_image = @import("stb_image.zig");
 const terminal = @import("terminal/terminal.zig");
 const theme = @import("ui/theme.zig");
@@ -21,6 +22,9 @@ const utils = @import("utils.zig");
 
 /// Arrow-key line step for transcript scroll (scaled px per key repeat).
 const TRANSCRIPT_KEYBOARD_LINE_PX: f32 = 29.0;
+const STACK_CONFIG_REFRESH_MS: i64 = 2000;
+const MANAGED_PROCESS_BASE_RESTART_BACKOFF_MS: i64 = 1000;
+const MANAGED_PROCESS_MAX_RESTART_BACKOFF_MS: i64 = 30000;
 
 pub fn paletteUiTextPrefixWidth(text: []const u8, font_size: f32, end: usize) f32 {
     return text_measure.textPrefixWidth(.ui, text, font_size, end);
@@ -1248,6 +1252,77 @@ pub const TerminalDockEntry = struct {
     }
 };
 
+pub const ManagedProcessStatus = enum {
+    stopped,
+    starting,
+    running,
+    crashed,
+    restarting,
+};
+
+pub const ManagedProcess = struct {
+    name: []u8,
+    kind: stack_config.ProcessKind,
+    command: []u8,
+    cwd: []u8,
+    restart: stack_config.RestartPolicy,
+    watch: std.ArrayList([]u8) = .empty,
+    status: ManagedProcessStatus = .stopped,
+    exit_code: ?u32 = null,
+    signal: ?u32 = null,
+    last_start_ms: i64 = 0,
+    last_exit_ms: i64 = 0,
+    next_restart_ms: i64 = 0,
+    restart_count: u32 = 0,
+    watch_trigger_count: u32 = 0,
+    last_watch_scan_ms: i64 = 0,
+    dock_id: ?u32 = null,
+    pane_id: ?WorkspacePaneId = null,
+    explicit_stop: bool = false,
+
+    fn initFromDefinition(allocator: std.mem.Allocator, definition: stack_config.ProcessDefinition) !ManagedProcess {
+        var process: ManagedProcess = .{
+            .name = try allocator.dupe(u8, definition.name),
+            .kind = definition.kind,
+            .command = try allocator.dupe(u8, definition.command),
+            .cwd = try allocator.dupe(u8, definition.cwd),
+            .restart = definition.restart,
+            .watch = .empty,
+        };
+        errdefer process.deinit(allocator);
+        for (definition.watch.items) |pattern| {
+            try process.watch.append(allocator, try allocator.dupe(u8, pattern));
+        }
+        return process;
+    }
+
+    fn updateFromDefinition(self: *ManagedProcess, allocator: std.mem.Allocator, definition: stack_config.ProcessDefinition) !void {
+        self.kind = definition.kind;
+        self.restart = definition.restart;
+        if (!std.mem.eql(u8, self.command, definition.command)) {
+            allocator.free(self.command);
+            self.command = try allocator.dupe(u8, definition.command);
+        }
+        if (!std.mem.eql(u8, self.cwd, definition.cwd)) {
+            allocator.free(self.cwd);
+            self.cwd = try allocator.dupe(u8, definition.cwd);
+        }
+        for (self.watch.items) |pattern| allocator.free(pattern);
+        self.watch.clearRetainingCapacity();
+        for (definition.watch.items) |pattern| {
+            try self.watch.append(allocator, try allocator.dupe(u8, pattern));
+        }
+    }
+
+    fn deinit(self: *ManagedProcess, allocator: std.mem.Allocator) void {
+        allocator.free(self.name);
+        allocator.free(self.command);
+        allocator.free(self.cwd);
+        for (self.watch.items) |pattern| allocator.free(pattern);
+        self.watch.deinit(allocator);
+    }
+};
+
 pub const WorkspaceSplitAxis = enum {
     horizontal,
     vertical,
@@ -1309,7 +1384,7 @@ pub const WorkspaceLayout = struct {
         return null;
     }
 
-    fn paneById(self: *const WorkspaceLayout, pane_id: WorkspacePaneId) ?*const WorkspacePane {
+    pub fn paneById(self: *const WorkspaceLayout, pane_id: WorkspacePaneId) ?*const WorkspacePane {
         for (self.panes.items) |*pane| {
             if (pane.id == pane_id) return pane;
         }
@@ -1883,6 +1958,8 @@ pub const Project = struct {
     thread_list_expanded: bool = false,
     terminal_dock: terminal.Dock,
     terminal_docks: std.ArrayList(TerminalDockEntry) = .empty,
+    managed_processes: std.ArrayList(ManagedProcess) = .empty,
+    last_stack_config_refresh_ms: i64 = 0,
     next_terminal_dock_id: u32 = 1,
     workspace_layout: WorkspaceLayout,
     threads: std.ArrayList(ChatThread),
@@ -1906,6 +1983,8 @@ pub const Project = struct {
             .thread_list_expanded = false,
             .terminal_dock = terminal_dock,
             .terminal_docks = .empty,
+            .managed_processes = .empty,
+            .last_stack_config_refresh_ms = 0,
             .next_terminal_dock_id = 1,
             .workspace_layout = try WorkspaceLayout.initDefaultChat(allocator),
             .threads = .empty,
@@ -1997,6 +2076,17 @@ pub const Project = struct {
                 chat_threads.sanitizeEnum(ChatRole, &message.role, .user);
             }
         }
+        if (self.threads.items.len > 0) {
+            const fallback_thread_index = @min(self.selected_thread_index, self.threads.items.len - 1);
+            for (self.workspace_layout.panes.items) |*pane| {
+                switch (pane.ref) {
+                    .chat => |*ref| {
+                        if (ref.thread_index >= self.threads.items.len) ref.thread_index = fallback_thread_index;
+                    },
+                    else => {},
+                }
+            }
+        }
         try self.ensureTerminalDocksForWorkspace(allocator, default_terminal_font_size);
     }
 
@@ -2027,6 +2117,20 @@ pub const Project = struct {
         return null;
     }
 
+    pub fn managedProcessByName(self: *Project, name: []const u8) ?*ManagedProcess {
+        for (self.managed_processes.items) |*process| {
+            if (std.mem.eql(u8, process.name, name)) return process;
+        }
+        return null;
+    }
+
+    fn managedProcessByDockId(self: *Project, dock_id: u32) ?*ManagedProcess {
+        for (self.managed_processes.items) |*process| {
+            if (process.dock_id != null and process.dock_id.? == dock_id) return process;
+        }
+        return null;
+    }
+
     fn removeTerminalDockById(self: *Project, allocator: std.mem.Allocator, dock_id: u32) bool {
         for (self.terminal_docks.items, 0..) |*entry, index| {
             if (entry.id != dock_id) continue;
@@ -2052,6 +2156,8 @@ pub const Project = struct {
         self.terminal_dock.deinit(allocator);
         for (self.terminal_docks.items) |*entry| entry.deinit(allocator);
         self.terminal_docks.deinit(allocator);
+        for (self.managed_processes.items) |*process| process.deinit(allocator);
+        self.managed_processes.deinit(allocator);
         self.workspace_layout.deinit(allocator);
         for (self.threads.items) |*thread| {
             thread.deinit(allocator);
@@ -3855,7 +3961,7 @@ pub const AppState = struct {
             return;
         }
 
-        var project = &self.projects.items[project_index];
+        const project = &self.projects.items[project_index];
         if (thread_index >= project.threads.items.len) {
             self.setSidebarNotice("Thread not found.");
             return;
@@ -3923,7 +4029,7 @@ pub const AppState = struct {
 
     pub fn selectThreadForProject(self: *AppState, project_index: usize, thread_index: usize) void {
         if (project_index >= self.projects.items.len) return;
-        var project = &self.projects.items[project_index];
+        const project = &self.projects.items[project_index];
         if (thread_index >= project.threads.items.len) return;
         self.selected_project_index = project_index;
         project.selected_thread_index = thread_index;
@@ -4649,7 +4755,7 @@ pub const AppState = struct {
         return &self.projects.items[self.selected_project_index];
     }
 
-    fn currentProjectMutable(self: *AppState) *Project {
+    pub fn currentProjectMutable(self: *AppState) *Project {
         return &self.projects.items[self.selected_project_index];
     }
 
@@ -5606,6 +5712,26 @@ pub const AppState = struct {
         return null;
     }
 
+    pub fn projectTerminalDock(self: *const AppState, project_index: usize, dock_id: u32) ?*const terminal.Dock {
+        if (project_index >= self.projects.items.len) return null;
+        const project = &self.projects.items[project_index];
+        if (dock_id == 0) return &project.terminal_dock;
+        for (project.terminal_docks.items) |*entry| {
+            if (entry.id == dock_id) return &entry.dock;
+        }
+        return null;
+    }
+
+    pub fn projectTerminalDockMutable(self: *AppState, project_index: usize, dock_id: u32) ?*terminal.Dock {
+        if (project_index >= self.projects.items.len) return null;
+        var project = &self.projects.items[project_index];
+        if (dock_id == 0) return &project.terminal_dock;
+        for (project.terminal_docks.items) |*entry| {
+            if (entry.id == dock_id) return &entry.dock;
+        }
+        return null;
+    }
+
     pub fn focusedWorkspaceTerminalDockId(self: *const AppState) ?u32 {
         if (self.projects.items.len == 0) return null;
         const layout = &self.projects.items[self.selected_project_index].workspace_layout;
@@ -5813,6 +5939,7 @@ pub const AppState = struct {
                     }
                 };
             }
+            self.pollManagedProcesses(project_index);
         }
         for (self.archived_projects.items) |*project| {
             if (project.terminal_dock.visible or project.terminal_dock.hasRunningSession()) {
@@ -6579,6 +6706,327 @@ pub const AppState = struct {
         };
     }
 
+    pub fn setWorkspaceChatPaneDraft(self: *AppState, pane_id: WorkspacePaneId, value: []const u8, append: bool) !bool {
+        if (self.projects.items.len == 0) return false;
+        var project = &self.projects.items[self.selected_project_index];
+        const pane = project.workspace_layout.paneById(pane_id) orelse return false;
+        const thread_index = switch (pane.ref) {
+            .chat => |ref| ref.thread_index,
+            else => return false,
+        };
+        if (thread_index >= project.threads.items.len) return false;
+        var thread = &project.threads.items[thread_index];
+        if (append) {
+            const current = thread.currentDraft();
+            var next: std.ArrayList(u8) = .empty;
+            defer next.deinit(self.allocator);
+            try next.ensureTotalCapacity(self.allocator, current.len + value.len);
+            try next.appendSlice(self.allocator, current);
+            try next.appendSlice(self.allocator, value);
+            thread.setDraft(next.items);
+        } else {
+            thread.setDraft(value);
+        }
+        project.selected_thread_index = thread_index;
+        self.terminal_focused = false;
+        self.syncPaletteComposerFromDraft();
+        self.markDirty();
+        return true;
+    }
+
+    pub fn sendWorkspaceChatPanePrompt(self: *AppState, pane_id: WorkspacePaneId, prompt: ?[]const u8) !bool {
+        if (prompt) |text| {
+            if (!try self.setWorkspaceChatPaneDraft(pane_id, text, false)) return false;
+        } else {
+            if (!self.selectWorkspaceChatPaneThread(pane_id)) return false;
+        }
+        try self.sendDraft();
+        return true;
+    }
+
+    pub fn followupWorkspaceChatPanePrompt(self: *AppState, pane_id: WorkspacePaneId, prompt: []const u8) !bool {
+        if (!try self.setWorkspaceChatPaneDraft(pane_id, prompt, false)) return false;
+        self.queueOrSteerDraftDuringSend();
+        return true;
+    }
+
+    pub fn stopWorkspaceChatPane(self: *AppState, pane_id: WorkspacePaneId) bool {
+        if (!self.selectWorkspaceChatPaneThread(pane_id)) return false;
+        self.abortCurrentThreadSend();
+        return true;
+    }
+
+    pub fn approveWorkspaceChatPane(self: *AppState, pane_id: WorkspacePaneId, decision: ai_harness.ApprovalDecision) bool {
+        if (!self.selectWorkspaceChatPaneThread(pane_id)) return false;
+        self.resolvePendingApproval(decision);
+        return true;
+    }
+
+    pub fn writeWorkspaceTerminalPane(self: *AppState, pane_id: WorkspacePaneId, bytes: []const u8) !bool {
+        if (self.projects.items.len == 0) return false;
+        var project = &self.projects.items[self.selected_project_index];
+        const pane = project.workspace_layout.paneById(pane_id) orelse return false;
+        const dock_id = switch (pane.ref) {
+            .terminal => |ref| ref.dock_id,
+            else => return false,
+        };
+        var dock = self.currentProjectTerminalDockMutable(dock_id) orelse return false;
+        try dock.ensureSession(self.allocator, project.path);
+        return try dock.writeInputToActivePane(bytes);
+    }
+
+    pub fn terminalPaneOutputTail(self: *AppState, pane_id: WorkspacePaneId, max_bytes: usize) !?[]u8 {
+        if (self.projects.items.len == 0) return null;
+        var project = &self.projects.items[self.selected_project_index];
+        const pane = project.workspace_layout.paneById(pane_id) orelse return null;
+        const dock_id = switch (pane.ref) {
+            .terminal => |ref| ref.dock_id,
+            else => return null,
+        };
+        const dock = self.currentProjectTerminalDock(dock_id) orelse return null;
+        return try dock.activeOutputTailAlloc(self.allocator, max_bytes);
+    }
+
+    pub fn terminalPaneScreenText(self: *AppState, pane_id: WorkspacePaneId) !?[]u8 {
+        if (self.projects.items.len == 0) return null;
+        var project = &self.projects.items[self.selected_project_index];
+        const pane = project.workspace_layout.paneById(pane_id) orelse return null;
+        const dock_id = switch (pane.ref) {
+            .terminal => |ref| ref.dock_id,
+            else => return null,
+        };
+        const dock = self.currentProjectTerminalDock(dock_id) orelse return null;
+        return try dock.activeScreenTextAlloc(self.allocator);
+    }
+
+    pub fn refreshProjectStackConfig(self: *AppState, project_index: usize) !void {
+        if (project_index >= self.projects.items.len) return;
+        var project = &self.projects.items[project_index];
+        project.last_stack_config_refresh_ms = unixTimestampMs();
+        var loaded = try stack_config.loadFromProject(self.allocator, project.path) orelse return;
+        defer loaded.deinit(self.allocator);
+
+        for (loaded.processes.items) |definition| {
+            if (project.managedProcessByName(definition.name)) |process| {
+                try process.updateFromDefinition(self.allocator, definition);
+            } else {
+                try project.managed_processes.append(self.allocator, try ManagedProcess.initFromDefinition(self.allocator, definition));
+            }
+        }
+        self.refreshManagedProcessStatuses(project_index);
+    }
+
+    pub fn refreshManagedProcessStatuses(self: *AppState, project_index: usize) void {
+        if (project_index >= self.projects.items.len) return;
+        const project = &self.projects.items[project_index];
+        for (project.managed_processes.items) |*process| {
+            const dock_id = process.dock_id orelse continue;
+            const dock = self.projectTerminalDock(project_index, dock_id) orelse continue;
+            const snapshot = dock.activeSessionSnapshot() orelse continue;
+            if (snapshot.running) {
+                process.status = .running;
+                process.exit_code = null;
+                process.signal = null;
+                continue;
+            }
+            if (process.status == .stopped and process.explicit_stop) continue;
+            process.exit_code = snapshot.exit_code;
+            process.signal = snapshot.signal;
+            if (process.last_exit_ms == 0) process.last_exit_ms = unixTimestampMs();
+            const clean_exit = snapshot.exit_code != null and snapshot.exit_code.? == 0;
+            process.status = if (clean_exit or process.explicit_stop) .stopped else .crashed;
+        }
+    }
+
+    pub fn pollManagedProcesses(self: *AppState, project_index: usize) void {
+        if (project_index >= self.projects.items.len) return;
+        const now = unixTimestampMs();
+        if (now - self.projects.items[project_index].last_stack_config_refresh_ms >= STACK_CONFIG_REFRESH_MS) {
+            self.refreshProjectStackConfig(project_index) catch |err| {
+                log.warn("failed to refresh verde stack config: {s}", .{@errorName(err)});
+            };
+        } else {
+            self.refreshManagedProcessStatuses(project_index);
+        }
+
+        var restart_names: std.ArrayList([]u8) = .empty;
+        defer {
+            for (restart_names.items) |name| self.allocator.free(name);
+            restart_names.deinit(self.allocator);
+        }
+
+        for (self.projects.items[project_index].managed_processes.items) |*process| {
+            if (process.explicit_stop) continue;
+            const should_restart_crash = process.status == .crashed and process.restart == .on_crash;
+            const should_restart_always = process.status != .running and process.restart == .always and process.last_start_ms != 0;
+            if (!should_restart_crash and !should_restart_always) continue;
+            if (process.next_restart_ms == 0) {
+                process.next_restart_ms = now + managedProcessRestartBackoffMs(process.restart_count);
+                process.status = .restarting;
+            }
+            if (now < process.next_restart_ms) continue;
+            restart_names.append(self.allocator, self.allocator.dupe(u8, process.name) catch continue) catch continue;
+        }
+
+        for (restart_names.items) |name| {
+            if (self.projects.items[project_index].managedProcessByName(name)) |process| {
+                process.restart_count += 1;
+                process.status = .restarting;
+            }
+            _ = self.startManagedProcess(project_index, name) catch |err| {
+                log.warn("failed to auto-restart managed process {s}: {s}", .{ name, @errorName(err) });
+                continue;
+            };
+        }
+    }
+
+    pub fn startManagedProcess(self: *AppState, project_index: usize, name: []const u8) !bool {
+        try self.refreshProjectStackConfig(project_index);
+        if (project_index >= self.projects.items.len) return false;
+        self.selected_project_index = project_index;
+        var project = &self.projects.items[project_index];
+        var process = project.managedProcessByName(name) orelse return false;
+        const dock_id = process.dock_id orelse try self.createCurrentProjectTerminalDock();
+        process.dock_id = dock_id;
+
+        const cwd = try self.resolveManagedProcessCwd(project.path, process.cwd);
+        defer self.allocator.free(cwd);
+        var dock = self.currentProjectTerminalDockMutable(dock_id) orelse return false;
+        const command_args = [_][]const u8{ "/bin/sh", "-lc", process.command };
+        try dock.restartWithProfile(self.allocator, cwd, .{
+            .kind = .custom,
+            .label = process.name,
+            .command = &command_args,
+        });
+        process.status = .running;
+        process.exit_code = null;
+        process.signal = null;
+        process.last_start_ms = unixTimestampMs();
+        process.last_exit_ms = 0;
+        process.next_restart_ms = 0;
+        process.explicit_stop = false;
+        process.pane_id = try project.workspace_layout.ensureTerminalPane(self.allocator, dock_id);
+        project.workspace_layout.maximized_pane_id = null;
+        self.terminal_focused = true;
+        self.markDirty();
+        return true;
+    }
+
+    pub fn stopManagedProcess(self: *AppState, project_index: usize, name: []const u8) !bool {
+        try self.refreshProjectStackConfig(project_index);
+        if (project_index >= self.projects.items.len) return false;
+        var project = &self.projects.items[project_index];
+        var process = project.managedProcessByName(name) orelse return false;
+        process.explicit_stop = true;
+        process.status = .stopped;
+        process.last_exit_ms = unixTimestampMs();
+        process.next_restart_ms = 0;
+        if (process.dock_id) |dock_id| {
+            if (self.projectTerminalDockMutable(project_index, dock_id)) |dock| {
+                _ = dock.terminateActiveSession();
+            }
+        }
+        self.markDirty();
+        return true;
+    }
+
+    pub fn restartManagedProcess(self: *AppState, project_index: usize, name: []const u8) !bool {
+        try self.refreshProjectStackConfig(project_index);
+        if (project_index >= self.projects.items.len) return false;
+        if (self.projects.items[project_index].managedProcessByName(name)) |process| {
+            process.restart_count += 1;
+            process.status = .restarting;
+        }
+        _ = try self.stopManagedProcess(project_index, name);
+        return try self.startManagedProcess(project_index, name);
+    }
+
+    pub fn startProjectStack(self: *AppState, project_index: usize) !usize {
+        try self.refreshProjectStackConfig(project_index);
+        if (project_index >= self.projects.items.len) return 0;
+        var started: usize = 0;
+        var names: std.ArrayList([]u8) = .empty;
+        defer {
+            for (names.items) |name| self.allocator.free(name);
+            names.deinit(self.allocator);
+        }
+        for (self.projects.items[project_index].managed_processes.items) |process| {
+            try names.append(self.allocator, try self.allocator.dupe(u8, process.name));
+        }
+        for (names.items) |name| {
+            if (try self.startManagedProcess(project_index, name)) started += 1;
+        }
+        return started;
+    }
+
+    pub fn stopProjectStack(self: *AppState, project_index: usize) !usize {
+        try self.refreshProjectStackConfig(project_index);
+        if (project_index >= self.projects.items.len) return 0;
+        var stopped: usize = 0;
+        var names: std.ArrayList([]u8) = .empty;
+        defer {
+            for (names.items) |name| self.allocator.free(name);
+            names.deinit(self.allocator);
+        }
+        for (self.projects.items[project_index].managed_processes.items) |process| {
+            try names.append(self.allocator, try self.allocator.dupe(u8, process.name));
+        }
+        for (names.items) |name| {
+            if (try self.stopManagedProcess(project_index, name)) stopped += 1;
+        }
+        return stopped;
+    }
+
+    pub fn restartProjectStack(self: *AppState, project_index: usize) !usize {
+        _ = try self.stopProjectStack(project_index);
+        return try self.startProjectStack(project_index);
+    }
+
+    pub fn managedProcessLogs(self: *AppState, project_index: usize, name: []const u8, max_bytes: usize) !?[]u8 {
+        try self.refreshProjectStackConfig(project_index);
+        if (project_index >= self.projects.items.len) return null;
+        const project = &self.projects.items[project_index];
+        const process = project.managedProcessByName(name) orelse return null;
+        const dock_id = process.dock_id orelse return null;
+        const dock = self.projectTerminalDock(project_index, dock_id) orelse return null;
+        return try dock.activeOutputTailAlloc(self.allocator, max_bytes);
+    }
+
+    pub fn managedProcessByNameConst(self: *AppState, project_index: usize, name: []const u8) !?*ManagedProcess {
+        try self.refreshProjectStackConfig(project_index);
+        if (project_index >= self.projects.items.len) return null;
+        return self.projects.items[project_index].managedProcessByName(name);
+    }
+
+    fn resolveManagedProcessCwd(self: *AppState, project_path: []const u8, raw_cwd: []const u8) ![]u8 {
+        if (raw_cwd.len == 0 or std.mem.eql(u8, raw_cwd, ".")) return self.allocator.dupe(u8, project_path);
+        if (std.fs.path.isAbsolute(raw_cwd)) return self.allocator.dupe(u8, raw_cwd);
+        return std.fs.path.join(self.allocator, &.{ project_path, raw_cwd });
+    }
+
+    fn managedProcessRestartBackoffMs(restart_count: u32) i64 {
+        const capped_shift: u6 = @intCast(@min(restart_count, 5));
+        const backoff = MANAGED_PROCESS_BASE_RESTART_BACKOFF_MS * (@as(i64, 1) << capped_shift);
+        return @min(backoff, MANAGED_PROCESS_MAX_RESTART_BACKOFF_MS);
+    }
+
+    fn selectWorkspaceChatPaneThread(self: *AppState, pane_id: WorkspacePaneId) bool {
+        if (self.projects.items.len == 0) return false;
+        var project = &self.projects.items[self.selected_project_index];
+        const pane = project.workspace_layout.paneById(pane_id) orelse return false;
+        const thread_index = switch (pane.ref) {
+            .chat => |ref| ref.thread_index,
+            else => return false,
+        };
+        if (thread_index >= project.threads.items.len) return false;
+        project.selected_thread_index = thread_index;
+        if (!pane.minimized) project.workspace_layout.focused_pane_id = pane_id;
+        self.terminal_focused = false;
+        self.syncPaletteComposerFromDraft();
+        self.markDirty();
+        return true;
+    }
+
     pub fn isCurrentProjectWorkspacePaneFocused(self: *const AppState, pane_id: WorkspacePaneId) bool {
         if (self.projects.items.len == 0) return false;
         return self.projects.items[self.selected_project_index].workspace_layout.focused_pane_id == pane_id;
@@ -6696,6 +7144,7 @@ pub const AppState = struct {
             self.setSidebarNotice("Failed to split workspace.");
             return false;
         };
+        layout.maximized_pane_id = null;
         self.terminal_focused = false;
         self.requestComposerFocus();
         self.syncRenameBuffer();
@@ -6731,6 +7180,7 @@ pub const AppState = struct {
             self.setSidebarNotice("Failed to split workspace.");
             return false;
         };
+        layout.maximized_pane_id = null;
         project.selected_thread_index = thread_index;
         self.terminal_focused = false;
         self.requestComposerFocus();
@@ -6778,6 +7228,7 @@ pub const AppState = struct {
             self.setSidebarNotice("Failed to split workspace.");
             return false;
         };
+        layout.maximized_pane_id = null;
         dock.visible = false;
         self.requestTerminalFocus();
         self.setSidebarNotice("Terminal pane created.");

--- a/packages/desktop/src/state.zig
+++ b/packages/desktop/src/state.zig
@@ -25,6 +25,8 @@ const TRANSCRIPT_KEYBOARD_LINE_PX: f32 = 29.0;
 const STACK_CONFIG_REFRESH_MS: i64 = 2000;
 const MANAGED_PROCESS_BASE_RESTART_BACKOFF_MS: i64 = 1000;
 const MANAGED_PROCESS_MAX_RESTART_BACKOFF_MS: i64 = 30000;
+const MANAGED_PROCESS_WATCH_SCAN_MS: i64 = 1000;
+const MANAGED_PROCESS_WATCH_DEBOUNCE_MS: i64 = 500;
 
 pub fn paletteUiTextPrefixWidth(text: []const u8, font_size: f32, end: usize) f32 {
     return text_measure.textPrefixWidth(.ui, text, font_size, end);
@@ -338,6 +340,7 @@ fn paletteComposerPromptEvent(context: ?*anyopaque, event: palette.ComposerPromp
                 return;
             }
             if (state.acceptPrimaryFileSearchResult()) return;
+            if (state.handleWorkspaceCommand(state.currentProject().currentDraft())) return;
             state.sendDraft() catch |err| {
                 log.err("failed to send draft: {s}", .{@errorName(err)});
             };
@@ -1276,6 +1279,11 @@ pub const ManagedProcess = struct {
     restart_count: u32 = 0,
     watch_trigger_count: u32 = 0,
     last_watch_scan_ms: i64 = 0,
+    last_watch_change_ms: i64 = 0,
+    pending_watch_restart_ms: i64 = 0,
+    watch_signature: u64 = 0,
+    watch_ready: bool = false,
+    watch_error_count: u32 = 0,
     dock_id: ?u32 = null,
     pane_id: ?WorkspacePaneId = null,
     explicit_stop: bool = false,
@@ -1299,6 +1307,7 @@ pub const ManagedProcess = struct {
     fn updateFromDefinition(self: *ManagedProcess, allocator: std.mem.Allocator, definition: stack_config.ProcessDefinition) !void {
         self.kind = definition.kind;
         self.restart = definition.restart;
+        var reset_watch_state = false;
         if (!std.mem.eql(u8, self.command, definition.command)) {
             allocator.free(self.command);
             self.command = try allocator.dupe(u8, definition.command);
@@ -1306,12 +1315,15 @@ pub const ManagedProcess = struct {
         if (!std.mem.eql(u8, self.cwd, definition.cwd)) {
             allocator.free(self.cwd);
             self.cwd = try allocator.dupe(u8, definition.cwd);
+            reset_watch_state = true;
         }
+        if (!watchPatternsEqual(self.watch.items, definition.watch.items)) reset_watch_state = true;
         for (self.watch.items) |pattern| allocator.free(pattern);
         self.watch.clearRetainingCapacity();
         for (definition.watch.items) |pattern| {
             try self.watch.append(allocator, try allocator.dupe(u8, pattern));
         }
+        if (reset_watch_state) self.resetWatchState();
     }
 
     fn deinit(self: *ManagedProcess, allocator: std.mem.Allocator) void {
@@ -1320,6 +1332,23 @@ pub const ManagedProcess = struct {
         allocator.free(self.cwd);
         for (self.watch.items) |pattern| allocator.free(pattern);
         self.watch.deinit(allocator);
+    }
+
+    fn resetWatchState(self: *ManagedProcess) void {
+        self.watch_signature = 0;
+        self.watch_ready = false;
+        self.last_watch_scan_ms = 0;
+        self.last_watch_change_ms = 0;
+        self.pending_watch_restart_ms = 0;
+        self.watch_error_count = 0;
+    }
+
+    fn watchPatternsEqual(left: []const []u8, right: []const []u8) bool {
+        if (left.len != right.len) return false;
+        for (left, right) |l, r| {
+            if (!std.mem.eql(u8, l, r)) return false;
+        }
+        return true;
     }
 };
 
@@ -1960,6 +1989,7 @@ pub const Project = struct {
     terminal_docks: std.ArrayList(TerminalDockEntry) = .empty,
     managed_processes: std.ArrayList(ManagedProcess) = .empty,
     last_stack_config_refresh_ms: i64 = 0,
+    stack_config_error: ?[]u8 = null,
     next_terminal_dock_id: u32 = 1,
     workspace_layout: WorkspaceLayout,
     threads: std.ArrayList(ChatThread),
@@ -1985,6 +2015,7 @@ pub const Project = struct {
             .terminal_docks = .empty,
             .managed_processes = .empty,
             .last_stack_config_refresh_ms = 0,
+            .stack_config_error = null,
             .next_terminal_dock_id = 1,
             .workspace_layout = try WorkspaceLayout.initDefaultChat(allocator),
             .threads = .empty,
@@ -2124,6 +2155,24 @@ pub const Project = struct {
         return null;
     }
 
+    fn clearManagedProcesses(self: *Project, allocator: std.mem.Allocator) void {
+        for (self.managed_processes.items) |*process| {
+            self.terminateManagedProcessSession(process);
+            process.deinit(allocator);
+        }
+        self.managed_processes.clearRetainingCapacity();
+    }
+
+    fn terminateManagedProcessSession(self: *Project, process: *ManagedProcess) void {
+        const dock_id = process.dock_id orelse return;
+        const entry = self.terminalDockEntryById(dock_id) orelse return;
+        _ = entry.dock.terminateActiveSession();
+        process.status = .stopped;
+        process.explicit_stop = true;
+        process.next_restart_ms = 0;
+        process.pending_watch_restart_ms = 0;
+    }
+
     fn managedProcessByDockId(self: *Project, dock_id: u32) ?*ManagedProcess {
         for (self.managed_processes.items) |*process| {
             if (process.dock_id != null and process.dock_id.? == dock_id) return process;
@@ -2158,6 +2207,7 @@ pub const Project = struct {
         self.terminal_docks.deinit(allocator);
         for (self.managed_processes.items) |*process| process.deinit(allocator);
         self.managed_processes.deinit(allocator);
+        if (self.stack_config_error) |message| allocator.free(message);
         self.workspace_layout.deinit(allocator);
         for (self.threads.items) |*thread| {
             thread.deinit(allocator);
@@ -2214,6 +2264,16 @@ pub const Project = struct {
         }
 
         self.sidebar_thread_cache_dirty = false;
+    }
+
+    fn setStackConfigError(self: *Project, allocator: std.mem.Allocator, message: []const u8) void {
+        if (self.stack_config_error) |existing| allocator.free(existing);
+        self.stack_config_error = allocator.dupe(u8, message) catch null;
+    }
+
+    fn clearStackConfigError(self: *Project, allocator: std.mem.Allocator) void {
+        if (self.stack_config_error) |existing| allocator.free(existing);
+        self.stack_config_error = null;
     }
 };
 
@@ -6803,8 +6863,29 @@ pub const AppState = struct {
         if (project_index >= self.projects.items.len) return;
         var project = &self.projects.items[project_index];
         project.last_stack_config_refresh_ms = unixTimestampMs();
-        var loaded = try stack_config.loadFromProject(self.allocator, project.path) orelse return;
+        const maybe_loaded = stack_config.loadFromProject(self.allocator, project.path) catch |err| {
+            project.setStackConfigError(self.allocator, @errorName(err));
+            return err;
+        };
+        if (maybe_loaded == null) {
+            project.clearStackConfigError(self.allocator);
+            project.clearManagedProcesses(self.allocator);
+            return;
+        }
+        var loaded = maybe_loaded.?;
         defer loaded.deinit(self.allocator);
+        project.clearStackConfigError(self.allocator);
+
+        var process_index: usize = 0;
+        while (process_index < project.managed_processes.items.len) {
+            if (stackDefinitionByName(&loaded, project.managed_processes.items[process_index].name) != null) {
+                process_index += 1;
+                continue;
+            }
+            var removed = project.managed_processes.orderedRemove(process_index);
+            project.terminateManagedProcessSession(&removed);
+            removed.deinit(self.allocator);
+        }
 
         for (loaded.processes.items) |definition| {
             if (project.managedProcessByName(definition.name)) |process| {
@@ -6814,6 +6895,13 @@ pub const AppState = struct {
             }
         }
         self.refreshManagedProcessStatuses(project_index);
+    }
+
+    fn stackDefinitionByName(config: *const stack_config.Config, name: []const u8) ?*const stack_config.ProcessDefinition {
+        for (config.processes.items) |*definition| {
+            if (std.mem.eql(u8, definition.name, name)) return definition;
+        }
+        return null;
     }
 
     pub fn refreshManagedProcessStatuses(self: *AppState, project_index: usize) void {
@@ -6857,6 +6945,15 @@ pub const AppState = struct {
 
         for (self.projects.items[project_index].managed_processes.items) |*process| {
             if (process.explicit_stop) continue;
+            if (process.watch.items.len > 0 and process.status == .running) {
+                self.pollManagedProcessWatch(project_index, process, now);
+            }
+            if (process.pending_watch_restart_ms != 0 and now >= process.pending_watch_restart_ms) {
+                restart_names.append(self.allocator, self.allocator.dupe(u8, process.name) catch continue) catch continue;
+                process.pending_watch_restart_ms = 0;
+                process.status = .restarting;
+                continue;
+            }
             const should_restart_crash = process.status == .crashed and process.restart == .on_crash;
             const should_restart_always = process.status != .running and process.restart == .always and process.last_start_ms != 0;
             if (!should_restart_crash and !should_restart_always) continue;
@@ -6904,6 +7001,7 @@ pub const AppState = struct {
         process.last_start_ms = unixTimestampMs();
         process.last_exit_ms = 0;
         process.next_restart_ms = 0;
+        process.pending_watch_restart_ms = 0;
         process.explicit_stop = false;
         process.pane_id = try project.workspace_layout.ensureTerminalPane(self.allocator, dock_id);
         project.workspace_layout.maximized_pane_id = null;
@@ -6921,6 +7019,7 @@ pub const AppState = struct {
         process.status = .stopped;
         process.last_exit_ms = unixTimestampMs();
         process.next_restart_ms = 0;
+        process.pending_watch_restart_ms = 0;
         if (process.dock_id) |dock_id| {
             if (self.projectTerminalDockMutable(project_index, dock_id)) |dock| {
                 _ = dock.terminateActiveSession();
@@ -6998,6 +7097,120 @@ pub const AppState = struct {
         return self.projects.items[project_index].managedProcessByName(name);
     }
 
+    pub fn focusManagedProcessTerminal(self: *AppState, project_index: usize, name: []const u8) !bool {
+        try self.refreshProjectStackConfig(project_index);
+        if (project_index >= self.projects.items.len) return false;
+        self.selected_project_index = project_index;
+        const process = self.projects.items[project_index].managedProcessByName(name) orelse return false;
+        if (process.pane_id) |pane_id| {
+            _ = self.focusCurrentProjectWorkspacePane(pane_id);
+            if (process.dock_id) |dock_id| self.requestTerminalDockFocus(dock_id);
+            return true;
+        }
+        if (process.dock_id) |dock_id| {
+            process.pane_id = try self.projects.items[project_index].workspace_layout.ensureTerminalPane(self.allocator, dock_id);
+            _ = self.focusCurrentProjectWorkspacePane(process.pane_id.?);
+            self.requestTerminalDockFocus(dock_id);
+            self.markDirty();
+            return true;
+        }
+        return false;
+    }
+
+    fn handleWorkspaceCommand(self: *AppState, raw_text: []const u8) bool {
+        const text = std.mem.trim(u8, raw_text, " \t\r\n");
+        if (!std.mem.startsWith(u8, text, "/")) return false;
+        var parts = std.mem.tokenizeAny(u8, text, " \t\r\n");
+        const root = parts.next() orelse return false;
+        if (!std.mem.eql(u8, root, "/stack") and !std.mem.eql(u8, root, "/process")) return false;
+        const action = parts.next() orelse {
+            self.setSidebarNotice(if (std.mem.eql(u8, root, "/stack")) "Usage: /stack start|stop|restart|status" else "Usage: /process start|stop|restart|focus|crashed <name>");
+            return true;
+        };
+        const project_index = self.selected_project_index;
+        if (std.mem.eql(u8, root, "/stack")) {
+            if (std.mem.eql(u8, action, "status")) {
+                self.refreshProjectStackConfig(project_index) catch |err| {
+                    self.setSidebarNotice(@errorName(err));
+                    return true;
+                };
+                self.refreshManagedProcessStatuses(project_index);
+                const count: usize = self.projects.items[project_index].managed_processes.items.len;
+                self.clearDraft();
+                self.syncPaletteComposerFromDraft();
+                var buffer: [96]u8 = undefined;
+                self.setSidebarNotice(std.fmt.bufPrint(&buffer, "Stack has {d} configured process(es).", .{count}) catch "Stack status updated.");
+                return true;
+            }
+            const result = if (std.mem.eql(u8, action, "start"))
+                self.startProjectStack(project_index)
+            else if (std.mem.eql(u8, action, "stop"))
+                self.stopProjectStack(project_index)
+            else if (std.mem.eql(u8, action, "restart"))
+                self.restartProjectStack(project_index)
+            else {
+                self.setSidebarNotice("Usage: /stack start|stop|restart|status");
+                return true;
+            };
+            const count = result catch |err| {
+                self.setSidebarNotice(@errorName(err));
+                return true;
+            };
+            self.clearDraft();
+            self.syncPaletteComposerFromDraft();
+            var buffer: [96]u8 = undefined;
+            self.setSidebarNotice(std.fmt.bufPrint(&buffer, "Stack {s}: {d} process(es).", .{ action, count }) catch "Stack command applied.");
+            return true;
+        }
+
+        if (std.mem.eql(u8, action, "crashed")) {
+            self.refreshProjectStackConfig(project_index) catch |err| {
+                self.setSidebarNotice(@errorName(err));
+                return true;
+            };
+            self.refreshManagedProcessStatuses(project_index);
+            var crashed: usize = 0;
+            for (self.projects.items[project_index].managed_processes.items) |process| {
+                if (process.status == .crashed) crashed += 1;
+            }
+            self.clearDraft();
+            self.syncPaletteComposerFromDraft();
+            var buffer: [96]u8 = undefined;
+            self.setSidebarNotice(std.fmt.bufPrint(&buffer, "{d} crashed process(es).", .{crashed}) catch "Crashed process status updated.");
+            return true;
+        }
+
+        const name = parts.next() orelse {
+            self.setSidebarNotice("Usage: /process start|stop|restart|focus <name>");
+            return true;
+        };
+        const changed = if (std.mem.eql(u8, action, "start"))
+            self.startManagedProcess(project_index, name)
+        else if (std.mem.eql(u8, action, "stop"))
+            self.stopManagedProcess(project_index, name)
+        else if (std.mem.eql(u8, action, "restart"))
+            self.restartManagedProcess(project_index, name)
+        else if (std.mem.eql(u8, action, "focus"))
+            self.focusManagedProcessTerminal(project_index, name)
+        else {
+            self.setSidebarNotice("Usage: /process start|stop|restart|focus|crashed <name>");
+            return true;
+        };
+        const changed_result = changed catch |err| {
+            self.setSidebarNotice(@errorName(err));
+            return true;
+        };
+        if (!changed_result) {
+            self.setSidebarNotice("Process not found.");
+            return true;
+        }
+        self.clearDraft();
+        self.syncPaletteComposerFromDraft();
+        var buffer: [128]u8 = undefined;
+        self.setSidebarNotice(std.fmt.bufPrint(&buffer, "Process {s}: {s}.", .{ action, name }) catch "Process command applied.");
+        return true;
+    }
+
     fn resolveManagedProcessCwd(self: *AppState, project_path: []const u8, raw_cwd: []const u8) ![]u8 {
         if (raw_cwd.len == 0 or std.mem.eql(u8, raw_cwd, ".")) return self.allocator.dupe(u8, project_path);
         if (std.fs.path.isAbsolute(raw_cwd)) return self.allocator.dupe(u8, raw_cwd);
@@ -7008,6 +7221,101 @@ pub const AppState = struct {
         const capped_shift: u6 = @intCast(@min(restart_count, 5));
         const backoff = MANAGED_PROCESS_BASE_RESTART_BACKOFF_MS * (@as(i64, 1) << capped_shift);
         return @min(backoff, MANAGED_PROCESS_MAX_RESTART_BACKOFF_MS);
+    }
+
+    fn pollManagedProcessWatch(self: *AppState, project_index: usize, process: *ManagedProcess, now: i64) void {
+        if (now - process.last_watch_scan_ms < MANAGED_PROCESS_WATCH_SCAN_MS) return;
+        process.last_watch_scan_ms = now;
+        const project = &self.projects.items[project_index];
+        const signature = self.scanManagedProcessWatchSignature(project.path, process.watch.items) catch |err| {
+            process.watch_error_count += 1;
+            log.warn("failed to scan watch patterns for managed process {s}: {s}", .{ process.name, @errorName(err) });
+            return;
+        };
+        if (!process.watch_ready or process.watch_signature == 0) {
+            process.watch_signature = signature;
+            process.watch_ready = true;
+            return;
+        }
+        if (process.watch_signature == signature) return;
+        process.watch_signature = signature;
+        process.last_watch_change_ms = now;
+        process.pending_watch_restart_ms = now + MANAGED_PROCESS_WATCH_DEBOUNCE_MS;
+        process.watch_trigger_count += 1;
+        process.status = .restarting;
+    }
+
+    fn scanManagedProcessWatchSignature(self: *AppState, project_path: []const u8, patterns: []const []u8) !u64 {
+        var hasher = std.hash.Wyhash.init(0);
+        hashBytes(&hasher, "verde-watch-v1");
+        for (patterns) |pattern| hashBytes(&hasher, pattern);
+
+        var threaded = std.Io.Threaded.init_single_threaded;
+        var dir = try std.Io.Dir.openDirAbsolute(threaded.io(), project_path, .{ .iterate = true });
+        defer dir.close(threaded.io());
+        var walker = try dir.walk(self.allocator);
+        defer walker.deinit();
+
+        while (try walker.next(threaded.io())) |entry| {
+            if (entry.kind == .directory and shouldSkipManagedWatchDirectory(entry.basename)) {
+                walker.leave(threaded.io());
+                continue;
+            }
+            const rel_path = std.mem.sliceTo(entry.path, 0);
+            if (!managedWatchPathMatches(patterns, rel_path)) continue;
+            const stat = entry.dir.statFile(threaded.io(), entry.basename, .{}) catch continue;
+            hashBytes(&hasher, rel_path);
+            hashU64(&hasher, @intFromEnum(stat.kind));
+            hashU64(&hasher, stat.size);
+            const mtime_ns: i128 = stat.mtime.nanoseconds;
+            hashBytes(&hasher, std.mem.asBytes(&mtime_ns));
+        }
+        return hasher.final();
+    }
+
+    fn shouldSkipManagedWatchDirectory(name: []const u8) bool {
+        return std.mem.eql(u8, name, ".git") or
+            std.mem.eql(u8, name, ".zig-cache") or
+            std.mem.eql(u8, name, "zig-out") or
+            std.mem.eql(u8, name, "node_modules");
+    }
+
+    fn managedWatchPathMatches(patterns: []const []u8, path: []const u8) bool {
+        for (patterns) |pattern| {
+            if (globMatch(pattern, path)) return true;
+        }
+        return false;
+    }
+
+    fn globMatch(pattern: []const u8, path: []const u8) bool {
+        if (pattern.len == 0) return path.len == 0;
+        if (pattern[0] == '*') {
+            const deep = pattern.len >= 2 and pattern[1] == '*';
+            const rest = if (deep) pattern[2..] else pattern[1..];
+            var index: usize = 0;
+            while (index <= path.len) : (index += 1) {
+                if (!deep and index > 0 and path[index - 1] == '/') break;
+                if (globMatch(rest, path[index..])) return true;
+            }
+            return false;
+        }
+        if (path.len == 0) return false;
+        if (pattern[0] == '?') {
+            if (path[0] == '/') return false;
+            return globMatch(pattern[1..], path[1..]);
+        }
+        if (pattern[0] != path[0]) return false;
+        return globMatch(pattern[1..], path[1..]);
+    }
+
+    fn hashBytes(hasher: *std.hash.Wyhash, bytes: []const u8) void {
+        hasher.update(bytes);
+        hashU64(hasher, bytes.len);
+    }
+
+    fn hashU64(hasher: *std.hash.Wyhash, value: u64) void {
+        var copy = value;
+        hasher.update(std.mem.asBytes(&copy));
     }
 
     fn selectWorkspaceChatPaneThread(self: *AppState, pane_id: WorkspacePaneId) bool {

--- a/packages/desktop/src/terminal/terminal.zig
+++ b/packages/desktop/src/terminal/terminal.zig
@@ -25,6 +25,7 @@ const MAX_FONT_SCALE: f32 = 3.3333333;
 const FONT_SCALE_STEP: f32 = 0.125;
 const WHEEL_SCROLL_LINES: f32 = 3.0;
 const KEY_SCROLL_LINES: isize = 3;
+const OUTPUT_RING_CAPACITY: usize = 256 * 1024;
 pub const DEFAULT_FONT_SIZE: f32 = @floatFromInt(CELL_PIXEL_HEIGHT);
 // Darwin exposes the winsize setter under the BSD ioctl value, not std.c.T.IOCSWINSZ.
 const TERMINAL_WINSIZE_IOCTL: c_int = switch (builtin.os.tag) {
@@ -72,6 +73,12 @@ pub const TerminalLaunchProfile = struct {
     kind: TerminalLaunchKind = .shell,
     label: []const u8 = "",
     command: []const []const u8 = &.{},
+};
+
+pub const SessionSnapshot = struct {
+    running: bool,
+    exit_code: ?u32 = null,
+    signal: ?u32 = null,
 };
 
 const SessionCreateOptions = struct {
@@ -228,6 +235,22 @@ pub const Dock = struct {
         try self.ensureWorkspace(allocator);
     }
 
+    pub fn restartWithProfile(self: *Dock, allocator: std.mem.Allocator, cwd: []const u8, profile: TerminalLaunchProfile) !void {
+        if (self.cwd) |old_cwd| allocator.free(old_cwd);
+        self.cwd = try allocator.dupe(u8, cwd);
+        self.clearTabs(allocator);
+
+        const previous_profile = self.launch_profile;
+        self.launch_profile = profile;
+        defer self.launch_profile = previous_profile;
+
+        try self.tabs.append(allocator, try self.buildSinglePaneTab(allocator));
+        self.active_tab_index = self.tabs.items.len - 1;
+        self.visible = true;
+        self.workspace_changed = true;
+        self.focus_requested = true;
+    }
+
     pub fn poll(self: *Dock, allocator: std.mem.Allocator) !void {
         for (self.tabs.items) |*tab| {
             try pollPaneNode(tab.root, allocator);
@@ -296,6 +319,37 @@ pub const Dock = struct {
             }
         }
         return false;
+    }
+
+    pub fn writeInputToActivePane(self: *Dock, bytes: []const u8) !bool {
+        if (bytes.len == 0) return false;
+        const pane = self.activePane() orelse return false;
+        const session = pane.session orelse return false;
+        return try session.writeInput(bytes);
+    }
+
+    pub fn terminateActiveSession(self: *Dock) bool {
+        const pane = self.activePane() orelse return false;
+        const session = pane.session orelse return false;
+        return session.terminate();
+    }
+
+    pub fn activeSessionSnapshot(self: *const Dock) ?SessionSnapshot {
+        const pane = self.activePaneConst() orelse return null;
+        const session = pane.session orelse return null;
+        return session.snapshot();
+    }
+
+    pub fn activeOutputTailAlloc(self: *const Dock, allocator: std.mem.Allocator, max_bytes: usize) !?[]u8 {
+        const pane = self.activePaneConst() orelse return null;
+        const session = pane.session orelse return null;
+        return try session.outputTailAlloc(allocator, max_bytes);
+    }
+
+    pub fn activeScreenTextAlloc(self: *const Dock, allocator: std.mem.Allocator) !?[]u8 {
+        const pane = self.activePaneConst() orelse return null;
+        const session = pane.session orelse return null;
+        return try session.screenTextAlloc(allocator);
     }
 
     pub fn handleKeyDown(
@@ -1085,8 +1139,24 @@ const UnsupportedSession = struct {
         return false;
     }
 
+    pub fn snapshot(_: *const UnsupportedSession) SessionSnapshot {
+        return .{ .running = false };
+    }
+
     pub fn writeInput(_: *UnsupportedSession, _: []const u8) !bool {
         return false;
+    }
+
+    pub fn terminate(_: *UnsupportedSession) bool {
+        return false;
+    }
+
+    pub fn outputTailAlloc(_: *const UnsupportedSession, allocator: std.mem.Allocator, _: usize) ![]u8 {
+        return allocator.dupe(u8, "");
+    }
+
+    pub fn screenTextAlloc(_: *const UnsupportedSession, allocator: std.mem.Allocator) ![]u8 {
+        return allocator.dupe(u8, "");
     }
 
     pub fn handleKeyDown(_: *UnsupportedSession, _: *const sdl.KeyboardEvent) !bool {
@@ -1128,6 +1198,7 @@ const UnixSession = struct {
     exit_status: ?u32 = null,
     launch_kind: TerminalLaunchKind = .shell,
     launch_label: []u8,
+    output_ring: std.ArrayList(u8) = .empty,
 
     const SpawnResult = struct {
         master_fd: std.posix.fd_t,
@@ -1197,6 +1268,7 @@ const UnixSession = struct {
         self.render_state.deinit(allocator);
         self.terminal.deinit(allocator);
         allocator.free(self.launch_label);
+        self.output_ring.deinit(allocator);
     }
 
     pub fn poll(self: *UnixSession, allocator: std.mem.Allocator) !void {
@@ -1280,10 +1352,39 @@ const UnixSession = struct {
         return self.running;
     }
 
+    pub fn snapshot(self: *const UnixSession) SessionSnapshot {
+        if (self.running) return .{ .running = true };
+        const status = self.exit_status orelse return .{ .running = false };
+        if (std.c.W.IFEXITED(status)) {
+            return .{ .running = false, .exit_code = @intCast(std.c.W.EXITSTATUS(status)) };
+        }
+        if (std.c.W.IFSIGNALED(status)) {
+            return .{ .running = false, .signal = @intFromEnum(std.c.W.TERMSIG(status)) };
+        }
+        return .{ .running = false };
+    }
+
     pub fn writeInput(self: *UnixSession, bytes: []const u8) !bool {
         if (!self.running or bytes.len == 0) return false;
         try writeAll(self.master_fd, bytes);
         return true;
+    }
+
+    pub fn terminate(self: *UnixSession) bool {
+        if (!self.running) return false;
+        std.posix.kill(self.child_pid, std.posix.SIG.TERM) catch return false;
+        self.running = false;
+        _ = self.captureExitStatus();
+        return true;
+    }
+
+    pub fn outputTailAlloc(self: *const UnixSession, allocator: std.mem.Allocator, max_bytes: usize) ![]u8 {
+        const count = @min(max_bytes, self.output_ring.items.len);
+        return allocator.dupe(u8, self.output_ring.items[self.output_ring.items.len - count ..]);
+    }
+
+    pub fn screenTextAlloc(self: *const UnixSession, allocator: std.mem.Allocator) ![]u8 {
+        return copyableRenderStateText(allocator, &self.render_state);
     }
 
     pub fn handleKeyDown(self: *UnixSession, event: *const sdl.KeyboardEvent) !bool {
@@ -1379,12 +1480,30 @@ const UnixSession = struct {
                 break;
             }
 
+            try self.appendOutput(allocator, buffer[0..read_len]);
             self.stream.nextSlice(buffer[0..read_len]);
             try self.repairTerminalState(allocator);
             changed = true;
         }
 
         return changed;
+    }
+
+    fn appendOutput(self: *UnixSession, allocator: std.mem.Allocator, bytes: []const u8) !void {
+        if (bytes.len >= OUTPUT_RING_CAPACITY) {
+            self.output_ring.clearRetainingCapacity();
+            try self.output_ring.appendSlice(allocator, bytes[bytes.len - OUTPUT_RING_CAPACITY ..]);
+            return;
+        }
+        const overflow = if (self.output_ring.items.len + bytes.len > OUTPUT_RING_CAPACITY)
+            self.output_ring.items.len + bytes.len - OUTPUT_RING_CAPACITY
+        else
+            0;
+        if (overflow > 0) {
+            std.mem.copyForwards(u8, self.output_ring.items[0 .. self.output_ring.items.len - overflow], self.output_ring.items[overflow..]);
+            self.output_ring.shrinkRetainingCapacity(self.output_ring.items.len - overflow);
+        }
+        try self.output_ring.appendSlice(allocator, bytes);
     }
 
     fn repairTerminalState(self: *UnixSession, allocator: std.mem.Allocator) !void {

--- a/packages/desktop/src/ui/chat_panel.zig
+++ b/packages/desktop/src/ui/chat_panel.zig
@@ -95,6 +95,23 @@ const WorkspaceHeaderHitCache = struct {
 
 var workspace_header_hits: WorkspaceHeaderHitCache = .{};
 
+const ProcessDashboardAction = enum {
+    start,
+    stop,
+    restart,
+    focus,
+};
+
+const ProcessDashboardHit = struct {
+    rect: palette.Rect = .{},
+    process_index: usize = 0,
+    action: ProcessDashboardAction = .focus,
+};
+
+const MAX_PROCESS_DASHBOARD_HITS = 64;
+var process_dashboard_hit_count: usize = 0;
+var process_dashboard_hits: [MAX_PROCESS_DASHBOARD_HITS]ProcessDashboardHit = [_]ProcessDashboardHit{.{}} ** MAX_PROCESS_DASHBOARD_HITS;
+
 pub fn renderWorkspace(state: *app_state.AppState, width: f32, height: f32) void {
     renderWorkspaceAt(state, .{ .x = estimateWorkspaceOriginX(state, width), .y = 0.0, .w = width, .h = height });
 }
@@ -135,6 +152,7 @@ pub fn renderWorkspaceAtForPaneWithReserve(state: *app_state.AppState, rect: pal
 
     state.invalidateComposerToolbarOverlayHitRects();
     file_search_hits = .{};
+    process_dashboard_hit_count = 0;
     if (pane_id == null) transcript_hit_count = 0;
     queueRect(state, rect, paletteColor(colors.CHAT_BLACK));
     if (state.projects.items.len == 0) {
@@ -257,6 +275,29 @@ fn estimateWorkspaceOriginX(state: *app_state.AppState, workspace_width: f32) f3
 pub fn handleWorkspaceHeaderPaletteMouseButton(state: *app_state.AppState, x: f32, y: f32, down: bool) bool {
     if (!down) return false;
     if (state.projects.items.len == 0) return false;
+
+    var process_hit_index: usize = 0;
+    while (process_hit_index < process_dashboard_hit_count) : (process_hit_index += 1) {
+        const hit = process_dashboard_hits[process_hit_index];
+        if (!rectContains(hit.rect, x, y)) continue;
+        if (hit.process_index >= state.currentProject().managed_processes.items.len) return true;
+        const name = state.currentProject().managed_processes.items[hit.process_index].name;
+        const project_index = state.selected_project_index;
+        const applied = switch (hit.action) {
+            .start => state.startManagedProcess(project_index, name),
+            .stop => state.stopManagedProcess(project_index, name),
+            .restart => state.restartManagedProcess(project_index, name),
+            .focus => state.focusManagedProcessTerminal(project_index, name),
+        } catch |err| {
+            state.setSidebarNotice(@errorName(err));
+            return true;
+        };
+        if (!applied) state.setSidebarNotice("Process not found.");
+        state.workspace_header_open_menu_open = false;
+        state.blurPaletteComposer();
+        state.noteInteraction();
+        return true;
+    }
 
     if (state.workspace_header_open_menu_open and rectContains(workspace_header_hits.menu_panel_rect, x, y)) {
         var i: usize = 0;
@@ -1178,7 +1219,7 @@ fn renderProcessDashboard(state: *app_state.AppState, rect: palette.Rect) void {
     var x = rect.x + theme.scaledUi(76.0);
     const row_y = rect.y + theme.scaledUi(7.0);
     const max_items = @min(project.managed_processes.items.len, 5);
-    for (project.managed_processes.items[0..max_items]) |process| {
+    for (project.managed_processes.items[0..max_items], 0..) |process, process_index| {
         const item_w = theme.clampf(rect.w * 0.18, theme.scaledUi(120.0), theme.scaledUi(190.0));
         if (x + item_w > rect.x + rect.w - theme.scaledUi(8.0)) break;
         const item = palette.Rect{ .x = x, .y = row_y, .w = item_w, .h = rect.h - theme.scaledUi(14.0) };
@@ -1188,7 +1229,7 @@ fn renderProcessDashboard(state: *app_state.AppState, rect: palette.Rect) void {
         queueChromeLabel(state, .{
             .x = item.x + theme.scaledUi(24.0),
             .y = item.y + theme.scaledUi(5.0),
-            .w = item.w - theme.scaledUi(30.0),
+            .w = @max(item.w - theme.scaledUi(108.0), theme.scaledUi(44.0)),
             .h = theme.scaledUi(18.0),
         }, process.name, paletteColor(theme.COLOR_WHITE), theme.scaledUi(12.0), clip);
         var detail_buffer: [96]u8 = undefined;
@@ -1196,9 +1237,23 @@ fn renderProcessDashboard(state: *app_state.AppState, rect: palette.Rect) void {
         queueChromeLabel(state, .{
             .x = item.x + theme.scaledUi(24.0),
             .y = item.y + theme.scaledUi(23.0),
-            .w = item.w - theme.scaledUi(30.0),
+            .w = @max(item.w - theme.scaledUi(108.0), theme.scaledUi(44.0)),
             .h = theme.scaledUi(16.0),
         }, detail, paletteColor(theme.COLOR_TEXT_MUTED), theme.scaledUi(11.0), clip);
+        const button_w = theme.scaledUi(20.0);
+        const button_h = theme.scaledUi(20.0);
+        const button_gap = theme.scaledUi(4.0);
+        var bx = item.x + item.w - theme.scaledUi(10.0) - button_w;
+        const by = item.y + (item.h - button_h) * 0.5;
+        renderProcessDashboardButton(state, .{ .x = bx, .y = by, .w = button_w, .h = button_h }, ">", process_index, .focus, clip);
+        bx -= button_w + button_gap;
+        renderProcessDashboardButton(state, .{ .x = bx, .y = by, .w = button_w, .h = button_h }, "R", process_index, .restart, clip);
+        bx -= button_w + button_gap;
+        if (process.status == .running or process.status == .starting or process.status == .restarting) {
+            renderProcessDashboardButton(state, .{ .x = bx, .y = by, .w = button_w, .h = button_h }, "X", process_index, .stop, clip);
+        } else {
+            renderProcessDashboardButton(state, .{ .x = bx, .y = by, .w = button_w, .h = button_h }, "S", process_index, .start, clip);
+        }
         x += item_w + theme.scaledUi(8.0);
     }
 
@@ -1211,6 +1266,20 @@ fn renderProcessDashboard(state: *app_state.AppState, rect: palette.Rect) void {
             .w = theme.scaledUi(32.0),
             .h = theme.scaledUi(18.0),
         }, more, paletteColor(theme.COLOR_TEXT_MUTED), theme.scaledUi(12.0), clip);
+    }
+}
+
+fn renderProcessDashboardButton(state: *app_state.AppState, rect: palette.Rect, label: []const u8, process_index: usize, action: ProcessDashboardAction, clip: palette.Rect) void {
+    queueRounded(state, rect, paletteColor(colors.rgba(34, 43, 47, 230)), theme.scaledUi(4.0));
+    queueChromeLabel(state, .{
+        .x = rect.x,
+        .y = rect.y + theme.scaledUi(2.0),
+        .w = rect.w,
+        .h = rect.h - theme.scaledUi(4.0),
+    }, label, paletteColor(theme.COLOR_WHITE), theme.scaledUi(11.0), clip);
+    if (process_dashboard_hit_count < process_dashboard_hits.len) {
+        process_dashboard_hits[process_dashboard_hit_count] = .{ .rect = rect, .process_index = process_index, .action = action };
+        process_dashboard_hit_count += 1;
     }
 }
 

--- a/packages/desktop/src/ui/chat_panel.zig
+++ b/packages/desktop/src/ui/chat_panel.zig
@@ -176,11 +176,21 @@ pub fn renderWorkspaceAtForPaneWithReserve(state: *app_state.AppState, rect: pal
         .w = rect.w,
         .h = @max(composer_y - (header.y + header.h) - attachment_reserve, theme.scaledUi(120.0)),
     };
+    const process_strip_height = if (pane_id == null and state.currentProject().managed_processes.items.len > 0)
+        theme.scaledUi(52.0)
+    else
+        0.0;
+    const transcript_body = if (process_strip_height > 0.0) palette.Rect{
+        .x = body.x,
+        .y = body.y + process_strip_height,
+        .w = body.w,
+        .h = @max(body.h - process_strip_height, theme.scaledUi(96.0)),
+    } else body;
 
-    const split_chat_browser = state.isBrowserVisible() and body.w >= theme.scaledUi(900.0);
-    const browser_width = if (split_chat_browser) state.browserPanelWidth(body.w) else 0.0;
-    const composer_lane_w = if (split_chat_browser) body.w - browser_width else body.w;
-    const composer_lane_x = body.x;
+    const split_chat_browser = state.isBrowserVisible() and transcript_body.w >= theme.scaledUi(900.0);
+    const browser_width = if (split_chat_browser) state.browserPanelWidth(transcript_body.w) else 0.0;
+    const composer_lane_w = if (split_chat_browser) transcript_body.w - browser_width else transcript_body.w;
+    const composer_lane_x = transcript_body.x;
 
     const composer_width = @max(theme.scaledUi(220.0), @min(composer_lane_w - side_margin * 2.0, theme.scaledUi(980.0)));
     const composer_rect = palette.Rect{
@@ -191,19 +201,28 @@ pub fn renderWorkspaceAtForPaneWithReserve(state: *app_state.AppState, rect: pal
     };
 
     if (split_chat_browser) {
-        const chat_rect = palette.Rect{ .x = body.x, .y = body.y, .w = body.w - browser_width, .h = body.h };
+        const chat_rect = palette.Rect{ .x = transcript_body.x, .y = transcript_body.y, .w = transcript_body.w - browser_width, .h = transcript_body.h };
         renderTranscript(state, chat_rect, pane_id);
         // Transcript uses only `body` (above composer). The browser column is empty to the right of the
         // composer, so extend the dock through that strip to the same bottom as the composer row.
-        const browser_dock_h = composer_bottom - body.y;
+        const browser_dock_h = composer_bottom - transcript_body.y;
         browser_panel.renderDockAt(state, .{
             .x = chat_rect.x + chat_rect.w,
-            .y = body.y,
+            .y = transcript_body.y,
             .w = browser_width,
             .h = @max(browser_dock_h, theme.scaledUi(120.0)),
         });
     } else {
-        renderTranscript(state, body, pane_id);
+        renderTranscript(state, transcript_body, pane_id);
+    }
+
+    if (process_strip_height > 0.0) {
+        renderProcessDashboard(state, .{
+            .x = body.x + side_margin,
+            .y = body.y + theme.scaledUi(6.0),
+            .w = @max(body.w - side_margin * 2.0, theme.scaledUi(220.0)),
+            .h = process_strip_height - theme.scaledUi(10.0),
+        });
     }
 
     // Paint after the transcript so the opaque header strip wins over any scrolled
@@ -1140,6 +1159,68 @@ fn renderEmptyProjects(state: *app_state.AppState, rect: palette.Rect) void {
     queueText(state, .{ .x = x, .y = y, .w = rect.w - theme.scaledUi(88.0), .h = theme.scaledUi(38.0) }, "No projects yet", paletteColor(theme.COLOR_WHITE), theme.scaledUi(28.0), rect);
     y += theme.scaledUi(42.0);
     queueText(state, .{ .x = x, .y = y, .w = rect.w - theme.scaledUi(88.0), .h = theme.scaledUi(28.0) }, "Use the project rail to add a folder and start chatting.", paletteColor(theme.COLOR_TEXT_MUTED), theme.scaledUi(16.0), rect);
+}
+
+fn renderProcessDashboard(state: *app_state.AppState, rect: palette.Rect) void {
+    if (state.projects.items.len == 0) return;
+    const project = state.currentProject();
+    if (project.managed_processes.items.len == 0) return;
+
+    const clip = snapRect(rect);
+    queuePanel(state, rect, paletteColor(colors.rgba(20, 28, 30, 232)), paletteColor(colors.rgba(64, 78, 84, 180)), theme.scaledUi(6.0), theme.scaledUi(1.0));
+    queueChromeLabel(state, .{
+        .x = rect.x + theme.scaledUi(12.0),
+        .y = rect.y + theme.scaledUi(10.0),
+        .w = theme.scaledUi(92.0),
+        .h = theme.scaledUi(22.0),
+    }, "Stack", paletteColor(theme.COLOR_TEXT_SUBTLE), theme.scaledUi(13.0), clip);
+
+    var x = rect.x + theme.scaledUi(76.0);
+    const row_y = rect.y + theme.scaledUi(7.0);
+    const max_items = @min(project.managed_processes.items.len, 5);
+    for (project.managed_processes.items[0..max_items]) |process| {
+        const item_w = theme.clampf(rect.w * 0.18, theme.scaledUi(120.0), theme.scaledUi(190.0));
+        if (x + item_w > rect.x + rect.w - theme.scaledUi(8.0)) break;
+        const item = palette.Rect{ .x = x, .y = row_y, .w = item_w, .h = rect.h - theme.scaledUi(14.0) };
+        queueRounded(state, item, paletteColor(colors.rgba(13, 18, 19, 210)), theme.scaledUi(5.0));
+        const dot = palette.Rect{ .x = item.x + theme.scaledUi(9.0), .y = item.y + theme.scaledUi(12.0), .w = theme.scaledUi(8.0), .h = theme.scaledUi(8.0) };
+        queueRounded(state, dot, managedProcessStatusColor(process.status), theme.scaledUi(4.0));
+        queueChromeLabel(state, .{
+            .x = item.x + theme.scaledUi(24.0),
+            .y = item.y + theme.scaledUi(5.0),
+            .w = item.w - theme.scaledUi(30.0),
+            .h = theme.scaledUi(18.0),
+        }, process.name, paletteColor(theme.COLOR_WHITE), theme.scaledUi(12.0), clip);
+        var detail_buffer: [96]u8 = undefined;
+        const detail = std.fmt.bufPrint(&detail_buffer, "{s} · {s}", .{ @tagName(process.kind), @tagName(process.status) }) catch @tagName(process.status);
+        queueChromeLabel(state, .{
+            .x = item.x + theme.scaledUi(24.0),
+            .y = item.y + theme.scaledUi(23.0),
+            .w = item.w - theme.scaledUi(30.0),
+            .h = theme.scaledUi(16.0),
+        }, detail, paletteColor(theme.COLOR_TEXT_MUTED), theme.scaledUi(11.0), clip);
+        x += item_w + theme.scaledUi(8.0);
+    }
+
+    if (project.managed_processes.items.len > max_items) {
+        var more_buffer: [32]u8 = undefined;
+        const more = std.fmt.bufPrint(&more_buffer, "+{d}", .{project.managed_processes.items.len - max_items}) catch "+";
+        queueChromeLabel(state, .{
+            .x = rect.x + rect.w - theme.scaledUi(42.0),
+            .y = rect.y + theme.scaledUi(15.0),
+            .w = theme.scaledUi(32.0),
+            .h = theme.scaledUi(18.0),
+        }, more, paletteColor(theme.COLOR_TEXT_MUTED), theme.scaledUi(12.0), clip);
+    }
+}
+
+fn managedProcessStatusColor(status: app_state.ManagedProcessStatus) palette.Color {
+    return paletteColor(switch (status) {
+        .running => colors.rgba(80, 200, 120, 255),
+        .starting, .restarting => colors.rgba(236, 178, 70, 255),
+        .crashed => colors.rgba(228, 84, 84, 255),
+        .stopped => colors.rgba(125, 139, 145, 255),
+    });
 }
 
 /// While the current thread is streaming, keep `transcript_auto_follow_pending` on when the viewport


### PR DESCRIPTION
## Summary
- add Verde live managed stack/process control and MCP process tools
- add shell completion generation for bash, zsh, and fish
- document live-control and completion usage for users and agents

## Verification
- mise run build
- verde completion bash/zsh/fish smoke checks
- live CLI managed process smoke checks earlier on this branch