### PR TITLE
Refine terminal pane scroll and close keybind

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,8 @@ Example config:
       "focus_left": ["Alt+Left", "Ctrl+H"],
       "focus_right": ["Alt+Right", "Ctrl+L"],
       "toggle_maximize": "CommandOrControl+Alt+M",
-      "minimize": "CommandOrControl+Alt+Minus"
+      "minimize": "CommandOrControl+Alt+Minus",
+      "close": ["CommandOrControl+W", "Alt+X"]
     },
     "terminal": {
       "toggle": null,

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -109,7 +109,8 @@ Config supports UI and terminal font size, keybind overrides, and the default ac
       "focus_up": ["Alt+Up", "Ctrl+K"],
       "focus_down": ["Alt+Down", "Ctrl+J"],
       "focus_left": ["Alt+Left", "Ctrl+H"],
-      "focus_right": ["Alt+Right", "Ctrl+L"]
+      "focus_right": ["Alt+Right", "Ctrl+L"],
+      "close": ["CommandOrControl+W", "Alt+X"]
     },
     "terminal": {
       "toggle": null,

--- a/packages/desktop/src/keybinds.zig
+++ b/packages/desktop/src/keybinds.zig
@@ -752,6 +752,7 @@ fn cloneDefaultNewThreadKeybinds(allocator: std.mem.Allocator) ![]Keybind {
 fn cloneDefaultWorkspaceCloseKeybinds(allocator: std.mem.Allocator) ![]Keybind {
     return allocator.dupe(Keybind, &.{
         try parseDefaultAccelerator("CommandOrControl+W"),
+        try parseDefaultAccelerator("Alt+X"),
     });
 }
 
@@ -1358,6 +1359,17 @@ test "default terminal internal split keybinds are disabled" {
     try std.testing.expectEqual(@as(usize, 0), config.terminal_split_down.len);
     try std.testing.expectEqual(@as(usize, 0), config.terminal_split_left.len);
     try std.testing.expectEqual(@as(usize, 0), config.terminal_split_right.len);
+}
+
+test "default workspace close supports primary w and alt x" {
+    var config = try NativeKeyboardConfig.load(std.testing.allocator);
+    defer config.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), config.workspace_close.len);
+    try std.testing.expect(config.workspace_close[0].primary);
+    try std.testing.expectEqual(sdl.Keycode.w, config.workspace_close[0].key);
+    try std.testing.expect(config.workspace_close[1].alt);
+    try std.testing.expectEqual(sdl.Keycode.x, config.workspace_close[1].key);
 }
 
 test "default workspace focus supports alt arrows and ctrl hjkl" {

--- a/packages/desktop/src/main.zig
+++ b/packages/desktop/src/main.zig
@@ -1117,6 +1117,11 @@ fn handleEvent(window: *sdl.Window, state: *AppState, keyboard: *keybinds.Native
             if (sidebar_ui.handlePaletteWheel(event.wheel.mouse_x, event.wheel.mouse_y, event.wheel.y)) {
                 return true;
             }
+            // Terminal panes route wheel input by the event coordinates, so let
+            // them claim scroll before chat/composer hit caches can consume it.
+            if (terminal_panel_ui.handlePaletteWheel(state, event.wheel.mouse_x, event.wheel.mouse_y, event.wheel.y)) {
+                return true;
+            }
             if (chat_panel_ui.handleTranscriptPaletteWheel(state, event.wheel.mouse_x, event.wheel.mouse_y, event.wheel.y)) {
                 return true;
             }
@@ -1124,9 +1129,6 @@ fn handleEvent(window: *sdl.Window, state: *AppState, keyboard: *keybinds.Native
                 return true;
             }
             if (state.handleComposerWheel(&event.wheel)) {
-                return true;
-            }
-            if (terminal_panel_ui.handlePaletteWheel(state, event.wheel.mouse_x, event.wheel.mouse_y, event.wheel.y)) {
                 return true;
             }
             if (state.handleBrowserMouse(browserMouseWheelEvent(&event.wheel))) {


### PR DESCRIPTION
## Summary
- add Alt+X as a configurable default close-pane keybind
- route terminal pane mouse wheel events before chat/composer hit caches so terminal scroll follows the pointer more consistently
- document the updated workspace close keybind defaults

## Validation
- zig fmt packages/desktop/src/main.zig packages/desktop/src/keybinds.zig
- git diff --check
- zig build -Doptimize=ReleaseSafe