### PR TITLE
Use Cursor ACP and bundle provider bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Verde talks to provider runtimes on your machine rather than bundling its own ho
 - Codex: install [Codex CLI](https://github.com/openai/codex) and run `codex login`.
 - Claude Code: install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and log in on your machine. Verde uses Anthropic's Claude Agent SDK to talk to the local Claude Code runtime.
 - OpenCode: install [OpenCode](https://github.com/anomalyco/opencode) and make sure `opencode` is on your `PATH`.
-- Cursor: set `CURSOR_API_KEY` in the environment used to launch Verde. The Cursor provider uses `@cursor/sdk`, which requires this API key.
+- Cursor: install the [Cursor CLI](https://cursor.com/docs/cli/installation), make sure `agent` is on your `PATH`, and run `agent login`. `CURSOR_API_KEY` is also supported for headless environments.
 
 Cursor example:
 
 ```bash
-export CURSOR_API_KEY=...
+agent login
 verde
 ```
 
@@ -332,7 +332,7 @@ verde live process inspect --focused [--json]
 - Codex threads use the local `codex` CLI and start `codex app-server` automatically when needed.
 - Claude Code threads use Anthropic's Claude Agent SDK and require Claude Code to be installed and logged in locally.
 - OpenCode threads use the local `opencode` CLI and can start `opencode serve` automatically when needed.
-- Cursor threads use `@cursor/sdk` and require `CURSOR_API_KEY`.
+- Cursor threads use the local Cursor CLI ACP server (`agent acp`) and require `agent login` or `CURSOR_API_KEY`.
 - Providers run against the project directory you import into Verde.
 
 If prompt sending fails, first check that the selected provider is installed, available to Verde's launch environment, and authenticated.
@@ -424,7 +424,6 @@ Those files capture Zig panic output, provider helper stderr, and the last panic
 
 Main third-party components used by the desktop app:
 
-- `@cursor/sdk` for Cursor provider integration.
 - `@anthropic-ai/claude-agent-sdk` for Claude Code provider integration.
 - `fff.nvim` / `fff-c` / `fff-search` for fast file indexing and search, vendored in [`vendor/fff`](vendor/fff). License: MIT.
 - Ghostty / `libghostty-vt` for terminal emulation and VT parsing. License: MIT.

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "verde",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.132",
-        "@cursor/sdk": "^1.0.12",
       },
       "devDependencies": {
         "@redwoodjs/agent-ci": "^0.6.0",
@@ -44,28 +43,6 @@
 
     "@balena/dockerignore": ["@balena/dockerignore@1.0.2", "", {}, "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="],
 
-    "@bufbuild/protobuf": ["@bufbuild/protobuf@1.10.0", "", {}, "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag=="],
-
-    "@connectrpc/connect": ["@connectrpc/connect@1.7.0", "", { "peerDependencies": { "@bufbuild/protobuf": "^1.10.0" } }, "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w=="],
-
-    "@connectrpc/connect-node": ["@connectrpc/connect-node@1.7.0", "", { "dependencies": { "undici": "^5.28.4" }, "peerDependencies": { "@bufbuild/protobuf": "^1.10.0", "@connectrpc/connect": "1.7.0" } }, "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A=="],
-
-    "@cursor/sdk": ["@cursor/sdk@1.0.12", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-node": "^1.6.1", "@statsig/js-client": "3.31.0", "sqlite3": "^5.1.7", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.12", "@cursor/sdk-darwin-x64": "1.0.12", "@cursor/sdk-linux-arm64": "1.0.12", "@cursor/sdk-linux-x64": "1.0.12", "@cursor/sdk-win32-x64": "1.0.12" } }, "sha512-jGx0wFY1N9uIdIKr303CfM6m/dLXmRCUnU/0yNP/oiOpkBXqgqaThGbgYbcOeVrYonMZc/DZJ9EydXOEPJLcbg=="],
-
-    "@cursor/sdk-darwin-arm64": ["@cursor/sdk-darwin-arm64@1.0.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AOFx+aX+4SntAeC66YncHACXk5duxp+HzDrxxF4Tl93N6nLjHaHEKSAXbt87ivL34MCHop4v/3c70QzBhamB2g=="],
-
-    "@cursor/sdk-darwin-x64": ["@cursor/sdk-darwin-x64@1.0.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-/ZDAYFUrnPd8hAGRky9ZGcROqZSZ2b5W+aEjTdINzLhJ8x5ZNXtjaz0ZYSHabOn2BeErjXgTcq+4bX2/To4C1A=="],
-
-    "@cursor/sdk-linux-arm64": ["@cursor/sdk-linux-arm64@1.0.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-kAxNqiB3dPtlW9fVjjIZEdbIGEGLA9moOM3zYwsXh8J1Qw942nJYMGDGR4o8x0zglwZ24a1JpovvZamrCaC3Yw=="],
-
-    "@cursor/sdk-linux-x64": ["@cursor/sdk-linux-x64@1.0.12", "", { "os": "linux", "cpu": "x64" }, "sha512-RmBiBCPKMZC5McDerGk2Rk4P47xz2A+uzRoRgH6sMoOjklc33ry11iAZC0D5F5xH85chgY878086A/Q8+XrAuA=="],
-
-    "@cursor/sdk-win32-x64": ["@cursor/sdk-win32-x64@1.0.12", "", { "os": "win32", "cpu": "x64" }, "sha512-uH4shdHrKOdtNLapy1uuScJ9lL2Pc8zc9I9ZKC6b6bx+0UX6xLAqjPP7dqVPfO6D9u61yLq1Hs86XOLs5ZVkPA=="],
-
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
-
-    "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
-
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.7.15", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.2.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ=="],
@@ -75,10 +52,6 @@
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
-
-    "@npmcli/fs": ["@npmcli/fs@1.1.1", "", { "dependencies": { "@gar/promisify": "^1.0.1", "semver": "^7.3.5" } }, "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ=="],
-
-    "@npmcli/move-file": ["@npmcli/move-file@1.1.2", "", { "dependencies": { "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg=="],
 
     "@polka/url": ["@polka/url@0.5.0", "", {}, "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw=="],
 
@@ -104,23 +77,9 @@
 
     "@redwoodjs/agent-ci": ["@redwoodjs/agent-ci@0.6.0", "", { "dependencies": { "@actions/workflow-parser": "0.3.43", "dockerode": "^4.0.2", "dtu-github-actions": "0.6.0", "log-update": "^7.2.0", "minimatch": "^10.2.1", "yaml": "^2.8.2" }, "bin": { "agent-ci": "dist/cli.js" } }, "sha512-sZDtLNPA5knljlm/XxqdKtQH48XlrZEv5nk8vORL4FkklRdzULx81QjsVWpixBNrK/qYZt7y1QMw/ANl7lqxlg=="],
 
-    "@statsig/client-core": ["@statsig/client-core@3.31.0", "", {}, "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ=="],
-
-    "@statsig/js-client": ["@statsig/js-client@3.31.0", "", { "dependencies": { "@statsig/client-core": "3.31.0" } }, "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g=="],
-
-    "@tootallnate/once": ["@tootallnate/once@1.1.2", "", {}, "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="],
-
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
-    "abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
-
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
-
-    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
-
-    "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -132,10 +91,6 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "aproba": ["aproba@2.1.0", "", {}, "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew=="],
-
-    "are-we-there-yet": ["are-we-there-yet@3.0.1", "", { "dependencies": { "delegates": "^1.0.0", "readable-stream": "^3.6.0" } }, "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg=="],
-
     "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
@@ -143,8 +98,6 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
-
-    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
@@ -158,15 +111,11 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
-    "cacache": ["cacache@15.3.0", "", { "dependencies": { "@npmcli/fs": "^1.0.0", "@npmcli/move-file": "^1.0.1", "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "glob": "^7.1.4", "infer-owner": "^1.0.4", "lru-cache": "^6.0.0", "minipass": "^3.1.1", "minipass-collect": "^1.0.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.2", "mkdirp": "^1.0.3", "p-map": "^4.0.0", "promise-inflight": "^1.0.1", "rimraf": "^3.0.2", "ssri": "^8.0.1", "tar": "^6.0.2", "unique-filename": "^1.1.1" } }, "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ=="],
-
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
-
-    "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -175,12 +124,6 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
-
-    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
-
-    "console-control-strings": ["console-control-strings@1.1.0", "", {}, "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -200,15 +143,7 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
-
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
-
-    "delegates": ["delegates@1.0.0", "", {}, "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="],
-
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
-    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "docker-modem": ["docker-modem@5.0.7", "", { "dependencies": { "debug": "^4.1.1", "readable-stream": "^3.5.0", "split-ca": "^1.0.1", "ssh2": "^1.15.0" } }, "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA=="],
 
@@ -224,15 +159,9 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
-    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
-
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
-    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
-
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
-
-    "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -250,8 +179,6 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
-    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
-
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.5.1", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ=="],
@@ -259,8 +186,6 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
-
-    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -270,13 +195,7 @@
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
-    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
-
-    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
-
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "gauge": ["gauge@4.0.4", "", { "dependencies": { "aproba": "^1.0.3 || ^2.0.0", "color-support": "^1.1.3", "console-control-strings": "^1.1.0", "has-unicode": "^2.0.1", "signal-exit": "^3.0.7", "string-width": "^4.2.3", "strip-ansi": "^6.0.1", "wide-align": "^1.1.5" } }, "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -286,55 +205,27 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
-    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
-
-    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
-
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
-
-    "has-unicode": ["has-unicode@2.0.1", "", {}, "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
 
-    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
-
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
-    "http-proxy-agent": ["http-proxy-agent@4.0.1", "", { "dependencies": { "@tootallnate/once": "1", "agent-base": "6", "debug": "4" } }, "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg=="],
-
-    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
-
-    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
-    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
-
-    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
-
-    "infer-owner": ["infer-owner@1.0.4", "", {}, "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="],
-
-    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
-
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
-
-    "is-lambda": ["is-lambda@1.0.1", "", {}, "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
@@ -356,10 +247,6 @@
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
-    "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
-
-    "make-fetch-happen": ["make-fetch-happen@9.1.0", "", { "dependencies": { "agentkeepalive": "^4.1.3", "cacache": "^15.2.0", "http-cache-semantics": "^4.1.0", "http-proxy-agent": "^4.0.1", "https-proxy-agent": "^5.0.0", "is-lambda": "^1.0.1", "lru-cache": "^6.0.0", "minipass": "^3.1.3", "minipass-collect": "^1.0.2", "minipass-fetch": "^1.3.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^0.6.2", "promise-retry": "^2.0.1", "socks-proxy-agent": "^6.0.0", "ssri": "^8.0.0" } }, "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg=="],
-
     "matchit": ["matchit@1.1.0", "", { "dependencies": { "@arr/every": "^1.0.0" } }, "sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -374,27 +261,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
-
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
-
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
-
-    "minipass-collect": ["minipass-collect@1.0.2", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA=="],
-
-    "minipass-fetch": ["minipass-fetch@1.4.1", "", { "dependencies": { "minipass": "^3.1.0", "minipass-sized": "^1.0.3", "minizlib": "^2.0.0" }, "optionalDependencies": { "encoding": "^0.1.12" } }, "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw=="],
-
-    "minipass-flush": ["minipass-flush@1.0.7", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA=="],
-
-    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
-
-    "minipass-sized": ["minipass-sized@1.0.3", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g=="],
-
-    "minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
-
-    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
@@ -402,19 +269,7 @@
 
     "nan": ["nan@2.26.2", "", {}, "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw=="],
 
-    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
-
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
-
-    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
-
-    "node-gyp": ["node-gyp@8.4.1", "", { "dependencies": { "env-paths": "^2.2.0", "glob": "^7.1.4", "graceful-fs": "^4.2.6", "make-fetch-happen": "^9.1.0", "nopt": "^5.0.0", "npmlog": "^6.0.0", "rimraf": "^3.0.2", "semver": "^7.3.5", "tar": "^6.1.2", "which": "^2.0.2" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w=="],
-
-    "nopt": ["nopt@5.0.0", "", { "dependencies": { "abbrev": "1" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ=="],
-
-    "npmlog": ["npmlog@6.0.2", "", { "dependencies": { "are-we-there-yet": "^3.0.0", "console-control-strings": "^1.1.0", "gauge": "^4.0.3", "set-blocking": "^2.0.0" } }, "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -426,11 +281,7 @@
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
-    "p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
-
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
-    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -439,12 +290,6 @@
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "polka": ["polka@0.5.2", "", { "dependencies": { "@polka/url": "^0.5.0", "trouter": "^2.0.1" } }, "sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw=="],
-
-    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
-
-    "promise-inflight": ["promise-inflight@1.0.1", "", {}, "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="],
-
-    "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
 
     "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
@@ -458,8 +303,6 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
-
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
@@ -468,23 +311,15 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
-    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
-
-    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
-
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -502,25 +337,11 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
-
-    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
-
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
-
-    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
-
-    "socks": ["socks@2.8.8", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog=="],
-
-    "socks-proxy-agent": ["socks-proxy-agent@6.2.1", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ=="],
 
     "split-ca": ["split-ca@1.0.1", "", {}, "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="],
 
-    "sqlite3": ["sqlite3@5.1.7", "", { "dependencies": { "bindings": "^1.5.0", "node-addon-api": "^7.0.0", "prebuild-install": "^7.1.1", "tar": "^6.1.11" }, "optionalDependencies": { "node-gyp": "8.x" } }, "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog=="],
-
     "ssh2": ["ssh2@1.17.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.23.0" } }, "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ=="],
-
-    "ssri": ["ssri@8.0.1", "", { "dependencies": { "minipass": "^3.1.1" } }, "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -529,10 +350,6 @@
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
-
-    "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
 
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
@@ -544,19 +361,11 @@
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
-    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
-
     "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
-
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "unique-filename": ["unique-filename@1.1.1", "", { "dependencies": { "unique-slug": "^2.0.0" } }, "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ=="],
-
-    "unique-slug": ["unique-slug@2.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -568,15 +377,11 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
-
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
-
-    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
@@ -590,49 +395,11 @@
 
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
-    "cacache/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
-
-    "cacache/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
-    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "gauge/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "gauge/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
-
-    "minipass-collect/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minipass-fetch/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "tar/chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
-
-    "wide-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -642,23 +409,9 @@
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "gauge/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "gauge/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
-
-    "wide-align/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "wide-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "wide-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,10 @@ zig = "0.16.0"
 zls = "0.16.0"
 # zls = "0.15.2"
 
+[tasks.tail]
+description = "Tails the desktop app log file."
+run = "tail -f -n 80 /home/rtg/.local/share/verde/Native/logs/verde.stderr.log"
+
 [tasks.setup]
 description = "Checks desktop build dependencies."
 run = "bash -lc 'bash scripts/dev/check-desktop-build-deps.sh'"

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ zls = "0.16.0"
 
 [tasks.tail]
 description = "Tails the desktop app log file."
-run = "tail -f -n 80 /home/rtg/.local/share/verde/Native/logs/verde.stderr.log"
+run = "tail -f -n 80 ${HOME}/.local/share/verde/Native/logs/verde.stderr.log"
 
 [tasks.setup]
 description = "Checks desktop build dependencies."

--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
     "@redwoodjs/agent-ci": "^0.6.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.132",
-    "@cursor/sdk": "^1.0.12"
-  },
-  "trustedDependencies": [
-    "sqlite3"
-  ]
+    "@anthropic-ai/claude-agent-sdk": "^0.2.132"
+  }
 }

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -10,7 +10,7 @@ This package contains Verde's standalone Zig desktop app. It uses SDL3, SDL_GPU,
   - Codex: `codex` on your `PATH` and `codex login`
   - Claude Code: Claude Code installed and logged in locally; Verde talks to it through Anthropic's Claude Agent SDK
   - OpenCode: `opencode` on your `PATH`
-  - Cursor: `CURSOR_API_KEY` set in the environment used to launch Verde
+  - Cursor: Cursor CLI `agent` on your `PATH` and `agent login`, or `CURSOR_API_KEY` for headless environments
 
 ## Development
 
@@ -96,7 +96,7 @@ The desktop app talks to local provider runtimes rather than a hosted Verde back
 - Codex uses the local `codex` CLI and starts `codex app-server` automatically when needed.
 - Claude Code uses Anthropic's Claude Agent SDK and requires Claude Code to be installed and logged in on your machine.
 - OpenCode uses the local `opencode` CLI and can start `opencode serve` automatically when needed.
-- Cursor uses `@cursor/sdk` and requires `CURSOR_API_KEY`.
+- Cursor uses the local Cursor CLI ACP server (`agent acp`) and requires `agent login` or `CURSOR_API_KEY`.
 
 Requests run against the project directory selected in Verde. If prompt sending fails, check that the selected provider is installed, available to Verde's launch environment, and authenticated.
 
@@ -195,13 +195,12 @@ Third-party Zig dependencies are declared in [`build.zig.zon`](build.zig.zon):
 - `zig_markdown`
 - `ghostty`
 
-The repo also uses `@anthropic-ai/claude-agent-sdk` and `@cursor/sdk` from the root npm package for Claude Code and Cursor provider integration.
+The repo also uses `@anthropic-ai/claude-agent-sdk` from the root npm package for Claude Code provider integration.
 
 ## Third-Party Attribution
 
 Main upstream components used by the desktop app:
 
-- `@cursor/sdk` for Cursor provider integration.
 - `@anthropic-ai/claude-agent-sdk` for Claude Code provider integration.
 - `fff.nvim` / `fff-c` / `fff-search` for project-scoped file indexing and composer file search, vendored in [`../../vendor/fff`](../../vendor/fff). License: MIT.
 - Ghostty / `libghostty-vt` for terminal emulation and VT parsing. License: MIT.

--- a/packages/desktop/build.zig
+++ b/packages/desktop/build.zig
@@ -93,6 +93,22 @@ pub fn build(b: *std.Build) void {
         ),
     });
 
+    const build_provider_bridge = b.addSystemCommand(&.{
+        "bun",
+        "build",
+        "src/providers/provider_bridge.ts",
+        "--target=node",
+        "--outfile",
+    });
+    const provider_bridge_output = build_provider_bridge.addOutputFileArg("provider_bridge.mjs");
+    build_provider_bridge.setCwd(b.path("."));
+    build_provider_bridge.addFileInput(b.path("src/providers/provider_bridge.ts"));
+    b.getInstallStep().dependOn(&b.addInstallFileWithDir(
+        provider_bridge_output,
+        .{ .custom = "share/verde" },
+        "provider_bridge.mjs",
+    ).step);
+
     const exe = b.addExecutable(.{
         .name = "verde",
         .root_module = b.createModule(.{

--- a/packages/desktop/src/providers/claude.zig
+++ b/packages/desktop/src/providers/claude.zig
@@ -6,7 +6,6 @@ const process_env = @import("../process_env.zig");
 const provider_types = @import("../provider_types.zig");
 const runtime_log = @import("../runtime_log.zig");
 
-const BRIDGE_SOURCE = @embedFile("claude_bridge.mjs");
 const MAX_BRIDGE_LINE_BYTES = 8 * 1024 * 1024;
 
 const Mutex = struct {
@@ -48,7 +47,7 @@ pub const Client = struct {
     }
 
     pub fn authState(self: *Client) !provider_types.AuthState {
-        var response = try self.runBridge(.{ .command = "auth", .cwd = self.config.cwd, .claude_executable = self.config.claude_executable }, null);
+        var response = try self.runBridge(.{ .provider = "claude", .command = "auth", .cwd = self.config.cwd, .claude_executable = self.config.claude_executable }, null);
         defer response.deinit(self.allocator);
 
         const result = response.result orelse return .unknown;
@@ -59,7 +58,7 @@ pub const Client = struct {
     }
 
     pub fn listThreads(self: *Client, allocator: std.mem.Allocator) ![]provider_types.ChatThreadSummary {
-        var response = try self.runBridge(.{ .command = "list_threads", .cwd = self.config.cwd, .claude_executable = self.config.claude_executable }, null);
+        var response = try self.runBridge(.{ .provider = "claude", .command = "list_threads", .cwd = self.config.cwd, .claude_executable = self.config.claude_executable }, null);
         defer response.deinit(self.allocator);
 
         const result = response.result orelse return allocator.alloc(provider_types.ChatThreadSummary, 0);
@@ -81,7 +80,7 @@ pub const Client = struct {
     }
 
     pub fn listModels(self: *Client, allocator: std.mem.Allocator) ![]provider_types.ModelInfo {
-        var response = try self.runBridge(.{ .command = "list_models", .cwd = self.config.cwd, .claude_executable = self.config.claude_executable }, null);
+        var response = try self.runBridge(.{ .provider = "claude", .command = "list_models", .cwd = self.config.cwd, .claude_executable = self.config.claude_executable }, null);
         defer response.deinit(self.allocator);
 
         const result = response.result orelse return allocator.alloc(provider_types.ModelInfo, 0);
@@ -118,6 +117,7 @@ pub const Client = struct {
         thread_id: []const u8,
     ) !provider_types.ReadThreadResult {
         var response = try self.runBridge(.{
+            .provider = "claude",
             .command = "read_thread",
             .cwd = self.config.cwd,
             .thread_id = thread_id,
@@ -171,6 +171,7 @@ pub const Client = struct {
         defer allocator.free(image_attachments);
 
         const bridge_request = BridgeSendPromptRequest{
+            .provider = "claude",
             .command = "send_prompt",
             .thread_id = request.thread_id,
             .prompt = request.prompt,
@@ -223,12 +224,11 @@ pub const Client = struct {
     fn runBridge(self: *Client, payload: anytype, stream_request: ?provider_types.SendPromptRequest) !BridgeResponse {
         var env_map = try process_env.buildAugmentedEnvMap(self.allocator);
         defer env_map.deinit();
-        try addBundledNodeModulesEnv(self.allocator, &env_map);
 
         const executable = try process_env.resolveExecutableInEnvMapAlloc(self.allocator, &env_map, self.config.executable);
         defer self.allocator.free(executable);
 
-        const bridge_path = try writeBridgeFile(self.allocator);
+        const bridge_path = try providerBridgePathAlloc(self.allocator);
         defer self.allocator.free(bridge_path);
 
         var threaded: std.Io.Threaded = .init(self.allocator, .{});
@@ -410,6 +410,7 @@ const BridgeResponse = struct {
 };
 
 const BridgeSendPromptRequest = struct {
+    provider: []const u8,
     command: []const u8,
     thread_id: ?[]const u8 = null,
     prompt: []const u8,
@@ -445,55 +446,30 @@ fn containsImagePath(images: []const provider_types.ImageAttachment, path: []con
     return false;
 }
 
-fn writeBridgeFile(allocator: std.mem.Allocator) ![]u8 {
-    var threaded = std.Io.Threaded.init_single_threaded;
-    const root = tempRoot();
-    const dir_path = try std.fs.path.join(allocator, &.{ root, "verde" });
-    defer allocator.free(dir_path);
-    try std.Io.Dir.cwd().createDirPath(threaded.io(), dir_path);
-
-    const path = try std.fs.path.join(allocator, &.{ dir_path, "verde-claude-agent-sdk-bridge.mjs" });
-    errdefer allocator.free(path);
-
-    const file = try std.Io.Dir.createFileAbsolute(threaded.io(), path, .{ .truncate = true });
-    defer file.close(threaded.io());
-    var write_buffer: [16 * 1024]u8 = undefined;
-    var writer = file.writer(threaded.io(), &write_buffer);
-    try writer.interface.writeAll(BRIDGE_SOURCE);
-    try writer.interface.flush();
-    return path;
-}
-
-fn tempRoot() []const u8 {
-    if (std.c.getenv("TMPDIR")) |value| return std.mem.sliceTo(value, 0);
-    if (std.c.getenv("TMP")) |value| return std.mem.sliceTo(value, 0);
-    if (std.c.getenv("TEMP")) |value| return std.mem.sliceTo(value, 0);
-    return "/tmp";
-}
-
-fn addBundledNodeModulesEnv(
-    allocator: std.mem.Allocator,
-    env_map: *std.process.Environ.Map,
-) !void {
-    const bundled = bundledNodeModulesPathAlloc(allocator) catch return;
-    defer allocator.free(bundled);
-
-    var threaded = std.Io.Threaded.init(allocator, .{});
-    defer threaded.deinit();
-    std.Io.Dir.cwd().access(threaded.io(), bundled, .{}) catch return;
-
-    try env_map.put("VERDE_NODE_MODULES", bundled);
-}
-
-fn bundledNodeModulesPathAlloc(allocator: std.mem.Allocator) ![]u8 {
+fn providerBridgePathAlloc(allocator: std.mem.Allocator) ![]u8 {
     const exe_path = try selfExePathAlloc(allocator);
     defer allocator.free(exe_path);
     const exe_dir = std.fs.path.dirname(exe_path) orelse return error.FileNotFound;
 
-    return switch (builtin.os.tag) {
-        .macos => std.fs.path.resolve(allocator, &.{ exe_dir, "..", "Resources", "node_modules" }),
-        else => std.fs.path.resolve(allocator, &.{ exe_dir, "..", "share", "verde", "node_modules" }),
+    const installed = switch (builtin.os.tag) {
+        .macos => try std.fs.path.resolve(allocator, &.{ exe_dir, "..", "Resources", "provider_bridge.mjs" }),
+        else => try std.fs.path.resolve(allocator, &.{ exe_dir, "..", "share", "verde", "provider_bridge.mjs" }),
     };
+    if (pathExists(allocator, installed)) return installed;
+    allocator.free(installed);
+
+    const dev = try std.fs.path.resolve(allocator, &.{ "zig-out", "share", "verde", "provider_bridge.mjs" });
+    if (pathExists(allocator, dev)) return dev;
+    allocator.free(dev);
+
+    return error.ProviderBridgeNotFound;
+}
+
+fn pathExists(allocator: std.mem.Allocator, path: []const u8) bool {
+    var threaded = std.Io.Threaded.init(allocator, .{});
+    defer threaded.deinit();
+    std.Io.Dir.cwd().access(threaded.io(), path, .{}) catch return false;
+    return true;
 }
 
 fn selfExePathAlloc(allocator: std.mem.Allocator) ![]u8 {
@@ -616,6 +592,7 @@ test "BridgeSendPromptRequest serializes multiple images" {
         .{ .path = "/tmp/two.png" },
     };
     const payload = BridgeSendPromptRequest{
+        .provider = "claude",
         .command = "send_prompt",
         .prompt = "describe",
         .images = images[0..],

--- a/packages/desktop/src/providers/cursor.zig
+++ b/packages/desktop/src/providers/cursor.zig
@@ -1,22 +1,39 @@
-//! Cursor provider harness backed by the official `@cursor/sdk` TypeScript runtime.
-//!
-//! Cursor's public SDK is TypeScript. Keep this provider as a thin Zig-owned
-//! bridge so Verde uses Cursor's harness, rules, hooks, skills, MCP config, and
-//! model routing as Cursor intends instead of reimplementing that agent loop.
+//! Cursor provider harness backed by Cursor CLI ACP (`agent acp`).
 
 const std = @import("std");
 const process_env = @import("../process_env.zig");
 const provider_types = @import("../provider_types.zig");
 const runtime_log = @import("../runtime_log.zig");
-const builtin = @import("builtin");
 
-const MAX_BRIDGE_STDOUT_BYTES = 16 * 1024 * 1024;
-const MAX_BRIDGE_STDERR_BYTES = 512 * 1024;
+const DEFAULT_EXECUTABLE = "agent";
+const FALLBACK_EXECUTABLE = "cursor-agent";
 const DEFAULT_MODEL = "composer-2";
-const IMPORT_MESSAGE_LIMIT = 1000;
+const MAX_ACP_LINE_BYTES = 16 * 1024 * 1024;
+const MAX_CURSOR_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+const Mutex = struct {
+    inner: std.atomic.Mutex = .unlocked,
+
+    fn lock(self: *Mutex) void {
+        while (!self.inner.tryLock()) std.atomic.spinLoopHint();
+    }
+
+    fn unlock(self: *Mutex) void {
+        self.inner.unlock();
+    }
+};
+
+const ActiveProcessState = struct {
+    mutex: Mutex = .{},
+    child: ?*std.process.Child = null,
+    stdin: ?std.Io.File = null,
+    session_id: ?[]const u8 = null,
+};
+
+var active_process_state: ActiveProcessState = .{};
 
 pub const Config = struct {
-    executable: []const u8 = "node",
+    executable: []const u8 = DEFAULT_EXECUTABLE,
     cwd: ?[]const u8 = null,
     api_key: ?[]const u8 = null,
     model: ?[]const u8 = DEFAULT_MODEL,
@@ -27,10 +44,7 @@ pub const Client = struct {
     config: Config,
 
     pub fn init(allocator: std.mem.Allocator, config: Config) !Client {
-        return .{
-            .allocator = allocator,
-            .config = config,
-        };
+        return .{ .allocator = allocator, .config = config };
     }
 
     pub fn deinit(self: *Client) void {
@@ -38,29 +52,94 @@ pub const Client = struct {
     }
 
     pub fn authState(self: *Client) !provider_types.AuthState {
-        const response = self.runBridge(.auth, std.heap.page_allocator, .{}) catch |err| switch (err) {
-            error.CursorSignedOut => return .signed_out,
+        var env_map = try self.cursorEnvMap(self.allocator);
+        defer env_map.deinit();
+
+        const executable = self.resolveExecutable(self.allocator, &env_map) catch |err| switch (err) {
             error.FileNotFound => return .unknown,
             else => return err,
         };
-        defer response.deinit(std.heap.page_allocator);
-        return .signed_in;
+        defer self.allocator.free(executable);
+
+        var threaded: std.Io.Threaded = .init(self.allocator, .{});
+        defer threaded.deinit();
+        const result = std.process.run(self.allocator, threaded.io(), .{
+            .argv = &.{ executable, "status", "--format", "json" },
+            .cwd = if (self.config.cwd) |path| .{ .path = path } else .inherit,
+            .environ_map = &env_map,
+            .stdout_limit = .limited(MAX_CURSOR_OUTPUT_BYTES),
+            .stderr_limit = .limited(512 * 1024),
+        }) catch |err| switch (err) {
+            error.FileNotFound => return .unknown,
+            else => return err,
+        };
+        defer self.allocator.free(result.stdout);
+        defer self.allocator.free(result.stderr);
+
+        switch (result.term) {
+            .exited => |code| if (code != 0) return .signed_out,
+            else => return .signed_out,
+        }
+
+        var parsed = std.json.parseFromSlice(std.json.Value, self.allocator, result.stdout, .{}) catch return .unknown;
+        defer parsed.deinit();
+        if (getOptionalObjectBool(parsed.value, "isAuthenticated") orelse false) return .signed_in;
+        if (getOptionalObjectString(parsed.value, "status")) |status| {
+            if (std.mem.eql(u8, status, "authenticated")) return .signed_in;
+        }
+        return .signed_out;
     }
 
     pub fn listThreads(self: *Client, allocator: std.mem.Allocator) ![]provider_types.ChatThreadSummary {
-        const response = self.runBridge(.list_threads, allocator, .{}) catch {
-            return allocator.alloc(provider_types.ChatThreadSummary, 0);
-        };
-        defer response.deinit(allocator);
-        return parseThreadSummariesAlloc(allocator, response.items orelse "[]");
+        var acp = try self.spawnAcp(allocator, null);
+        defer acp.deinit();
+
+        var state: ListThreadsState = .{};
+        errdefer state.deinit(allocator);
+
+        try acp.writeLine(try makeInitializeRequestAlloc(allocator, 1));
+        try acp.writeLine(try makeSessionListRequestAlloc(allocator, 2, try self.cwdAbsoluteAlloc(allocator)));
+        try acp.closeStdin();
+
+        var read_buffer: [16 * 1024]u8 = undefined;
+        var reader = acp.child.stdout.?.reader(acp.threaded.io(), &read_buffer);
+        while (try takeAcpLineAlloc(allocator, &reader)) |raw_line| {
+            defer allocator.free(raw_line);
+            const line = std.mem.trim(u8, raw_line, " \t\r");
+            if (line.len == 0) continue;
+            if (try handleListThreadsLine(allocator, line, &state)) break;
+        }
+
+        acp.stop();
+        const threads = try state.threads.toOwnedSlice(allocator);
+        state.threads = .empty;
+        return threads;
     }
 
     pub fn listModels(self: *Client, allocator: std.mem.Allocator) ![]provider_types.ModelInfo {
-        const response = self.runBridge(.list_models, allocator, .{}) catch {
-            return staticModelsAlloc(allocator);
-        };
-        defer response.deinit(allocator);
-        return parseModelsAlloc(allocator, response.items orelse "[]") catch staticModelsAlloc(allocator);
+        var env_map = try self.cursorEnvMap(allocator);
+        defer env_map.deinit();
+
+        const executable = self.resolveExecutable(allocator, &env_map) catch return staticModelsAlloc(allocator);
+        defer allocator.free(executable);
+
+        var threaded: std.Io.Threaded = .init(allocator, .{});
+        defer threaded.deinit();
+        const result = std.process.run(allocator, threaded.io(), .{
+            .argv = &.{ executable, "models" },
+            .cwd = if (self.config.cwd) |path| .{ .path = path } else .inherit,
+            .environ_map = &env_map,
+            .stdout_limit = .limited(MAX_CURSOR_OUTPUT_BYTES),
+            .stderr_limit = .limited(512 * 1024),
+        }) catch return staticModelsAlloc(allocator);
+        defer allocator.free(result.stdout);
+        defer allocator.free(result.stderr);
+
+        switch (result.term) {
+            .exited => |code| if (code != 0) return staticModelsAlloc(allocator),
+            else => return staticModelsAlloc(allocator),
+        }
+        return parseModelsTextAlloc(allocator, result.stdout) catch staticModelsAlloc(allocator);
     }
 
     pub fn readThread(
@@ -68,17 +147,36 @@ pub const Client = struct {
         allocator: std.mem.Allocator,
         thread_id: []const u8,
     ) !provider_types.ReadThreadResult {
-        const response = try self.runBridge(.read_thread, allocator, .{
-            .thread_id = thread_id,
-        });
-        defer response.deinit(allocator);
+        var acp = try self.spawnAcp(allocator, null);
+        defer acp.deinit();
 
-        const title = response.title orelse thread_id;
-        const messages = try parseMessagesAlloc(allocator, response.items orelse "[]");
+        const cwd = try self.cwdAbsoluteAlloc(allocator);
+        defer allocator.free(cwd);
+
+        var state: ReadThreadState = .{};
+        errdefer state.deinit(allocator);
+
+        try acp.writeLine(try makeInitializeRequestAlloc(allocator, 1));
+        try acp.writeLine(try makeSessionLoadRequestAlloc(allocator, 2, thread_id, cwd));
+        try acp.closeStdin();
+
+        var read_buffer: [16 * 1024]u8 = undefined;
+        var reader = acp.child.stdout.?.reader(acp.threaded.io(), &read_buffer);
+        while (try takeAcpLineAlloc(allocator, &reader)) |raw_line| {
+            defer allocator.free(raw_line);
+            const line = std.mem.trim(u8, raw_line, " \t\r");
+            if (line.len == 0) continue;
+            if (try handleReadThreadLine(allocator, line, thread_id, &state)) break;
+        }
+
+        acp.stop();
+        const messages = try state.messages.toOwnedSlice(allocator);
+        state.messages = .empty;
+        const title = if (state.title) |title| title else try allocator.dupe(u8, thread_id);
+        state.title = null;
         return .{
             .thread_id = try allocator.dupe(u8, thread_id),
-            .title = try allocator.dupe(u8, title),
-            .updated_at = response.updated_at,
+            .title = title,
             .messages = messages,
         };
     }
@@ -88,31 +186,87 @@ pub const Client = struct {
         allocator: std.mem.Allocator,
         request: provider_types.SendPromptRequest,
     ) !provider_types.SendPromptResult {
-        const bridge_response = try self.runBridge(.send_prompt, allocator, .{
-            .request = request,
-        });
-        defer bridge_response.deinit(allocator);
+        const model_arg = try cursorModelArgAlloc(allocator, request.model orelse self.config.model orelse DEFAULT_MODEL, request.cursor_model_params_json);
+        defer if (model_arg) |arg| allocator.free(arg);
 
-        if (request.on_thread_id) |on_thread_id| {
-            on_thread_id(request.stream_context, bridge_response.thread_id);
+        var acp = try self.spawnAcp(allocator, model_arg);
+        defer acp.deinit();
+
+        const cwd = try self.cwdAbsoluteAllocForRequest(allocator, request);
+        defer allocator.free(cwd);
+
+        var state: SendPromptState = .{};
+        errdefer state.deinit(allocator);
+
+        try acp.writeLine(try makeInitializeRequestAlloc(allocator, 1));
+        if (request.thread_id) |thread_id| {
+            try acp.writeLine(try makeSessionLoadRequestAlloc(allocator, 2, thread_id, cwd));
+        } else {
+            try acp.writeLine(try makeSessionNewRequestAlloc(allocator, 2, cwd));
         }
-        if (bridge_response.run_id) |run_id| {
-            if (request.on_turn_id) |on_turn_id| {
-                on_turn_id(request.stream_context, run_id);
+
+        var read_buffer: [16 * 1024]u8 = undefined;
+        var reader = acp.child.stdout.?.reader(acp.threaded.io(), &read_buffer);
+        while (try takeAcpLineAlloc(allocator, &reader)) |raw_line| {
+            defer allocator.free(raw_line);
+            const line = std.mem.trim(u8, raw_line, " \t\r");
+            if (line.len == 0) continue;
+            const action = try handleSendPromptLine(allocator, line, request, &state, acp.child.stdin);
+            switch (action) {
+                .continue_reading => {},
+                .session_ready => {
+                    if (state.session_id) |session_id| {
+                        registerActiveChild(&acp.child, acp.child.stdin, session_id);
+                        if (request.on_thread_id) |on_thread_id| on_thread_id(request.stream_context, session_id);
+                        if (request.on_turn_id) |on_turn_id| on_turn_id(request.stream_context, session_id);
+                        try acp.writeLine(try makePromptRequestAlloc(allocator, 3, session_id, request, state.capabilities.image));
+                    }
+                },
+                .prompt_done => break,
+            }
+            if (request.on_should_stop) |should_stop| {
+                if (should_stop(request.stream_context)) {
+                    if (state.session_id) |session_id| {
+                        try acp.writeLine(try makeCancelNotificationAlloc(allocator, session_id));
+                    }
+                    return error.CodexTurnInterrupted;
+                }
             }
         }
+
+        unregisterActiveChild(&acp.child);
+        try acp.closeStdin();
+        acp.stop();
+
+        const thread_id = state.session_id orelse return error.CursorAcpFailed;
+        state.session_id = null;
+        const reply_text = try state.reply.toOwnedSlice(allocator);
+        state.reply = .empty;
         return .{
-            .thread_id = try allocator.dupe(u8, bridge_response.thread_id),
-            .reply_text = try allocator.dupe(u8, bridge_response.reply_text),
+            .thread_id = thread_id,
+            .reply_text = reply_text,
         };
     }
 
     pub fn interruptThread(self: *Client, request: provider_types.InterruptThreadRequest) !void {
-        const response = try self.runBridge(.interrupt_thread, self.allocator, .{
-            .thread_id = request.thread_id,
-            .turn_id = request.turn_id,
-        });
-        response.deinit(self.allocator);
+        _ = self;
+        active_process_state.mutex.lock();
+        defer active_process_state.mutex.unlock();
+
+        const child = active_process_state.child orelse return;
+        const session_id = active_process_state.session_id orelse return;
+        if (!std.mem.eql(u8, session_id, request.thread_id)) return;
+        if (active_process_state.stdin) |stdin| {
+            const line = try makeCancelNotificationAlloc(std.heap.page_allocator, session_id);
+            defer std.heap.page_allocator.free(line);
+            writeJsonLineToFile(std.heap.page_allocator, stdin, line) catch {
+                var threaded = std.Io.Threaded.init_single_threaded;
+                child.kill(threaded.io());
+            };
+        } else {
+            var threaded = std.Io.Threaded.init_single_threaded;
+            child.kill(threaded.io());
+        }
     }
 
     pub fn steerThread(self: *Client, request: provider_types.SteerThreadRequest) !void {
@@ -121,394 +275,1016 @@ pub const Client = struct {
         return error.UnsupportedOperation;
     }
 
-    fn runBridge(
-        self: *Client,
-        command: BridgeCommand,
-        allocator: std.mem.Allocator,
-        input: BridgeInput,
-    ) !BridgeResponse {
-        const request_json = try makeBridgeRequestJsonAlloc(allocator, self.config, command, input);
-        defer allocator.free(request_json);
-        const bridge_cwd = try resolveBridgeCwdAlloc(allocator, self.config.cwd);
-        defer if (bridge_cwd) |path| allocator.free(path);
-
+    fn cursorEnvMap(self: *Client, allocator: std.mem.Allocator) !std.process.Environ.Map {
         var env_map = try process_env.buildAugmentedEnvMap(allocator);
-        defer env_map.deinit();
-        try env_map.put("VERDE_CURSOR_REQUEST", request_json);
-        try addBundledNodeModulesEnv(allocator, &env_map);
+        errdefer env_map.deinit();
         try ensureCursorApiKeyEnv(allocator, self.config, &env_map);
-
-        const executable = try process_env.resolveExecutableInEnvMapAlloc(allocator, &env_map, self.config.executable);
-        defer allocator.free(executable);
-
-        if (command == .send_prompt) {
-            runtime_log.diagnostic("cursor.runBridge send_prompt bridge_cwd={s} request_json_len={d}", .{ bridge_cwd orelse "(inherit)", request_json.len });
-            return self.runBridgeStreaming(allocator, input, executable, bridge_cwd, &env_map);
-        }
-
-        var threaded = std.Io.Threaded.init(allocator, .{});
-        defer threaded.deinit();
-
-        const result = try std.process.run(allocator, threaded.io(), .{
-            .argv = &.{ executable, "--input-type=module", "--eval", BRIDGE_SCRIPT },
-            // Keep Node module resolution anchored at Verde's launch cwd; the selected
-            // project is still passed to Cursor through `local.cwd` in the JSON request.
-            .cwd = if (bridge_cwd) |path| .{ .path = path } else .inherit,
-            .environ_map = &env_map,
-            .stdout_limit = .limited(MAX_BRIDGE_STDOUT_BYTES),
-            .stderr_limit = .limited(MAX_BRIDGE_STDERR_BYTES),
-        });
-        defer allocator.free(result.stdout);
-        defer allocator.free(result.stderr);
-
-        return parseBridgeEventsAlloc(allocator, result.stdout, result.term, if (input.request) |request| request else null);
+        return env_map;
     }
 
-    fn runBridgeStreaming(
-        self: *Client,
-        allocator: std.mem.Allocator,
-        input: BridgeInput,
-        executable: []const u8,
-        bridge_cwd: ?[]const u8,
-        env_map: *const std.process.Environ.Map,
-    ) !BridgeResponse {
-        _ = self;
-        var threaded = std.Io.Threaded.init(allocator, .{});
-        defer threaded.deinit();
-        const io = threaded.io();
-        runtime_log.diagnostic("cursor.spawn streaming bridge cwd={s}", .{bridge_cwd orelse "(inherit)"});
-        var child = try std.process.spawn(io, .{
-            .argv = &.{ executable, "--input-type=module", "--eval", BRIDGE_SCRIPT },
-            .cwd = if (bridge_cwd) |path| .{ .path = path } else .inherit,
-            .environ_map = env_map,
-            .stdin = .ignore,
+    fn resolveExecutable(self: *Client, allocator: std.mem.Allocator, env_map: *const std.process.Environ.Map) ![]u8 {
+        return resolveCursorExecutableAlloc(allocator, env_map, self.config.executable);
+    }
+
+    fn spawnAcp(self: *Client, allocator: std.mem.Allocator, model_arg: ?[]const u8) !AcpProcess {
+        var env_map = try self.cursorEnvMap(allocator);
+        errdefer env_map.deinit();
+        const executable = try self.resolveExecutable(allocator, &env_map);
+        errdefer allocator.free(executable);
+
+        var threaded: std.Io.Threaded = .init(allocator, .{});
+        errdefer threaded.deinit();
+        const argv_with_model = [_][]const u8{ executable, "--model", model_arg orelse "", "acp" };
+        const argv_default = [_][]const u8{ executable, "acp" };
+        var child = try std.process.spawn(threaded.io(), .{
+            .argv = if (model_arg != null) argv_with_model[0..] else argv_default[0..],
+            .stdin = .pipe,
             .stdout = .pipe,
-            .stderr = .ignore,
+            .stderr = .inherit,
+            .cwd = if (self.config.cwd) |path| .{ .path = path } else .inherit,
+            .environ_map = &env_map,
         });
-        defer if (child.id != null) child.kill(io);
+        errdefer child.kill(threaded.io());
+        if (child.id) |pid| _ = std.c.setpgid(pid, pid);
 
-        var state: BridgeParseState = .{};
-        errdefer state.deinit(allocator);
+        return .{
+            .allocator = allocator,
+            .threaded = threaded,
+            .child = child,
+            .env_map = env_map,
+            .executable = executable,
+        };
+    }
 
-        var read_buffer: [16 * 1024]u8 = undefined;
-        var reader = child.stdout.?.readerStreaming(io, &read_buffer);
-        while (try reader.interface.takeDelimiter('\n')) |raw_line| {
-            if (try processBridgeLine(allocator, raw_line, if (input.request) |request| request else null, &state)) {
-                break;
-            }
-            if (input.request) |send_request| {
-                if (send_request.on_should_stop) |should_stop| {
-                    if (should_stop(send_request.stream_context)) {
-                        runtime_log.diagnostic("cursor.streaming bridge stopping on shutdown request", .{});
-                        _ = child.kill(io);
-                        child.id = null;
-                        return error.CodexTurnInterrupted;
-                    }
-                }
-            }
-        }
+    fn cwdAbsoluteAlloc(self: *Client, allocator: std.mem.Allocator) ![]u8 {
+        if (self.config.cwd) |cwd| return std.fs.path.resolve(allocator, &.{cwd});
+        var threaded: std.Io.Threaded = .init(allocator, .{});
+        defer threaded.deinit();
+        return std.process.currentPathAlloc(threaded.io(), allocator);
+    }
 
-        const term = if (child.id != null) try child.wait(io) else std.process.Child.Term{ .exited = 1 };
-        runtime_log.diagnostic("cursor.streaming bridge finished reply_len={d}", .{state.reply.items.len});
-        try finishBridgeResponse(term, state.saw_error);
-        if (state.response.thread_id.len == 0 and state.reply.items.len == 0) {
-            if (state.error_message) |message| {
-                runtime_log.diagnostic("cursor.streaming bridge empty response after error: {s}", .{message});
-            } else {
-                runtime_log.diagnostic("cursor.streaming bridge empty response without final event", .{});
-            }
-        }
-        state.response.reply_text = try state.reply.toOwnedSlice(allocator);
-        state.reply = .empty;
-        const response = state.response;
-        state.response = .{};
-        return response;
+    fn cwdAbsoluteAllocForRequest(self: *Client, allocator: std.mem.Allocator, request: provider_types.SendPromptRequest) ![]u8 {
+        if (request.cwd) |cwd| return std.fs.path.resolve(allocator, &.{cwd});
+        return self.cwdAbsoluteAlloc(allocator);
     }
 };
 
 pub fn shutdownOwnedServer() void {}
 
-fn resolveBridgeCwdAlloc(allocator: std.mem.Allocator, configured_cwd: ?[]const u8) !?[]u8 {
-    if (configured_cwd) |cwd| {
-        if (hasCursorSdkNodeModule(cwd)) return try allocator.dupe(u8, cwd);
+const AcpProcess = struct {
+    allocator: std.mem.Allocator,
+    threaded: std.Io.Threaded,
+    child: std.process.Child,
+    env_map: std.process.Environ.Map,
+    executable: []u8,
+    finished: bool = false,
+
+    fn writeLine(self: *AcpProcess, line: []u8) !void {
+        defer self.allocator.free(line);
+        const stdin = self.child.stdin orelse return error.ConnectionClosed;
+        try writeJsonLineToFile(self.allocator, stdin, line);
     }
 
-    const candidates = [_][]const u8{ ".", "..", "../.." };
-    for (candidates) |candidate| {
-        if (hasCursorSdkNodeModule(candidate)) return try allocator.dupe(u8, candidate);
+    fn closeStdin(self: *AcpProcess) !void {
+        if (self.child.stdin) |stdin| {
+            stdin.close(self.threaded.io());
+            self.child.stdin = null;
+        }
+    }
+
+    fn stop(self: *AcpProcess) void {
+        if (self.finished or self.child.id == null) return;
+        self.child.kill(self.threaded.io());
+        self.finished = true;
+        self.child.stdin = null;
+        self.child.stdout = null;
+    }
+
+    fn deinit(self: *AcpProcess) void {
+        unregisterActiveChild(&self.child);
+        if (!self.finished and self.child.id != null) {
+            self.child.kill(self.threaded.io());
+        }
+        if (self.child.stdin) |stdin| stdin.close(self.threaded.io());
+        self.env_map.deinit();
+        self.allocator.free(self.executable);
+        self.threaded.deinit();
+    }
+};
+
+fn registerActiveChild(child: *std.process.Child, stdin: ?std.Io.File, session_id: []const u8) void {
+    active_process_state.mutex.lock();
+    defer active_process_state.mutex.unlock();
+    active_process_state.child = child;
+    active_process_state.stdin = stdin;
+    active_process_state.session_id = session_id;
+}
+
+fn unregisterActiveChild(child: *std.process.Child) void {
+    active_process_state.mutex.lock();
+    defer active_process_state.mutex.unlock();
+    if (active_process_state.child == child) {
+        active_process_state.child = null;
+        active_process_state.stdin = null;
+        active_process_state.session_id = null;
+    }
+}
+
+fn takeAcpLineAlloc(allocator: std.mem.Allocator, reader: anytype) !?[]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+
+    _ = reader.interface.streamDelimiterLimit(&writer.writer, '\n', .limited(MAX_ACP_LINE_BYTES)) catch |err| switch (err) {
+        error.StreamTooLong => return error.CursorAcpMessageTooLarge,
+        else => return err,
+    };
+    const has_bytes = writer.written().len > 0;
+    _ = reader.interface.discardDelimiterInclusive('\n') catch |err| switch (err) {
+        error.EndOfStream => {
+            if (!has_bytes) {
+                writer.deinit();
+                return null;
+            }
+        },
+        else => return err,
+    };
+    return try writer.toOwnedSlice();
+}
+
+const AcpCapabilities = struct {
+    image: bool = false,
+    load_session: bool = false,
+    list_sessions: bool = false,
+};
+
+const ListThreadsState = struct {
+    saw_initialize: bool = false,
+    threads: std.ArrayList(provider_types.ChatThreadSummary) = .empty,
+
+    fn deinit(self: *ListThreadsState, allocator: std.mem.Allocator) void {
+        for (self.threads.items) |thread| {
+            allocator.free(thread.id);
+            allocator.free(thread.title);
+        }
+        self.threads.deinit(allocator);
+    }
+};
+
+const ReadThreadState = struct {
+    saw_initialize: bool = false,
+    messages: std.ArrayList(provider_types.ChatMessage) = .empty,
+    title: ?[]u8 = null,
+
+    fn deinit(self: *ReadThreadState, allocator: std.mem.Allocator) void {
+        for (self.messages.items) |message| {
+            allocator.free(message.author);
+            allocator.free(message.body);
+        }
+        self.messages.deinit(allocator);
+        if (self.title) |title| allocator.free(title);
+    }
+};
+
+const SendPromptState = struct {
+    capabilities: AcpCapabilities = .{},
+    session_id: ?[]u8 = null,
+    reply: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *SendPromptState, allocator: std.mem.Allocator) void {
+        if (self.session_id) |session_id| allocator.free(session_id);
+        self.reply.deinit(allocator);
+    }
+};
+
+const SendLineAction = enum {
+    continue_reading,
+    session_ready,
+    prompt_done,
+};
+
+fn handleListThreadsLine(allocator: std.mem.Allocator, line: []const u8, state: *ListThreadsState) !bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+    defer parsed.deinit();
+    try failIfJsonRpcError(parsed.value);
+    if (responseId(parsed.value)) |id| {
+        if (id == 1) {
+            const capabilities = parseCapabilities(parsed.value);
+            if (!capabilities.list_sessions) return error.UnsupportedOperation;
+            state.saw_initialize = true;
+            return false;
+        }
+        if (id == 2) {
+            try parseSessionListResponse(allocator, parsed.value, &state.threads);
+            return true;
+        }
+    }
+    return false;
+}
+
+fn handleReadThreadLine(allocator: std.mem.Allocator, line: []const u8, thread_id: []const u8, state: *ReadThreadState) !bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+    defer parsed.deinit();
+    try failIfJsonRpcError(parsed.value);
+    if (responseId(parsed.value)) |id| {
+        if (id == 1) {
+            const capabilities = parseCapabilities(parsed.value);
+            if (!capabilities.load_session) return error.UnsupportedOperation;
+            state.saw_initialize = true;
+            return false;
+        }
+        if (id == 2) {
+            if (state.title == null) state.title = try allocator.dupe(u8, thread_id);
+            return true;
+        }
+    }
+    if (isMethod(parsed.value, "session/update")) {
+        try handleReadSessionUpdate(allocator, parsed.value, state);
+    }
+    return false;
+}
+
+fn handleSendPromptLine(
+    allocator: std.mem.Allocator,
+    line: []const u8,
+    request: provider_types.SendPromptRequest,
+    state: *SendPromptState,
+    stdin: ?std.Io.File,
+) !SendLineAction {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, line, .{});
+    defer parsed.deinit();
+    try failIfJsonRpcError(parsed.value);
+
+    if (responseId(parsed.value)) |id| {
+        if (id == 1) {
+            state.capabilities = parseCapabilities(parsed.value);
+            return .continue_reading;
+        }
+        if (id == 2) {
+            if (state.session_id == null) {
+                const session_id = parseSessionId(parsed.value) orelse request.thread_id orelse return error.CursorAcpFailed;
+                state.session_id = try allocator.dupe(u8, session_id);
+            }
+            return .session_ready;
+        }
+        if (id == 3) return .prompt_done;
+    }
+
+    if (isMethod(parsed.value, "session/request_permission")) {
+        try handlePermissionRequest(allocator, parsed.value, request, stdin);
+        return .continue_reading;
+    }
+    if (isMethod(parsed.value, "session/update")) {
+        try handleLiveSessionUpdate(allocator, parsed.value, request, state);
+        return .continue_reading;
+    }
+    return .continue_reading;
+}
+
+fn makeInitializeRequestAlloc(allocator: std.mem.Allocator, id: i64) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var stringify: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try stringify.beginObject();
+    try writeJsonRpcHead(&stringify, id, "initialize");
+    try stringify.objectField("params");
+    try stringify.beginObject();
+    try stringify.objectField("protocolVersion");
+    try stringify.write(1);
+    try stringify.objectField("clientCapabilities");
+    try stringify.beginObject();
+    try stringify.objectField("fs");
+    try stringify.beginObject();
+    try stringify.objectField("readTextFile");
+    try stringify.write(false);
+    try stringify.objectField("writeTextFile");
+    try stringify.write(false);
+    try stringify.endObject();
+    try stringify.objectField("terminal");
+    try stringify.write(false);
+    try stringify.endObject();
+    try stringify.objectField("clientInfo");
+    try stringify.beginObject();
+    try stringify.objectField("name");
+    try stringify.write("verde");
+    try stringify.objectField("version");
+    try stringify.write("0.1.0");
+    try stringify.endObject();
+    try stringify.endObject();
+    try stringify.endObject();
+    return writer.toOwnedSlice();
+}
+
+fn makeSessionListRequestAlloc(allocator: std.mem.Allocator, id: i64, cwd_owned: []u8) ![]u8 {
+    defer allocator.free(cwd_owned);
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var stringify: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try stringify.beginObject();
+    try writeJsonRpcHead(&stringify, id, "session/list");
+    try stringify.objectField("params");
+    try stringify.beginObject();
+    try stringify.objectField("cwd");
+    try stringify.write(cwd_owned);
+    try stringify.endObject();
+    try stringify.endObject();
+    return writer.toOwnedSlice();
+}
+
+fn makeSessionNewRequestAlloc(allocator: std.mem.Allocator, id: i64, cwd: []const u8) ![]u8 {
+    return makeSessionSetupRequestAlloc(allocator, id, "session/new", null, cwd);
+}
+
+fn makeSessionLoadRequestAlloc(allocator: std.mem.Allocator, id: i64, session_id: []const u8, cwd: []const u8) ![]u8 {
+    return makeSessionSetupRequestAlloc(allocator, id, "session/load", session_id, cwd);
+}
+
+fn makeSessionSetupRequestAlloc(
+    allocator: std.mem.Allocator,
+    id: i64,
+    method: []const u8,
+    session_id: ?[]const u8,
+    cwd: []const u8,
+) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var stringify: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try stringify.beginObject();
+    try writeJsonRpcHead(&stringify, id, method);
+    try stringify.objectField("params");
+    try stringify.beginObject();
+    if (session_id) |sid| {
+        try stringify.objectField("sessionId");
+        try stringify.write(sid);
+    }
+    try stringify.objectField("cwd");
+    try stringify.write(cwd);
+    try stringify.objectField("mcpServers");
+    try stringify.beginArray();
+    try stringify.endArray();
+    try stringify.endObject();
+    try stringify.endObject();
+    return writer.toOwnedSlice();
+}
+
+fn makePromptRequestAlloc(
+    allocator: std.mem.Allocator,
+    id: i64,
+    session_id: []const u8,
+    request: provider_types.SendPromptRequest,
+    image_supported: bool,
+) ![]u8 {
+    const images = try collectImageAttachments(allocator, request);
+    defer allocator.free(images);
+    if (images.len > 0 and !image_supported) return error.CursorAttachmentsUnsupported;
+
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var stringify: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try stringify.beginObject();
+    try writeJsonRpcHead(&stringify, id, "session/prompt");
+    try stringify.objectField("params");
+    try stringify.beginObject();
+    try stringify.objectField("sessionId");
+    try stringify.write(session_id);
+    try stringify.objectField("prompt");
+    try stringify.beginArray();
+    try stringify.beginObject();
+    try stringify.objectField("type");
+    try stringify.write("text");
+    try stringify.objectField("text");
+    try stringify.write(request.prompt);
+    try stringify.endObject();
+    for (images) |image| {
+        try writeImageContentBlock(allocator, &stringify, image);
+    }
+    try stringify.endArray();
+    try stringify.endObject();
+    try stringify.endObject();
+    return writer.toOwnedSlice();
+}
+
+fn makeCancelNotificationAlloc(allocator: std.mem.Allocator, session_id: []const u8) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var stringify: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try stringify.beginObject();
+    try stringify.objectField("jsonrpc");
+    try stringify.write("2.0");
+    try stringify.objectField("method");
+    try stringify.write("session/cancel");
+    try stringify.objectField("params");
+    try stringify.beginObject();
+    try stringify.objectField("sessionId");
+    try stringify.write(session_id);
+    try stringify.endObject();
+    try stringify.endObject();
+    return writer.toOwnedSlice();
+}
+
+fn makePermissionResponseAlloc(allocator: std.mem.Allocator, id: i64, option_id: []const u8) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var stringify: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try stringify.beginObject();
+    try stringify.objectField("jsonrpc");
+    try stringify.write("2.0");
+    try stringify.objectField("id");
+    try stringify.write(id);
+    try stringify.objectField("result");
+    try stringify.beginObject();
+    try stringify.objectField("outcome");
+    try stringify.beginObject();
+    try stringify.objectField("outcome");
+    try stringify.write("selected");
+    try stringify.objectField("optionId");
+    try stringify.write(option_id);
+    try stringify.endObject();
+    try stringify.endObject();
+    try stringify.endObject();
+    return writer.toOwnedSlice();
+}
+
+fn writeJsonRpcHead(stringify: *std.json.Stringify, id: i64, method: []const u8) !void {
+    try stringify.objectField("jsonrpc");
+    try stringify.write("2.0");
+    try stringify.objectField("id");
+    try stringify.write(id);
+    try stringify.objectField("method");
+    try stringify.write(method);
+}
+
+fn writeImageContentBlock(allocator: std.mem.Allocator, stringify: *std.json.Stringify, image: provider_types.ImageAttachment) !void {
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(threaded.io(), image.path, allocator, .limited(20 * 1024 * 1024));
+    defer allocator.free(bytes);
+    const encoded = try encodeBase64Alloc(allocator, bytes);
+    defer allocator.free(encoded);
+
+    try stringify.beginObject();
+    try stringify.objectField("type");
+    try stringify.write("image");
+    try stringify.objectField("mimeType");
+    try stringify.write(mimeTypeForPath(image.path));
+    try stringify.objectField("data");
+    try stringify.write(encoded);
+    try stringify.endObject();
+}
+
+fn collectImageAttachments(allocator: std.mem.Allocator, request: provider_types.SendPromptRequest) ![]const provider_types.ImageAttachment {
+    const legacy_count: usize = if (request.image) |legacy|
+        if (containsImagePath(request.images, legacy.path)) 0 else 1
+    else
+        0;
+    const images = try allocator.alloc(provider_types.ImageAttachment, request.images.len + legacy_count);
+    @memcpy(images[0..request.images.len], request.images);
+    if (request.image) |legacy| {
+        if (legacy_count == 1) images[request.images.len] = legacy;
+    }
+    return images;
+}
+
+fn containsImagePath(images: []const provider_types.ImageAttachment, path: []const u8) bool {
+    for (images) |image| {
+        if (std.mem.eql(u8, image.path, path)) return true;
+    }
+    return false;
+}
+
+fn encodeBase64Alloc(allocator: std.mem.Allocator, bytes: []const u8) ![]u8 {
+    const size = std.base64.standard.Encoder.calcSize(bytes.len);
+    const out = try allocator.alloc(u8, size);
+    _ = std.base64.standard.Encoder.encode(out, bytes);
+    return out;
+}
+
+fn mimeTypeForPath(path: []const u8) []const u8 {
+    const ext = std.fs.path.extension(path);
+    if (std.ascii.eqlIgnoreCase(ext, ".jpg") or std.ascii.eqlIgnoreCase(ext, ".jpeg")) return "image/jpeg";
+    if (std.ascii.eqlIgnoreCase(ext, ".gif")) return "image/gif";
+    if (std.ascii.eqlIgnoreCase(ext, ".webp")) return "image/webp";
+    return "image/png";
+}
+
+fn writeJsonLineToFile(allocator: std.mem.Allocator, file: std.Io.File, line: []const u8) !void {
+    var threaded: std.Io.Threaded = .init(allocator, .{});
+    defer threaded.deinit();
+    var write_buffer: [16 * 1024]u8 = undefined;
+    var writer = file.writer(threaded.io(), &write_buffer);
+    try writer.interface.writeAll(line);
+    try writer.interface.writeByte('\n');
+    try writer.interface.flush();
+}
+
+fn responseId(value: std.json.Value) ?i64 {
+    return getOptionalObjectInteger(value, "id");
+}
+
+fn isMethod(value: std.json.Value, method: []const u8) bool {
+    const actual = getOptionalObjectString(value, "method") orelse return false;
+    return std.mem.eql(u8, actual, method);
+}
+
+fn failIfJsonRpcError(value: std.json.Value) !void {
+    const error_value = getObjectField(value, "error") orelse return;
+    const message = getOptionalObjectString(error_value, "message") orelse "";
+    if (isAuthError(message)) return error.CursorSignedOut;
+    runtime_log.diagnostic("cursor.acp error: {s}", .{message});
+    return error.CursorAcpFailed;
+}
+
+fn parseCapabilities(value: std.json.Value) AcpCapabilities {
+    const result = getObjectField(value, "result") orelse return .{};
+    const agent = getObjectField(result, "agentCapabilities") orelse return .{};
+    const prompt = getObjectField(agent, "promptCapabilities");
+    const sessions = getObjectField(agent, "sessionCapabilities");
+    return .{
+        .image = if (prompt) |p| getOptionalObjectBool(p, "image") orelse false else false,
+        .load_session = getOptionalObjectBool(agent, "loadSession") orelse false,
+        .list_sessions = if (sessions) |s| getObjectField(s, "list") != null else false,
+    };
+}
+
+fn parseSessionId(value: std.json.Value) ?[]const u8 {
+    const result = getObjectField(value, "result") orelse return null;
+    return getOptionalObjectString(result, "sessionId");
+}
+
+fn parseSessionListResponse(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+    threads: *std.ArrayList(provider_types.ChatThreadSummary),
+) !void {
+    const result = getObjectField(value, "result") orelse return;
+    const sessions = getObjectField(result, "sessions") orelse return;
+    if (sessions != .array) return;
+    for (sessions.array.items) |session| {
+        if (session != .object) continue;
+        const id = getOptionalObjectString(session, "sessionId") orelse continue;
+        const title = getOptionalObjectString(session, "title") orelse id;
+        try threads.append(allocator, .{
+            .id = try allocator.dupe(u8, id),
+            .title = try allocator.dupe(u8, title),
+        });
+    }
+}
+
+fn handleReadSessionUpdate(allocator: std.mem.Allocator, value: std.json.Value, state: *ReadThreadState) !void {
+    const update = sessionUpdateObject(value) orelse return;
+    const kind = getOptionalObjectString(update, "sessionUpdate") orelse return;
+    if (std.mem.eql(u8, kind, "session_info_update")) {
+        if (getOptionalObjectString(update, "title")) |title| {
+            if (state.title) |old| allocator.free(old);
+            state.title = try allocator.dupe(u8, title);
+        }
+        return;
+    }
+    const role: provider_types.MessageRole = if (std.mem.eql(u8, kind, "user_message_chunk"))
+        .user
+    else if (std.mem.eql(u8, kind, "agent_message_chunk"))
+        .assistant
+    else
+        return;
+    const text = contentText(update) orelse return;
+    try appendChatMessageChunk(allocator, &state.messages, role, text);
+}
+
+fn handleLiveSessionUpdate(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+    request: provider_types.SendPromptRequest,
+    state: *SendPromptState,
+) !void {
+    const update = sessionUpdateObject(value) orelse return;
+    const kind = getOptionalObjectString(update, "sessionUpdate") orelse return;
+    if (std.mem.eql(u8, kind, "agent_message_chunk")) {
+        const text = contentText(update) orelse return;
+        if (text.len == 0) return;
+        try state.reply.appendSlice(allocator, text);
+        if (request.on_stream_delta) |on_stream_delta| {
+            on_stream_delta(request.stream_context, text);
+        }
+        return;
+    }
+    if (std.mem.eql(u8, kind, "tool_call") or std.mem.eql(u8, kind, "tool_call_update")) {
+        const event = (try cursorToolEventAlloc(allocator, update, kind)) orelse return;
+        defer event.deinit(allocator);
+        if (request.on_stream_event) |on_stream_event| {
+            on_stream_event(request.stream_context, .{ .message = .{ .title = event.title, .body = event.body } });
+        }
+    }
+}
+
+fn handlePermissionRequest(
+    allocator: std.mem.Allocator,
+    value: std.json.Value,
+    request: provider_types.SendPromptRequest,
+    stdin: ?std.Io.File,
+) !void {
+    const id = responseId(value) orelse return;
+    const params = getObjectField(value, "params") orelse value;
+    const title = getOptionalObjectString(params, "title") orelse "Cursor permission request";
+    const body = permissionBody(params);
+    const call_id = getOptionalObjectString(params, "toolCallId") orelse getOptionalObjectString(params, "permissionId") orelse "cursor-tool";
+    const decision = if (request.on_approval_request) |on_approval_request|
+        on_approval_request(request.stream_context, .{
+            .call_id = call_id,
+            .title = title,
+            .body = body,
+        })
+    else
+        .deny;
+    if (stdin) |file| {
+        const option_id = permissionOptionId(params, decision);
+        const response = try makePermissionResponseAlloc(allocator, id, option_id);
+        defer allocator.free(response);
+        try writeJsonLineToFile(allocator, file, response);
+    }
+}
+
+fn permissionOptionId(params: std.json.Value, decision: provider_types.ApprovalDecision) []const u8 {
+    const fallback = if (decision == .approve) "allow-once" else "reject-once";
+    const options = getObjectField(params, "options") orelse return fallback;
+    if (options != .array) return fallback;
+
+    var first: ?[]const u8 = null;
+    for (options.array.items) |option| {
+        if (option != .object) continue;
+        const id = getOptionalObjectString(option, "optionId") orelse getOptionalObjectString(option, "id") orelse continue;
+        if (first == null) first = id;
+        if (decision == .approve) {
+            if (containsAnyIgnoreCase(id, &.{ "allow", "approve", "accept" })) return id;
+        } else {
+            if (containsAnyIgnoreCase(id, &.{ "reject", "deny", "disallow" })) return id;
+        }
+    }
+    return first orelse fallback;
+}
+
+fn containsAnyIgnoreCase(haystack: []const u8, needles: []const []const u8) bool {
+    for (needles) |needle| {
+        if (std.ascii.indexOfIgnoreCase(haystack, needle) != null) return true;
+    }
+    return false;
+}
+
+fn permissionBody(params: std.json.Value) []const u8 {
+    if (getOptionalObjectString(params, "body")) |body| return body;
+    if (getOptionalObjectString(params, "description")) |description| return description;
+    if (getOptionalObjectString(params, "toolCallId")) |tool| return tool;
+    return "";
+}
+
+fn sessionUpdateObject(value: std.json.Value) ?std.json.Value {
+    const params = getObjectField(value, "params") orelse return null;
+    return getObjectField(params, "update");
+}
+
+fn contentText(update: std.json.Value) ?[]const u8 {
+    const content = getObjectField(update, "content") orelse return null;
+    if (content == .object) {
+        return getOptionalObjectString(content, "text");
     }
     return null;
 }
 
-fn hasCursorSdkNodeModule(cwd: []const u8) bool {
-    var threaded = std.Io.Threaded.init_single_threaded;
-    const manifest = std.fmt.allocPrint(
-        std.heap.page_allocator,
-        "{s}/node_modules/@cursor/sdk/package.json",
-        .{cwd},
-    ) catch return false;
-    defer std.heap.page_allocator.free(manifest);
-    std.Io.Dir.cwd().access(threaded.io(), manifest, .{}) catch return false;
-    return true;
+const CursorToolEvent = struct {
+    title: []u8,
+    body: []u8,
+
+    fn deinit(self: CursorToolEvent, allocator: std.mem.Allocator) void {
+        allocator.free(self.title);
+        allocator.free(self.body);
+    }
+};
+
+fn cursorToolEventAlloc(allocator: std.mem.Allocator, update: std.json.Value, kind: []const u8) !?CursorToolEvent {
+    const title_text = cursorToolTitle(update);
+    const body = try cursorToolBodyAlloc(allocator, update);
+    errdefer if (body) |text| allocator.free(text);
+    const status = getTrimmedObjectString(update, "status");
+
+    if (body) |text| {
+        if (isNoisyCursorToolStatus(text)) {
+            allocator.free(text);
+            return null;
+        }
+        return .{
+            .title = try allocator.dupe(u8, title_text),
+            .body = text,
+        };
+    }
+    if (status) |text| {
+        if (isNoisyCursorToolStatus(text)) return null;
+        return .{
+            .title = try allocator.dupe(u8, title_text),
+            .body = try allocator.dupe(u8, text),
+        };
+    }
+    if (std.mem.eql(u8, kind, "tool_call") and !std.mem.eql(u8, title_text, "Cursor tool")) {
+        return .{
+            .title = try allocator.dupe(u8, title_text),
+            .body = try allocator.dupe(u8, "Started"),
+        };
+    }
+    return null;
 }
 
-const BridgeResponse = struct {
-    thread_id: []u8 = &.{},
-    run_id: ?[]u8 = null,
-    reply_text: []u8 = &.{},
-    title: ?[]u8 = null,
-    items: ?[]u8 = null,
-    updated_at: ?i64 = null,
-
-    fn deinit(self: BridgeResponse, allocator: std.mem.Allocator) void {
-        if (self.thread_id.len > 0) allocator.free(self.thread_id);
-        if (self.run_id) |run_id| allocator.free(run_id);
-        if (self.reply_text.len > 0) allocator.free(self.reply_text);
-        if (self.title) |title| allocator.free(title);
-        if (self.items) |items| allocator.free(items);
+fn cursorToolTitle(update: std.json.Value) []const u8 {
+    if (getTrimmedObjectString(update, "title")) |title| return title;
+    if (getTrimmedObjectString(update, "name")) |name| return name;
+    if (getTrimmedObjectString(update, "toolName")) |tool_name| return tool_name;
+    if (getObjectField(update, "toolCall")) |tool_call| {
+        if (getTrimmedObjectString(tool_call, "title")) |title| return title;
+        if (getTrimmedObjectString(tool_call, "name")) |name| return name;
+        if (getTrimmedObjectString(tool_call, "toolName")) |tool_name| return tool_name;
     }
-};
+    return "Cursor tool";
+}
 
-const BridgeParseState = struct {
-    response: BridgeResponse = .{},
-    reply: std.ArrayList(u8) = .empty,
-    saw_error: bool = false,
-    error_message: ?[]u8 = null,
-
-    fn deinit(self: *BridgeParseState, allocator: std.mem.Allocator) void {
-        self.response.deinit(allocator);
-        self.reply.deinit(allocator);
-        if (self.error_message) |message| allocator.free(message);
+fn cursorToolBodyAlloc(allocator: std.mem.Allocator, update: std.json.Value) !?[]u8 {
+    if (getTrimmedObjectString(update, "command")) |command| return try toolBodyWithNameAlloc(allocator, update, command);
+    if (getTrimmedObjectString(update, "body")) |body| return try allocator.dupe(u8, body);
+    if (getTrimmedObjectString(update, "description")) |description| return try allocator.dupe(u8, description);
+    if (try cursorToolStructuredBodyAlloc(allocator, update)) |body| return body;
+    if (getObjectField(update, "toolCall")) |tool_call| {
+        if (getTrimmedObjectString(tool_call, "command")) |command| return try toolBodyWithNameAlloc(allocator, update, command);
+        if (getTrimmedObjectString(tool_call, "body")) |body| return try allocator.dupe(u8, body);
+        if (getTrimmedObjectString(tool_call, "description")) |description| return try allocator.dupe(u8, description);
+        if (try cursorToolStructuredBodyAlloc(allocator, tool_call)) |body| return body;
     }
-};
+    if (contentText(update)) |text| {
+        const trimmed = std.mem.trim(u8, text, &std.ascii.whitespace);
+        if (trimmed.len > 0) return try allocator.dupe(u8, trimmed);
+    }
+    return null;
+}
 
-const BridgeCommand = enum {
-    auth,
-    list_threads,
-    list_models,
-    read_thread,
-    send_prompt,
-    interrupt_thread,
-};
-
-const BridgeInput = struct {
-    request: ?provider_types.SendPromptRequest = null,
-    thread_id: ?[]const u8 = null,
-    turn_id: ?[]const u8 = null,
-};
-
-fn makeBridgeRequestJsonAlloc(
-    allocator: std.mem.Allocator,
-    config: Config,
-    command: BridgeCommand,
-    input: BridgeInput,
-) ![]u8 {
-    var writer: std.Io.Writer.Allocating = .init(allocator);
-    defer writer.deinit();
-
-    var stringify: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
-    try stringify.beginObject();
-    try stringify.objectField("command");
-    try stringify.write(@tagName(command));
-    try stringify.objectField("cwd");
-    try stringify.write(if (input.request) |request| request.cwd orelse config.cwd else config.cwd);
-    try stringify.objectField("model");
-    try stringify.write(if (input.request) |request| request.model orelse config.model orelse DEFAULT_MODEL else config.model orelse DEFAULT_MODEL);
-    try stringify.objectField("modelParams");
-    if (input.request) |request| {
-        if (request.cursor_model_params_json) |params_json| {
-            var parsed_params = try std.json.parseFromSlice(std.json.Value, allocator, params_json, .{});
-            defer parsed_params.deinit();
-            try stringify.write(parsed_params.value);
-        } else {
-            try stringify.write(null);
+fn cursorToolStructuredBodyAlloc(allocator: std.mem.Allocator, value: std.json.Value) !?[]u8 {
+    const field_names = [_][]const u8{ "input", "args", "arguments", "rawInput", "params" };
+    for (field_names) |field_name| {
+        const field = getObjectField(value, field_name) orelse continue;
+        switch (field) {
+            .string => |text| {
+                const trimmed = std.mem.trim(u8, text, &std.ascii.whitespace);
+                if (trimmed.len > 0) return try toolBodyWithNameAlloc(allocator, value, trimmed);
+            },
+            .object, .array => {
+                const json = try jsonValueCompactAlloc(allocator, field);
+                errdefer allocator.free(json);
+                const trimmed = std.mem.trim(u8, json, &std.ascii.whitespace);
+                if (trimmed.len == 0) {
+                    allocator.free(json);
+                    continue;
+                }
+                return try toolBodyWithNameOwnedAlloc(allocator, value, json);
+            },
+            else => {},
         }
-    } else {
-        try stringify.write(null);
     }
-    try stringify.objectField("threadId");
-    try stringify.write(input.thread_id orelse if (input.request) |request| request.thread_id else null);
-    try stringify.objectField("turnId");
-    try stringify.write(input.turn_id);
-    try stringify.objectField("title");
-    try stringify.write(if (input.request) |request| request.thread_title else null);
-    try stringify.objectField("prompt");
-    try stringify.write(if (input.request) |request| request.prompt else null);
-    try stringify.objectField("images");
-    if (input.request) |request| {
-        try writePromptImages(&stringify, request);
-    } else {
-        try stringify.write(null);
-    }
-    try stringify.objectField("limit");
-    try stringify.write(IMPORT_MESSAGE_LIMIT);
-    try stringify.endObject();
+    return null;
+}
 
+fn toolBodyWithNameAlloc(allocator: std.mem.Allocator, update: std.json.Value, body: []const u8) ![]u8 {
+    const title = cursorToolTitle(update);
+    if (std.mem.eql(u8, title, "Cursor tool")) return allocator.dupe(u8, body);
+    return std.fmt.allocPrint(allocator, "{s}: {s}", .{ title, body });
+}
+
+fn toolBodyWithNameOwnedAlloc(allocator: std.mem.Allocator, update: std.json.Value, body: []u8) ![]u8 {
+    const title = cursorToolTitle(update);
+    if (std.mem.eql(u8, title, "Cursor tool")) return body;
+    defer allocator.free(body);
+    return std.fmt.allocPrint(allocator, "{s}: {s}", .{ title, body });
+}
+
+fn jsonValueCompactAlloc(allocator: std.mem.Allocator, value: std.json.Value) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var stringify: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try stringify.write(value);
     return writer.toOwnedSlice();
 }
 
-fn writePromptImages(stringify: *std.json.Stringify, request: provider_types.SendPromptRequest) !void {
-    try stringify.beginArray();
-    if (request.image) |image| {
-        try writePromptImage(stringify, image);
-    }
-    for (request.images) |image| {
-        if (request.image) |legacy| {
-            if (std.mem.eql(u8, legacy.path, image.path)) continue;
-        }
-        try writePromptImage(stringify, image);
-    }
-    try stringify.endArray();
+fn getTrimmedObjectString(value: std.json.Value, key: []const u8) ?[]const u8 {
+    const text = getOptionalObjectString(value, key) orelse return null;
+    const trimmed = std.mem.trim(u8, text, &std.ascii.whitespace);
+    return if (trimmed.len > 0) trimmed else null;
 }
 
-fn writePromptImage(stringify: *std.json.Stringify, image: provider_types.ImageAttachment) !void {
-    try stringify.beginObject();
-    try stringify.objectField("path");
-    try stringify.write(image.path);
-    try stringify.endObject();
+fn isNoisyCursorToolStatus(text: []const u8) bool {
+    const trimmed = std.mem.trim(u8, text, &std.ascii.whitespace);
+    return std.mem.eql(u8, trimmed, "pending") or
+        std.mem.eql(u8, trimmed, "in_progress") or
+        std.mem.eql(u8, trimmed, "completed");
 }
 
-fn parseBridgeEventsAlloc(
+fn appendChatMessageChunk(
     allocator: std.mem.Allocator,
-    payload: []const u8,
-    term: std.process.Child.Term,
-    request: ?provider_types.SendPromptRequest,
-) !BridgeResponse {
-    var state: BridgeParseState = .{};
-    errdefer state.deinit(allocator);
+    messages: *std.ArrayList(provider_types.ChatMessage),
+    role: provider_types.MessageRole,
+    text: []const u8,
+) !void {
+    const trimmed = std.mem.trim(u8, text, &std.ascii.whitespace);
+    if (trimmed.len == 0) return;
+    if (messages.items.len > 0 and messages.items[messages.items.len - 1].role == role) {
+        const old = messages.items[messages.items.len - 1].body;
+        const combined = try std.fmt.allocPrint(allocator, "{s}{s}", .{ old, text });
+        allocator.free(old);
+        messages.items[messages.items.len - 1].body = combined;
+        return;
+    }
+    try messages.append(allocator, .{
+        .role = role,
+        .author = try allocator.dupe(u8, switch (role) {
+            .user => "You",
+            .assistant => "Cursor",
+            .system => "System",
+        }),
+        .body = try allocator.dupe(u8, trimmed),
+    });
+}
+
+fn parseModelsTextAlloc(allocator: std.mem.Allocator, payload: []const u8) ![]provider_types.ModelInfo {
+    var raw_models: std.ArrayList(RawCursorModel) = .empty;
+    defer raw_models.deinit(allocator);
 
     var lines = std.mem.splitScalar(u8, payload, '\n');
-    while (lines.next()) |raw_line| {
-        _ = try processBridgeLine(allocator, raw_line, request, &state);
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trim(u8, line_raw, " \t\r");
+        if (line.len == 0 or std.mem.eql(u8, line, "Available models")) continue;
+        const sep = std.mem.indexOf(u8, line, " - ") orelse continue;
+        const id = std.mem.trim(u8, line[0..sep], " \t");
+        var name = std.mem.trim(u8, line[sep + 3 ..], " \t");
+        if (std.mem.endsWith(u8, name, " (current)")) name = name[0 .. name.len - " (current)".len];
+        if (std.mem.endsWith(u8, name, " (default)")) name = name[0 .. name.len - " (default)".len];
+        if (id.len == 0 or name.len == 0) continue;
+        try raw_models.append(allocator, .{ .id = id, .name = name });
+    }
+    if (raw_models.items.len == 0) return staticModelsAlloc(allocator);
+
+    var models: std.ArrayList(provider_types.ModelInfo) = .empty;
+    errdefer {
+        for (models.items) |model| model.deinit(allocator);
+        models.deinit(allocator);
     }
 
-    try finishBridgeResponse(term, state.saw_error);
+    const consumed = try allocator.alloc(bool, raw_models.items.len);
+    defer allocator.free(consumed);
+    @memset(consumed, false);
 
-    state.response.reply_text = try state.reply.toOwnedSlice(allocator);
-    state.reply = .empty;
-    const response = state.response;
-    state.response = .{};
-    return response;
+    const pinned = [_][]const u8{ "auto", "composer-2.5", "composer-2" };
+    for (pinned) |id| {
+        _ = try appendCursorModelByBaseId(allocator, raw_models.items, consumed, &models, id);
+    }
+
+    for (raw_models.items, 0..) |raw, index| {
+        if (consumed[index]) continue;
+        if (stripFastSuffix(raw.id)) |base_id| {
+            if (rawModelIndex(raw_models.items, base_id) != null) {
+                _ = try appendCursorModelByBaseId(allocator, raw_models.items, consumed, &models, base_id);
+                continue;
+            }
+        }
+        try appendModel(allocator, &models, raw.id, raw.name, false);
+        consumed[index] = true;
+    }
+    return models.toOwnedSlice(allocator);
 }
 
-fn processBridgeLine(
+const RawCursorModel = struct {
+    id: []const u8,
+    name: []const u8,
+};
+
+fn appendCursorModelByBaseId(
     allocator: std.mem.Allocator,
-    raw_line: []const u8,
-    request: ?provider_types.SendPromptRequest,
-    state: *BridgeParseState,
+    raw_models: []const RawCursorModel,
+    consumed: []bool,
+    models: *std.ArrayList(provider_types.ModelInfo),
+    base_id: []const u8,
 ) !bool {
-    const line = std.mem.trim(u8, raw_line, " \t\r");
-    if (line.len == 0) return false;
+    const fast_id = try std.fmt.allocPrint(allocator, "{s}-fast", .{base_id});
+    defer allocator.free(fast_id);
+    const base_index = rawModelIndex(raw_models, base_id);
+    const fast_index = rawModelIndex(raw_models, fast_id);
 
-    var parsed = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch return false;
-    defer parsed.deinit();
-    if (parsed.value != .object) return false;
-
-    const event_type = getOptionalObjectString(parsed.value, "type") orelse return false;
-    if (std.mem.eql(u8, event_type, "error")) {
-        state.saw_error = true;
-        if (getOptionalObjectString(parsed.value, "message")) |message| {
-            runtime_log.diagnostic("cursor.bridge error: {s}", .{message});
-            if (state.error_message == null) state.error_message = try allocator.dupe(u8, message);
-        }
-        if (isAuthError(getOptionalObjectString(parsed.value, "message"))) return error.CursorSignedOut;
-        return false;
+    if (base_index) |index| {
+        try appendModel(allocator, models, raw_models[index].id, raw_models[index].name, fast_index != null);
+        consumed[index] = true;
+        if (fast_index) |fi| consumed[fi] = true;
+        return true;
     }
-    if (std.mem.eql(u8, event_type, "thread")) {
-        if (state.response.thread_id.len == 0) {
-            const thread_id = getOptionalObjectString(parsed.value, "threadId") orelse getOptionalObjectString(parsed.value, "agentId") orelse return false;
-            state.response.thread_id = try allocator.dupe(u8, thread_id);
-        }
-        if (state.response.title == null) {
-            if (getOptionalObjectString(parsed.value, "title")) |title| state.response.title = try allocator.dupe(u8, title);
-        }
-        state.response.updated_at = getOptionalObjectInteger(parsed.value, "updatedAt") orelse state.response.updated_at;
-        return false;
-    }
-    if (std.mem.eql(u8, event_type, "turn")) {
-        if (state.response.run_id == null) {
-            const run_id = getOptionalObjectString(parsed.value, "runId") orelse return false;
-            state.response.run_id = try allocator.dupe(u8, run_id);
-        }
-        return false;
-    }
-    if (std.mem.eql(u8, event_type, "delta")) {
-        const text = getOptionalObjectString(parsed.value, "text") orelse return false;
-        try state.reply.appendSlice(allocator, text);
-        if (request) |send_request| {
-            if (send_request.on_stream_delta) |on_stream_delta| {
-                on_stream_delta(send_request.stream_context, text);
-            }
-        }
-        return false;
-    }
-    if (std.mem.eql(u8, event_type, "command")) {
-        const body = getOptionalObjectString(parsed.value, "command") orelse getOptionalObjectString(parsed.value, "body") orelse return false;
-        const failed = getOptionalObjectBool(parsed.value, "failed") orelse false;
-        if (request) |send_request| {
-            if (send_request.on_stream_event) |on_stream_event| {
-                on_stream_event(send_request.stream_context, .{
-                    .message = .{
-                        .title = if (failed) "Command failed" else "Ran command",
-                        .body = body,
-                    },
-                });
-            }
-        }
-        return false;
-    }
-    if (std.mem.eql(u8, event_type, "debug")) {
-        const name = getOptionalObjectString(parsed.value, "name") orelse "unknown";
-        const value = getOptionalObjectInteger(parsed.value, "value") orelse 0;
-        runtime_log.diagnostic("cursor.bridge debug {s}={d}", .{ name, value });
-        return false;
-    }
-    if (std.mem.eql(u8, event_type, "items")) {
-        const json = getObjectField(parsed.value, "items") orelse return false;
-        state.response.items = try std.json.Stringify.valueAlloc(allocator, json, .{ .whitespace = .minified });
-        return false;
-    }
-    if (std.mem.eql(u8, event_type, "final")) {
-        if (getOptionalObjectString(parsed.value, "replyText")) |text| {
-            if (text.len > 0) {
-                state.reply.clearRetainingCapacity();
-                try state.reply.appendSlice(allocator, text);
-            }
-        }
-        if (state.response.thread_id.len == 0) {
-            const thread_id = getOptionalObjectString(parsed.value, "threadId") orelse getOptionalObjectString(parsed.value, "agentId") orelse "";
-            if (thread_id.len > 0) state.response.thread_id = try allocator.dupe(u8, thread_id);
-        }
-        if (state.response.run_id == null) {
-            if (getOptionalObjectString(parsed.value, "runId")) |run_id| state.response.run_id = try allocator.dupe(u8, run_id);
-        }
+    if (fast_index) |index| {
+        try appendModel(allocator, models, raw_models[index].id, raw_models[index].name, false);
+        consumed[index] = true;
         return true;
     }
     return false;
 }
 
-fn finishBridgeResponse(term: std.process.Child.Term, saw_error: bool) !void {
-    if (saw_error) return error.CursorBridgeFailed;
-    switch (term) {
-        .exited => |code| if (code != 0) {
-            return error.CursorBridgeFailed;
-        },
-        else => return error.CursorBridgeFailed,
+fn rawModelIndex(raw_models: []const RawCursorModel, id: []const u8) ?usize {
+    for (raw_models, 0..) |model, index| {
+        if (std.mem.eql(u8, model.id, id)) return index;
     }
+    return null;
 }
 
-fn addBundledNodeModulesEnv(
+fn stripFastSuffix(id: []const u8) ?[]const u8 {
+    return if (std.mem.endsWith(u8, id, "-fast")) id[0 .. id.len - "-fast".len] else null;
+}
+
+fn staticModelsAlloc(allocator: std.mem.Allocator) ![]provider_types.ModelInfo {
+    var models: std.ArrayList(provider_types.ModelInfo) = .empty;
+    errdefer {
+        for (models.items) |model| model.deinit(allocator);
+        models.deinit(allocator);
+    }
+
+    try appendModel(allocator, &models, "auto", "Auto", false);
+    try appendModel(allocator, &models, "composer-2.5", "Composer 2.5", true);
+    try appendModel(allocator, &models, "composer-2", "Composer 2", true);
+    try appendModel(allocator, &models, "gpt-5.5-medium", "GPT-5.5", true);
+    try appendModel(allocator, &models, "gpt-5.4-medium", "GPT-5.4", true);
+    try appendModel(allocator, &models, "claude-opus-4-7-thinking-xhigh", "Claude Opus 4.7 Thinking", true);
+    try appendModel(allocator, &models, "claude-sonnet-4-6", "Claude Sonnet 4.6", false);
+    return models.toOwnedSlice(allocator);
+}
+
+fn appendModel(
     allocator: std.mem.Allocator,
-    env_map: *std.process.Environ.Map,
+    models: *std.ArrayList(provider_types.ModelInfo),
+    id: []const u8,
+    name: []const u8,
+    fast_supported: bool,
 ) !void {
-    const bundled = bundledNodeModulesPathAlloc(allocator) catch return;
-    defer allocator.free(bundled);
+    try models.append(allocator, .{
+        .provider_id = try allocator.dupe(u8, "cursor"),
+        .provider_name = try allocator.dupe(u8, "Cursor"),
+        .model_id = try allocator.dupe(u8, id),
+        .model_name = try allocator.dupe(u8, name),
+        .cursor_fast_supported = fast_supported,
+    });
+}
 
-    var threaded = std.Io.Threaded.init(allocator, .{});
-    defer threaded.deinit();
-    std.Io.Dir.cwd().access(threaded.io(), bundled, .{}) catch return;
+fn cursorModelArgAlloc(allocator: std.mem.Allocator, model: []const u8, params_json: ?[]const u8) !?[]u8 {
+    const params = params_json orelse return try allocator.dupe(u8, model);
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, params, .{});
+    defer parsed.deinit();
+    if (parsed.value != .array) return try allocator.dupe(u8, model);
 
-    try env_map.put("VERDE_NODE_MODULES", bundled);
+    var fast: ?bool = null;
+    var reasoning: ?[]const u8 = null;
+    for (parsed.value.array.items) |item| {
+        if (item != .object) continue;
+        const id = getOptionalObjectString(item, "id") orelse continue;
+        const value = getOptionalObjectString(item, "value") orelse continue;
+        if (std.mem.eql(u8, id, "fast")) {
+            fast = std.mem.eql(u8, value, "true");
+        } else if (std.mem.eql(u8, id, "reasoning") or std.mem.eql(u8, id, "effort")) {
+            reasoning = value;
+        }
+    }
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try out.appendSlice(allocator, model);
+    if (reasoning) |value| {
+        if (!std.mem.eql(u8, value, "medium") and std.mem.indexOf(u8, model, value) == null) {
+            try out.append(allocator, '-');
+            try out.appendSlice(allocator, value);
+        }
+    }
+    if (fast == true and !std.mem.endsWith(u8, out.items, "-fast")) {
+        try out.appendSlice(allocator, "-fast");
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+fn resolveCursorExecutableAlloc(
+    allocator: std.mem.Allocator,
+    env_map: *const std.process.Environ.Map,
+    configured: []const u8,
+) ![]u8 {
+    const candidates = [_][]const u8{ configured, DEFAULT_EXECUTABLE, FALLBACK_EXECUTABLE };
+    var tried: [3][]const u8 = .{ "", "", "" };
+    var tried_len: usize = 0;
+    for (candidates) |candidate| {
+        if (candidate.len == 0) continue;
+        var duplicate = false;
+        for (tried[0..tried_len]) |old| {
+            if (std.mem.eql(u8, old, candidate)) duplicate = true;
+        }
+        if (duplicate) continue;
+        tried[tried_len] = candidate;
+        tried_len += 1;
+        return process_env.resolveExecutableInEnvMapAlloc(allocator, env_map, candidate) catch |err| switch (err) {
+            error.FileNotFound, error.AccessDenied => continue,
+            else => return err,
+        };
+    }
+    runtime_log.diagnostic("cursor CLI not found; install with `curl https://cursor.com/install -fsS | bash`, ensure ~/.local/bin is on PATH, then run `agent login`.", .{});
+    return error.FileNotFound;
 }
 
 fn ensureCursorApiKeyEnv(
@@ -544,10 +1320,7 @@ fn loadCursorApiKeyFromUserEnvFilesAlloc(allocator: std.mem.Allocator) ![]u8 {
     for (candidates) |candidate| {
         const path = try std.fs.path.join(allocator, &.{ home, candidate });
         defer allocator.free(path);
-        const api_key = loadCursorApiKeyFromFileAlloc(allocator, path) catch |err| switch (err) {
-            error.FileNotFound, error.AccessDenied, error.IsDir => continue,
-            else => continue,
-        };
+        const api_key = loadCursorApiKeyFromFileAlloc(allocator, path) catch continue;
         if (api_key.len > 0) return api_key;
         allocator.free(api_key);
     }
@@ -593,42 +1366,6 @@ fn parseCursorApiKeyLine(line: []const u8) ?[]const u8 {
     return rest[0..end];
 }
 
-fn bundledNodeModulesPathAlloc(allocator: std.mem.Allocator) ![]u8 {
-    const exe_path = try selfExePathAlloc(allocator);
-    defer allocator.free(exe_path);
-    const exe_dir = std.fs.path.dirname(exe_path) orelse return error.FileNotFound;
-
-    return switch (builtin.os.tag) {
-        .macos => std.fs.path.resolve(allocator, &.{ exe_dir, "..", "Resources", "node_modules" }),
-        else => std.fs.path.resolve(allocator, &.{ exe_dir, "..", "share", "verde", "node_modules" }),
-    };
-}
-
-fn selfExePathAlloc(allocator: std.mem.Allocator) ![]u8 {
-    switch (builtin.os.tag) {
-        .linux => {
-            var buffer: [std.fs.max_path_bytes]u8 = undefined;
-            const len = std.c.readlink("/proc/self/exe", &buffer, buffer.len);
-            if (len < 0) return error.FileNotFound;
-            return allocator.dupe(u8, buffer[0..@intCast(len)]);
-        },
-        .macos => {
-            var size: u32 = std.fs.max_path_bytes;
-            var buffer: [std.fs.max_path_bytes]u8 = undefined;
-            if (_NSGetExecutablePath(&buffer, &size) != 0) {
-                const dynamic_buffer = try allocator.alloc(u8, size);
-                errdefer allocator.free(dynamic_buffer);
-                if (_NSGetExecutablePath(dynamic_buffer.ptr, &size) != 0) return error.NameTooLong;
-                return std.fs.path.resolve(allocator, &.{std.mem.sliceTo(dynamic_buffer, 0)});
-            }
-            return std.fs.path.resolve(allocator, &.{std.mem.sliceTo(&buffer, 0)});
-        },
-        else => return error.FileNotFound,
-    }
-}
-
-extern "c" fn _NSGetExecutablePath(buf: [*]u8, bufsize: *u32) c_int;
-
 fn getOptionalObjectString(value: std.json.Value, key: []const u8) ?[]const u8 {
     if (value != .object) return null;
     const field = value.object.get(key) orelse return null;
@@ -659,518 +1396,188 @@ fn getOptionalObjectBool(value: std.json.Value, key: []const u8) ?bool {
     };
 }
 
-fn isAuthError(message: ?[]const u8) bool {
-    const text = message orelse return false;
-    return std.mem.indexOf(u8, text, "API key") != null or
-        std.mem.indexOf(u8, text, "unauthorized") != null or
-        std.mem.indexOf(u8, text, "Authentication") != null;
+fn isAuthError(message: []const u8) bool {
+    return std.mem.indexOf(u8, message, "auth") != null or
+        std.mem.indexOf(u8, message, "login") != null or
+        std.mem.indexOf(u8, message, "API key") != null or
+        std.mem.indexOf(u8, message, "unauthorized") != null;
 }
 
-fn parseThreadSummariesAlloc(allocator: std.mem.Allocator, payload: []const u8) ![]provider_types.ChatThreadSummary {
-    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
+test "makeInitializeRequestAlloc writes ACP initialize JSON-RPC" {
+    const json = try makeInitializeRequestAlloc(std.testing.allocator, 42);
+    defer std.testing.allocator.free(json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
     defer parsed.deinit();
-    if (parsed.value != .array) return allocator.alloc(provider_types.ChatThreadSummary, 0);
+    try std.testing.expectEqual(@as(i64, 42), responseId(parsed.value).?);
+    try std.testing.expectEqualStrings("initialize", getOptionalObjectString(parsed.value, "method").?);
+}
 
+test "makePromptRequestAlloc writes text and image content blocks" {
+    const request = provider_types.SendPromptRequest{ .prompt = "hello" };
+    const json = try makePromptRequestAlloc(std.testing.allocator, 3, "session-1", request, true);
+    defer std.testing.allocator.free(json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer parsed.deinit();
+    const params = getObjectField(parsed.value, "params").?;
+    try std.testing.expectEqualStrings("session-1", getOptionalObjectString(params, "sessionId").?);
+    const prompt = getObjectField(params, "prompt").?.array.items;
+    try std.testing.expectEqual(@as(usize, 1), prompt.len);
+    try std.testing.expectEqualStrings("text", getOptionalObjectString(prompt[0], "type").?);
+}
+
+test "parseSessionListResponse maps ACP sessions to thread summaries" {
+    const payload =
+        \\{"jsonrpc":"2.0","id":2,"result":{"sessions":[{"sessionId":"s1","cwd":"/tmp","title":"One"},{"sessionId":"s2","cwd":"/tmp"}]}}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, payload, .{});
+    defer parsed.deinit();
     var threads: std.ArrayList(provider_types.ChatThreadSummary) = .empty;
-    errdefer {
+    defer {
         for (threads.items) |thread| {
-            allocator.free(thread.id);
-            allocator.free(thread.title);
+            std.testing.allocator.free(thread.id);
+            std.testing.allocator.free(thread.title);
         }
-        threads.deinit(allocator);
+        threads.deinit(std.testing.allocator);
     }
-
-    for (parsed.value.array.items) |item| {
-        if (item != .object) continue;
-        const id = getOptionalObjectString(item, "agentId") orelse getOptionalObjectString(item, "id") orelse continue;
-        const title = getOptionalObjectString(item, "name") orelse
-            getOptionalObjectString(item, "summary") orelse
-            id;
-        try threads.append(allocator, .{
-            .id = try allocator.dupe(u8, id),
-            .title = try allocator.dupe(u8, title),
-        });
-    }
-
-    return threads.toOwnedSlice(allocator);
+    try parseSessionListResponse(std.testing.allocator, parsed.value, &threads);
+    try std.testing.expectEqual(@as(usize, 2), threads.items.len);
+    try std.testing.expectEqualStrings("s1", threads.items[0].id);
+    try std.testing.expectEqualStrings("One", threads.items[0].title);
+    try std.testing.expectEqualStrings("s2", threads.items[1].title);
 }
 
-fn parseModelsAlloc(allocator: std.mem.Allocator, payload: []const u8) ![]provider_types.ModelInfo {
-    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
-    defer parsed.deinit();
-    if (parsed.value != .array) return staticModelsAlloc(allocator);
-
-    var models: std.ArrayList(provider_types.ModelInfo) = .empty;
-    errdefer {
-        for (models.items) |model| model.deinit(allocator);
-        models.deinit(allocator);
-    }
-
-    for (parsed.value.array.items) |item| {
-        if (item != .object) continue;
-        const id = getOptionalObjectString(item, "id") orelse continue;
-        const name = getOptionalObjectString(item, "displayName") orelse id;
-        try appendCursorModelFromJson(allocator, &models, item, id, name);
-    }
-
-    if (models.items.len == 0) return staticModelsAlloc(allocator);
-    return models.toOwnedSlice(allocator);
+test "handleReadSessionUpdate combines consecutive role chunks" {
+    var state: ReadThreadState = .{};
+    defer state.deinit(std.testing.allocator);
+    const one =
+        \\{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hel"}}}}
+    ;
+    const two =
+        \\{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"lo"}}}}
+    ;
+    var parsed_one = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, one, .{});
+    defer parsed_one.deinit();
+    var parsed_two = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, two, .{});
+    defer parsed_two.deinit();
+    try handleReadSessionUpdate(std.testing.allocator, parsed_one.value, &state);
+    try handleReadSessionUpdate(std.testing.allocator, parsed_two.value, &state);
+    try std.testing.expectEqual(@as(usize, 1), state.messages.items.len);
+    try std.testing.expectEqualStrings("hello", state.messages.items[0].body);
 }
 
-fn staticModelsAlloc(allocator: std.mem.Allocator) ![]provider_types.ModelInfo {
-    var models: std.ArrayList(provider_types.ModelInfo) = .empty;
-    errdefer {
-        for (models.items) |model| model.deinit(allocator);
-        models.deinit(allocator);
-    }
-
-    try appendModel(allocator, &models, "default", "Auto");
-    try appendModel(allocator, &models, "composer-2.5", "Composer 2.5");
-    try appendModel(allocator, &models, "composer-2", "Composer 2");
-    try appendModel(allocator, &models, "gpt-5.5", "GPT-5.5");
-    try appendModel(allocator, &models, "gpt-5.4", "GPT-5.4");
-    try appendModel(allocator, &models, "claude-opus-4-7", "Claude Opus 4.7");
-    try appendModel(allocator, &models, "claude-sonnet-4-5", "Claude Sonnet 4.5");
-    return models.toOwnedSlice(allocator);
-}
-
-fn appendModel(
-    allocator: std.mem.Allocator,
-    models: *std.ArrayList(provider_types.ModelInfo),
-    id: []const u8,
-    name: []const u8,
-) !void {
-    try models.append(allocator, .{
-        .provider_id = try allocator.dupe(u8, "cursor"),
-        .provider_name = try allocator.dupe(u8, "Cursor"),
-        .model_id = try allocator.dupe(u8, id),
-        .model_name = try allocator.dupe(u8, name),
-    });
-}
-
-fn appendCursorModelFromJson(
-    allocator: std.mem.Allocator,
-    models: *std.ArrayList(provider_types.ModelInfo),
-    item: std.json.Value,
-    id: []const u8,
-    name: []const u8,
-) !void {
-    var fast_supported = false;
-    var reasoning_param_id: ?[]const u8 = null;
-    var reasoning_values: ?[][:0]const u8 = null;
-    var requires_thinking = false;
-
-    if (item.object.get("parameters")) |params_value| {
-        if (params_value == .array) {
-            var effort_values: ?std.json.Value = null;
-            var reasoning_param_values: ?std.json.Value = null;
-            var has_thinking = false;
-            for (params_value.array.items) |param| {
-                if (param != .object) continue;
-                const param_id = getOptionalObjectString(param, "id") orelse continue;
-                if (std.mem.eql(u8, param_id, "fast")) {
-                    fast_supported = true;
-                } else if (std.mem.eql(u8, param_id, "thinking")) {
-                    has_thinking = true;
-                } else if (std.mem.eql(u8, param_id, "reasoning")) {
-                    reasoning_param_values = param.object.get("values");
-                    reasoning_param_id = "reasoning";
-                } else if (std.mem.eql(u8, param_id, "effort")) {
-                    effort_values = param.object.get("values");
-                }
-            }
-            if (reasoning_param_values == null and effort_values != null) {
-                reasoning_param_values = effort_values;
-                reasoning_param_id = "effort";
-                requires_thinking = has_thinking;
-            }
-            if (reasoning_param_values) |values| {
-                reasoning_values = try cursorParamValuesAlloc(allocator, values);
-            }
-        }
-    }
-
-    errdefer if (reasoning_values) |values| {
-        for (values) |value| allocator.free(value);
-        allocator.free(values);
-    };
-
-    try models.append(allocator, .{
-        .provider_id = try allocator.dupe(u8, "cursor"),
-        .provider_name = try allocator.dupe(u8, "Cursor"),
-        .model_id = try allocator.dupe(u8, id),
-        .model_name = try allocator.dupe(u8, name),
-        .cursor_fast_supported = fast_supported,
-        .cursor_reasoning_param_id = if (reasoning_param_id) |param_id| try allocator.dupe(u8, param_id) else null,
-        .cursor_reasoning_values = reasoning_values,
-        .cursor_reasoning_requires_thinking = requires_thinking,
-    });
-}
-
-fn cursorParamValuesAlloc(allocator: std.mem.Allocator, values: std.json.Value) !?[][:0]const u8 {
-    if (values != .array) return null;
-    var out: std.ArrayList([:0]const u8) = .empty;
-    errdefer {
-        for (out.items) |value| allocator.free(value);
-        out.deinit(allocator);
-    }
-    for (values.array.items) |value_obj| {
-        if (value_obj != .object) continue;
-        const value = getOptionalObjectString(value_obj, "value") orelse continue;
-        if (std.mem.eql(u8, value, "false") or std.mem.eql(u8, value, "true")) continue;
-        try out.append(allocator, try allocator.dupeZ(u8, value));
-    }
-    if (out.items.len == 0) {
-        out.deinit(allocator);
-        return null;
-    }
-    return try out.toOwnedSlice(allocator);
-}
-
-fn parseMessagesAlloc(allocator: std.mem.Allocator, payload: []const u8) ![]provider_types.ChatMessage {
-    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
-    defer parsed.deinit();
-    if (parsed.value != .array) return allocator.alloc(provider_types.ChatMessage, 0);
-
-    var messages: std.ArrayList(provider_types.ChatMessage) = .empty;
-    errdefer {
-        for (messages.items) |message| {
-            allocator.free(message.author);
-            allocator.free(message.body);
-        }
-        messages.deinit(allocator);
-    }
-
-    for (parsed.value.array.items) |item| {
-        if (item != .object) continue;
-        const role_text = getOptionalObjectString(item, "role") orelse continue;
-        const body = getOptionalObjectString(item, "text") orelse continue;
-        const trimmed = std.mem.trim(u8, body, &std.ascii.whitespace);
-        if (trimmed.len == 0) continue;
-        const role: provider_types.MessageRole = if (std.mem.eql(u8, role_text, "user"))
-            .user
-        else if (std.mem.eql(u8, role_text, "assistant"))
-            .assistant
-        else
-            .system;
-        try messages.append(allocator, .{
-            .role = role,
-            .author = try allocator.dupe(u8, switch (role) {
-                .user => "You",
-                .assistant => "Cursor",
-                .system => "System",
-            }),
-            .body = try allocator.dupe(u8, trimmed),
-        });
-    }
-
-    return messages.toOwnedSlice(allocator);
-}
-
-const BRIDGE_SCRIPT =
-    \\import { createRequire } from "node:module";
-    \\import { readFile } from "node:fs/promises";
-    \\import { pathToFileURL } from "node:url";
-    \\const fail = (message) => {
-    \\  process.stdout.write(JSON.stringify({ type: "error", message }) + "\n");
-    \\  process.exit(1);
-    \\};
-    \\const emit = (event) => process.stdout.write(JSON.stringify(event) + "\n");
-    \\const requireFromBundledModules = () => {
-    \\  const root = process.env.VERDE_NODE_MODULES;
-    \\  if (!root) return createRequire(import.meta.url);
-    \\  const normalized = root.replace(/\/+$/, "");
-    \\  return createRequire(pathToFileURL(`${normalized}/package.json`));
-    \\};
-    \\const withTimeout = (promise, ms, label) => new Promise((resolve, reject) => {
-    \\  const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-    \\  promise.then((value) => {
-    \\    clearTimeout(timer);
-    \\    resolve(value);
-    \\  }, (error) => {
-    \\    clearTimeout(timer);
-    \\    reject(error);
-    \\  });
-    \\});
-    \\const modelSelection = (id, params) => id ? { id, ...(Array.isArray(params) && params.length ? { params } : {}) } : undefined;
-    \\const mimeTypeForPath = (path) => {
-    \\  const lower = String(path || "").toLowerCase();
-    \\  if (lower.endsWith(".png")) return "image/png";
-    \\  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
-    \\  if (lower.endsWith(".webp")) return "image/webp";
-    \\  if (lower.endsWith(".gif")) return "image/gif";
-    \\  return "application/octet-stream";
-    \\};
-    \\const userMessageForInput = async () => {
-    \\  const images = [];
-    \\  for (const image of Array.isArray(input.images) ? input.images : []) {
-    \\    if (!image?.path) continue;
-    \\    const data = await readFile(image.path, { encoding: "base64" });
-    \\    images.push({ data, mimeType: mimeTypeForPath(image.path) });
-    \\  }
-    \\  return images.length ? { text: input.prompt || "", images } : (input.prompt || "");
-    \\};
-    \\const agentOptions = () => ({
-    \\  apiKey: process.env.CURSOR_API_KEY,
-    \\  model: modelSelection(input.model || "composer-2", input.modelParams),
-    \\  name: input.title || undefined,
-    \\  local: { cwd: input.cwd || process.cwd() },
-    \\});
-    \\const textFromContent = (content) =>
-    \\  Array.isArray(content)
-    \\    ? content.filter((part) => part?.type === "text" && typeof part.text === "string").map((part) => part.text).join("")
-    \\    : "";
-    \\const messageText = (message) => {
-    \\  if (typeof message?.text === "string") return message.text;
-    \\  if (typeof message?.content === "string") return message.content;
-    \\  return textFromContent(message?.content);
-    \\};
-    \\const messageRole = (message) => {
-    \\  if (message?.role === "user" || message?.role === "assistant") return message.role;
-    \\  if (message?.type === "user" || message?.type === "assistant") return message.type;
-    \\  return undefined;
-    \\};
-    \\const normalizeMessage = (item) => {
-    \\  const message = item?.message ?? item;
-    \\  const role = messageRole(message);
-    \\  const text = messageText(message);
-    \\  if (!role || !text) return null;
-    \\  return { role, text };
-    \\};
-    \\const agentId = (agent) => agent?.agentId || agent?.id;
-    \\const titleOf = (item) => item?.name || item?.summary || item?.agentId || item?.id || "";
-    \\
-    \\let input;
-    \\try {
-    \\  input = JSON.parse(process.env.VERDE_CURSOR_REQUEST || "{}");
-    \\} catch (error) {
-    \\  fail(`invalid request: ${error?.message || error}`);
-    \\}
-    \\
-    \\try {
-    \\  const require = requireFromBundledModules();
-    \\  const sdkModule = await import(require.resolve("@cursor/sdk"));
-    \\  const sdk = sdkModule.Agent ? sdkModule : (sdkModule.default || sdkModule);
-    \\  const { Agent, Cursor } = sdk;
-    \\  if (input.command === "auth") {
-    \\    await Cursor.me({ apiKey: process.env.CURSOR_API_KEY });
-    \\    emit({ type: "ok" });
-    \\  } else if (input.command === "list_models") {
-    \\    const models = await withTimeout(Cursor.models.list({ apiKey: process.env.CURSOR_API_KEY }), 5000, "Cursor model discovery");
-    \\    emit({ type: "items", items: models });
-    \\  } else if (input.command === "list_threads") {
-    \\    const result = await Agent.list({ runtime: "local", cwd: input.cwd || process.cwd(), limit: input.limit || 100 });
-    \\    emit({ type: "items", items: result.items });
-    \\  } else if (input.command === "read_thread") {
-    \\    if (!input.threadId) fail("threadId is required");
-    \\    const info = await Agent.get(input.threadId, { cwd: input.cwd || process.cwd(), apiKey: process.env.CURSOR_API_KEY });
-    \\    emit({ type: "thread", threadId: input.threadId, title: titleOf(info), updatedAt: info?.lastModified || null });
-    \\    const messages = await Agent.messages.list(input.threadId, { runtime: "local", cwd: input.cwd || process.cwd(), limit: input.limit || 1000 });
-    \\    emit({ type: "items", items: (Array.isArray(messages) ? messages : messages?.items || []).map(normalizeMessage).filter(Boolean) });
-    \\  } else if (input.command === "interrupt_thread") {
-    \\    if (!input.threadId || !input.turnId) fail("threadId and turnId are required");
-    \\    const run = await Agent.getRun(input.turnId, { runtime: "local", cwd: input.cwd || process.cwd(), agentId: input.threadId, apiKey: process.env.CURSOR_API_KEY });
-    \\    await run.cancel();
-    \\    emit({ type: "ok" });
-    \\  } else if (input.command === "send_prompt") {
-    \\  const agent = input.threadId
-    \\    ? await Agent.resume(input.threadId, agentOptions())
-    \\    : await Agent.create(agentOptions());
-    \\  emit({ type: "thread", threadId: agentId(agent), title: input.title || agentId(agent) });
-    \\  const run = await agent.send(await userMessageForInput(), { model: modelSelection(input.model || "composer-2", input.modelParams), local: { force: true } });
-    \\  emit({ type: "turn", runId: run.id });
-    \\  let deltaCount = 0;
-    \\  for await (const event of run.stream()) {
-    \\    if (event?.type === "assistant") {
-    \\      const content = Array.isArray(event.message?.content) ? event.message.content : [];
-    \\      const text = content
-    \\        .filter((block) => block?.type === "text" && typeof block.text === "string")
-    \\        .map((block) => block.text)
-    \\        .join("");
-    \\      if (!text) continue;
-    \\      deltaCount += 1;
-    \\      emit({ type: "delta", text });
-    \\      continue;
-    \\    }
-    \\    if (event?.type === "text-delta") {
-    \\      const text = typeof event.text === "string" ? event.text : "";
-    \\      if (!text) continue;
-    \\      deltaCount += 1;
-    \\      emit({ type: "delta", text });
-    \\      continue;
-    \\    }
-    \\    if (event?.type === "tool_call" && event.name) {
-    \\      emit({ type: "command", command: `${event.name} ${JSON.stringify(event.args ?? {})}`, failed: event.status === "error" });
-    \\    }
-    \\  }
-    \\  const result = await run.wait();
-    \\  emit({ type: "debug", name: "deltaCount", value: deltaCount });
-    \\  emit({ type: "final", threadId: agentId(agent) || run.agentId, runId: run.id, replyText: "" });
-    \\  } else {
-    \\    fail(`unsupported command: ${input.command}`);
-    \\  }
-    \\} catch (error) {
-    \\  fail(error?.stack || error?.message || String(error));
-    \\}
-;
-
-test "parseBridgeEventsAlloc reads cursor ids and reply" {
+test "cursorToolEvent suppresses status-only ACP tool updates" {
     const payload =
-        \\{"type":"thread","threadId":"agent_123"}
-        \\{"type":"turn","runId":"run_456"}
-        \\{"type":"delta","text":"do"}
-        \\{"type":"delta","text":"ne"}
+        \\{"sessionUpdate":"tool_call_update","toolCallId":"call-1","status":"in_progress"}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, payload, .{});
+    defer parsed.deinit();
+    const event = try cursorToolEventAlloc(std.testing.allocator, parsed.value, "tool_call_update");
+    try std.testing.expect(event == null);
+}
+
+test "cursorToolEvent keeps meaningful ACP tool text" {
+    const payload =
+        \\{"sessionUpdate":"tool_call","title":"Shell","command":"git status --short","status":"pending"}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, payload, .{});
+    defer parsed.deinit();
+    const event = (try cursorToolEventAlloc(std.testing.allocator, parsed.value, "tool_call")).?;
+    defer event.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("Shell", event.title);
+    try std.testing.expectEqualStrings("Shell: git status --short", event.body);
+}
+
+test "cursorToolEvent keeps non-lifecycle status failures" {
+    const payload =
+        \\{"sessionUpdate":"tool_call_update","toolName":"edit","status":"failed"}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, payload, .{});
+    defer parsed.deinit();
+    const event = (try cursorToolEventAlloc(std.testing.allocator, parsed.value, "tool_call_update")).?;
+    defer event.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("edit", event.title);
+    try std.testing.expectEqualStrings("failed", event.body);
+}
+
+test "cursorToolEvent shows tool call starts with structured input" {
+    const payload =
+        \\{"sessionUpdate":"tool_call","toolName":"Read","input":{"path":"/tmp/a.txt"},"status":"pending"}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, payload, .{});
+    defer parsed.deinit();
+    const event = (try cursorToolEventAlloc(std.testing.allocator, parsed.value, "tool_call")).?;
+    defer event.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("Read", event.title);
+    try std.testing.expectEqualStrings("Read: {\"path\":\"/tmp/a.txt\"}", event.body);
+}
+
+test "handleSendPromptLine accepts session/load response without sessionId" {
+    var state: SendPromptState = .{};
+    defer state.deinit(std.testing.allocator);
+    const request = provider_types.SendPromptRequest{
+        .thread_id = "existing-session",
+        .prompt = "continue",
+    };
+    const line =
+        \\{"jsonrpc":"2.0","id":2,"result":{"models":{"currentModelId":"composer-2[fast=true]"}}}
+    ;
+    const action = try handleSendPromptLine(std.testing.allocator, line, request, &state, null);
+    try std.testing.expectEqual(SendLineAction.session_ready, action);
+    try std.testing.expectEqualStrings("existing-session", state.session_id.?);
+}
+
+test "makePermissionResponseAlloc writes selected ACP option id" {
+    const approve = try makePermissionResponseAlloc(std.testing.allocator, 9, "allow-always");
+    defer std.testing.allocator.free(approve);
+    const deny = try makePermissionResponseAlloc(std.testing.allocator, 10, "reject-once");
+    defer std.testing.allocator.free(deny);
+    try std.testing.expect(std.mem.indexOf(u8, approve, "allow-always") != null);
+    try std.testing.expect(std.mem.indexOf(u8, deny, "reject-once") != null);
+}
+
+test "permissionOptionId chooses matching ACP request options" {
+    const payload =
+        \\{"options":[{"optionId":"reject-once"},{"optionId":"allow-once"}]}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, payload, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("allow-once", permissionOptionId(parsed.value, .approve));
+    try std.testing.expectEqualStrings("reject-once", permissionOptionId(parsed.value, .deny));
+}
+
+test "resolveCursorExecutableAlloc falls back to cursor-agent after configured command" {
+    var env_map = std.process.Environ.Map.init(std.testing.allocator);
+    defer env_map.deinit();
+    try env_map.put("PATH", "/definitely/missing");
+    try std.testing.expectError(error.FileNotFound, resolveCursorExecutableAlloc(std.testing.allocator, &env_map, "missing-agent"));
+}
+
+test "cursorModelArgAlloc folds legacy SDK params into CLI model id" {
+    const params =
+        \\[{"id":"reasoning","value":"high"},{"id":"fast","value":"true"}]
+    ;
+    const arg = try cursorModelArgAlloc(std.testing.allocator, "gpt-5.5", params);
+    defer std.testing.allocator.free(arg.?);
+    try std.testing.expectEqualStrings("gpt-5.5-high-fast", arg.?);
+}
+
+test "parseModelsTextAlloc reads Cursor CLI model output" {
+    const output =
+        \\Available models
+        \\
+        \\composer-2-fast - Composer 2 Fast
+        \\composer-2 - Composer 2 (current)
+        \\gpt-5.3-codex - Codex 5.3
+        \\composer-2.5 - Composer 2.5
+        \\composer-2.5-fast - Composer 2.5 Fast (default)
         \\
     ;
-    const parsed = try parseBridgeEventsAlloc(std.testing.allocator, payload, .{ .exited = 0 }, null);
-    defer parsed.deinit(std.testing.allocator);
-
-    try std.testing.expectEqualStrings("agent_123", parsed.thread_id);
-    try std.testing.expectEqualStrings("run_456", parsed.run_id.?);
-    try std.testing.expectEqualStrings("done", parsed.reply_text);
-}
-
-test "parseBridgeEventsAlloc keeps streamed reply when final reply is empty" {
-    const payload =
-        \\{"type":"thread","threadId":"agent_123"}
-        \\{"type":"turn","runId":"run_456"}
-        \\{"type":"delta","text":"streamed"}
-        \\{"type":"final","threadId":"agent_123","runId":"run_456","replyText":""}
-        \\
-    ;
-    const parsed = try parseBridgeEventsAlloc(std.testing.allocator, payload, .{ .exited = 0 }, null);
-    defer parsed.deinit(std.testing.allocator);
-
-    try std.testing.expectEqualStrings("agent_123", parsed.thread_id);
-    try std.testing.expectEqualStrings("run_456", parsed.run_id.?);
-    try std.testing.expectEqualStrings("streamed", parsed.reply_text);
-}
-
-test "makeBridgeRequestJsonAlloc keeps cursor model and cwd" {
-    const json = try makeBridgeRequestJsonAlloc(std.testing.allocator, .{}, .send_prompt, .{
-        .request = .{
-            .prompt = "hello",
-            .cwd = "/tmp/project",
-            .model = "composer-2",
-        },
-    });
-    defer std.testing.allocator.free(json);
-
-    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
-    defer parsed.deinit();
-
-    try std.testing.expectEqualStrings("hello", getOptionalObjectString(parsed.value, "prompt").?);
-    try std.testing.expectEqualStrings("/tmp/project", getOptionalObjectString(parsed.value, "cwd").?);
-    try std.testing.expectEqualStrings("composer-2", getOptionalObjectString(parsed.value, "model").?);
-    try std.testing.expectEqualStrings("send_prompt", getOptionalObjectString(parsed.value, "command").?);
-}
-
-test "makeBridgeRequestJsonAlloc maps legacy and multi image requests" {
-    const images = [_]provider_types.ImageAttachment{
-        .{ .path = "/tmp/one.png" },
-        .{ .path = "/tmp/two.png" },
-    };
-
-    const json = try makeBridgeRequestJsonAlloc(std.testing.allocator, .{}, .send_prompt, .{
-        .request = .{
-            .prompt = "see attached",
-            .image = .{ .path = "/tmp/legacy.png" },
-            .images = images[0..],
-        },
-    });
-    defer std.testing.allocator.free(json);
-
-    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
-    defer parsed.deinit();
-
-    const image_values = getObjectField(parsed.value, "images").?.array.items;
-    try std.testing.expectEqual(@as(usize, 3), image_values.len);
-    try std.testing.expectEqualStrings("/tmp/legacy.png", getOptionalObjectString(image_values[0], "path").?);
-    try std.testing.expectEqualStrings("/tmp/one.png", getOptionalObjectString(image_values[1], "path").?);
-    try std.testing.expectEqualStrings("/tmp/two.png", getOptionalObjectString(image_values[2], "path").?);
-}
-
-test "makeBridgeRequestJsonAlloc does not duplicate legacy image already in images" {
-    const images = [_]provider_types.ImageAttachment{
-        .{ .path = "/tmp/one.png" },
-        .{ .path = "/tmp/two.png" },
-    };
-
-    const json = try makeBridgeRequestJsonAlloc(std.testing.allocator, .{}, .send_prompt, .{
-        .request = .{
-            .prompt = "see attached",
-            .image = .{ .path = "/tmp/one.png" },
-            .images = images[0..],
-        },
-    });
-    defer std.testing.allocator.free(json);
-
-    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
-    defer parsed.deinit();
-
-    const image_values = getObjectField(parsed.value, "images").?.array.items;
-    try std.testing.expectEqual(@as(usize, 2), image_values.len);
-    try std.testing.expectEqualStrings("/tmp/one.png", getOptionalObjectString(image_values[0], "path").?);
-    try std.testing.expectEqualStrings("/tmp/two.png", getOptionalObjectString(image_values[1], "path").?);
-}
-
-test "makeBridgeRequestJsonAlloc preserves text-only prompts with empty images" {
-    const json = try makeBridgeRequestJsonAlloc(std.testing.allocator, .{}, .send_prompt, .{
-        .request = .{
-            .prompt = "text only",
-            .cwd = "/tmp/project",
-        },
-    });
-    defer std.testing.allocator.free(json);
-
-    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
-    defer parsed.deinit();
-
-    try std.testing.expectEqualStrings("text only", getOptionalObjectString(parsed.value, "prompt").?);
-    try std.testing.expectEqual(@as(usize, 0), getObjectField(parsed.value, "images").?.array.items.len);
-}
-
-test "parseBridgeEventsAlloc maps command events to stream events" {
-    const Context = struct {
-        title: []const u8 = "",
-        body: []const u8 = "",
-
-        fn onEvent(raw: ?*anyopaque, event: provider_types.StreamEvent) void {
-            const ctx: *@This() = @ptrCast(@alignCast(raw orelse return));
-            switch (event) {
-                .message => |message| {
-                    ctx.title = message.title;
-                    ctx.body = message.body;
-                },
-                .diff => {},
-            }
-        }
-    };
-
-    var ctx: Context = .{};
-    const payload =
-        \\{"type":"thread","threadId":"agent_123"}
-        \\{"type":"command","command":"bash -lc zig build test","failed":true}
-        \\
-    ;
-    const parsed = try parseBridgeEventsAlloc(std.testing.allocator, payload, .{ .exited = 0 }, .{
-        .prompt = "hello",
-        .stream_context = &ctx,
-        .on_stream_event = Context.onEvent,
-    });
-    defer parsed.deinit(std.testing.allocator);
-
-    try std.testing.expectEqualStrings("Command failed", ctx.title);
-    try std.testing.expectEqualStrings("bash -lc zig build test", ctx.body);
-}
-
-test "parseBridgeEventsAlloc fails when bridge emits an error" {
-    const payload =
-        \\{"type":"error","message":"UnknownAgentError: already has active run"}
-        \\
-    ;
-    try std.testing.expectError(
-        error.CursorBridgeFailed,
-        parseBridgeEventsAlloc(std.testing.allocator, payload, .{ .exited = 0 }, null),
-    );
+    const models = try parseModelsTextAlloc(std.testing.allocator, output);
+    defer provider_types.freeModelInfos(std.testing.allocator, models);
+    try std.testing.expectEqual(@as(usize, 3), models.len);
+    try std.testing.expectEqualStrings("composer-2.5", models[0].model_id);
+    try std.testing.expect(models[0].cursor_fast_supported);
+    try std.testing.expectEqualStrings("composer-2", models[1].model_id);
+    try std.testing.expect(models[1].cursor_fast_supported);
+    try std.testing.expectEqualStrings("gpt-5.3-codex", models[2].model_id);
 }

--- a/packages/desktop/src/providers/provider_bridge.ts
+++ b/packages/desktop/src/providers/provider_bridge.ts
@@ -1,33 +1,42 @@
 #!/usr/bin/env node
 
 import readline from "node:readline";
-import { createRequire } from "node:module";
-import { dirname, extname, join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { extname } from "node:path";
+import * as claudeSdkStatic from "@anthropic-ai/claude-agent-sdk";
 
-async function loadSdk() {
-  try {
-    const require = requireFromBundledModules();
-    if (require) {
-      return await import(require.resolve("@anthropic-ai/claude-agent-sdk"));
-    }
-    return await import("@anthropic-ai/claude-agent-sdk");
-  } catch (err) {
-    throw new Error(
-      `Unable to load @anthropic-ai/claude-agent-sdk. Install it for the desktop package or provide bundled node_modules. ${err?.message ?? err}`,
-    );
+const write = (message) => {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+};
+
+const fail = (message) => {
+  write({ type: "error", message });
+  process.exitCode = 1;
+};
+
+function mimeTypeForPath(path) {
+  switch (extname(String(path || "")).toLowerCase()) {
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".png":
+      return "image/png";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    default:
+      return undefined;
   }
 }
 
-function requireFromBundledModules() {
-  const root = process.env.VERDE_NODE_MODULES;
-  if (!root) return null;
-  const normalized = root.replace(/\/+$/, "");
-  return createRequire(pathToFileURL(`${normalized}/package.json`));
-}
-
-function write(message) {
-  process.stdout.write(`${JSON.stringify(message)}\n`);
+function textFromContent(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const chunks = [];
+  for (const item of content) {
+    if (item?.type === "text" && typeof item.text === "string") chunks.push(item.text);
+  }
+  return chunks.join("");
 }
 
 let nextApprovalRequestId = 1;
@@ -49,8 +58,7 @@ function handleInputLine(line) {
 
 function approvalRequestBody(toolName, input, options) {
   if (options?.description) return options.description;
-  const parts = [];
-  parts.push(`Tool: ${toolName}`);
+  const parts = [`Tool: ${toolName}`];
   if (options?.blockedPath) parts.push(`Path: ${options.blockedPath}`);
   if (options?.decisionReason) parts.push(`Reason: ${options.decisionReason}`);
   try {
@@ -85,40 +93,14 @@ async function requestToolApproval(toolName, input, options) {
     : { behavior: "deny", message: "Denied by user", toolUseID: options?.toolUseID, decisionClassification: "user_reject" };
 }
 
-function roleFromSdkMessage(message) {
+function claudeRoleFromSdkMessage(message) {
   if (message?.type === "user") return "user";
   if (message?.type === "assistant") return "assistant";
   if (message?.type === "system") return "system";
   return undefined;
 }
 
-function textFromContent(content) {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  const chunks = [];
-  for (const item of content) {
-    if (item?.type === "text" && typeof item.text === "string") chunks.push(item.text);
-  }
-  return chunks.join("");
-}
-
-function mimeTypeForPath(path) {
-  switch (extname(path).toLowerCase()) {
-    case ".jpg":
-    case ".jpeg":
-      return "image/jpeg";
-    case ".png":
-      return "image/png";
-    case ".gif":
-      return "image/gif";
-    case ".webp":
-      return "image/webp";
-    default:
-      return undefined;
-  }
-}
-
-async function buildPrompt(request) {
+async function buildClaudePrompt(request) {
   const images = Array.isArray(request.images) ? request.images : [];
   if (images.length === 0) return request.prompt;
 
@@ -140,13 +122,13 @@ async function buildPrompt(request) {
   return lines.join("\n");
 }
 
-function emitSdkMessage(message) {
-  const role = roleFromSdkMessage(message);
+function emitClaudeSdkMessage(message) {
+  const role = claudeRoleFromSdkMessage(message);
   const text = textFromContent(message?.message?.content ?? message?.content);
   if (role && text) write({ type: "message", role, text });
 }
 
-function commandFromToolUse(item) {
+function commandFromClaudeToolUse(item) {
   if (item?.type !== "tool_use") return null;
   const name = String(item.name ?? "").toLowerCase();
   if (name !== "bash" && name !== "shell") return null;
@@ -173,12 +155,12 @@ function scheduleBackgroundTask(query, toolUseId, command) {
   }, 4000).unref?.();
 }
 
-function emitToolEvents(message, commandByToolUseId, query) {
+function emitClaudeToolEvents(message, commandByToolUseId, query) {
   const content = message?.message?.content ?? message?.content;
   if (!Array.isArray(content)) return false;
   let sawBackgroundableCommand = false;
   for (const item of content) {
-    const command = commandFromToolUse(item);
+    const command = commandFromClaudeToolUse(item);
     if (typeof command === "string" && command.length > 0) {
       if (typeof item.id === "string") commandByToolUseId.set(item.id, command);
       write({ type: "stream_event", title: "Ran command", body: command });
@@ -198,46 +180,22 @@ function emitToolEvents(message, commandByToolUseId, query) {
   return sawBackgroundableCommand;
 }
 
-function permissionMode(approvalPolicy, sandboxMode) {
-  if (approvalPolicy === "never" && sandboxMode === "danger_full_access") {
-    return "bypassPermissions";
-  }
+function claudePermissionMode(approvalPolicy, sandboxMode) {
+  if (approvalPolicy === "never" && sandboxMode === "danger_full_access") return "bypassPermissions";
   if (approvalPolicy === "on_request") return "default";
   if (approvalPolicy === "never") return "dontAsk";
   return undefined;
 }
 
-function bundledClaudePackageName() {
-  const arch = process.arch === "arm64" ? "arm64" : process.arch === "x64" ? "x64" : null;
-  if (!arch) return null;
-  if (process.platform === "darwin") return `@anthropic-ai/claude-agent-sdk-darwin-${arch}`;
-  if (process.platform === "linux") return `@anthropic-ai/claude-agent-sdk-linux-${arch}`;
-  if (process.platform === "win32") return `@anthropic-ai/claude-agent-sdk-win32-${arch}`;
-  return null;
-}
-
-function bundledClaudeCodeExecutable() {
-  const require = requireFromBundledModules();
-  const packageName = bundledClaudePackageName();
-  if (!require || !packageName) return undefined;
-  try {
-    const manifest = require.resolve(`${packageName}/package.json`);
-    return join(dirname(manifest), process.platform === "win32" ? "claude.exe" : "claude");
-  } catch {
-    return undefined;
-  }
-}
-
 function pathToClaudeCodeExecutable(request) {
   if (request?.claude_executable && request.claude_executable !== "claude") return request.claude_executable;
   return process.env.VERDE_CLAUDE_CODE_EXECUTABLE ||
-    bundledClaudeCodeExecutable() ||
     process.env.CLAUDE_CODE_EXECUTABLE ||
     request?.claude_executable ||
     "claude";
 }
 
-function buildOptions(request) {
+function buildClaudeOptions(request) {
   const options = {
     cwd: request.cwd ?? undefined,
     resume: request.thread_id ?? undefined,
@@ -246,7 +204,7 @@ function buildOptions(request) {
     pathToClaudeCodeExecutable: pathToClaudeCodeExecutable(request),
   };
 
-  const mode = permissionMode(request.approval_policy, request.sandbox_mode);
+  const mode = claudePermissionMode(request.approval_policy, request.sandbox_mode);
   if (mode) {
     options.permissionMode = mode;
     if (mode === "bypassPermissions") options.allowDangerouslySkipPermissions = true;
@@ -254,28 +212,6 @@ function buildOptions(request) {
   }
 
   return Object.fromEntries(Object.entries(options).filter(([, value]) => value !== undefined));
-}
-
-async function handleAuth(sdk, request) {
-  const query = sdk.query({ prompt: "", options: { maxTurns: 0, pathToClaudeCodeExecutable: pathToClaudeCodeExecutable(request) } });
-  const info = await query.accountInfo();
-  query.close?.();
-  write({ type: "result", state: info ? "signed_in" : "signed_out" });
-}
-
-async function handleListModels(sdk, request) {
-  const query = sdk.query({ prompt: "", options: { maxTurns: 0, pathToClaudeCodeExecutable: pathToClaudeCodeExecutable(request) } });
-  const models = await query.supportedModels();
-  query.close?.();
-  write({
-    type: "result",
-    models: (models ?? []).map((model) => ({
-      id: model.value ?? model.id ?? model.name ?? String(model),
-      name: claudeModelDisplayName(model),
-      reasoning_supported: model.supportsEffort ?? false,
-      supported_effort_levels: Array.isArray(model.supportedEffortLevels) ? model.supportedEffortLevels : null,
-    })),
-  });
 }
 
 function claudeModelDisplayName(model) {
@@ -290,7 +226,33 @@ function claudeModelDisplayName(model) {
   return version;
 }
 
-async function handleListThreads(sdk, request) {
+async function loadClaudeSdk() {
+  return claudeSdkStatic;
+}
+
+async function handleClaudeAuth(sdk, request) {
+  const query = sdk.query({ prompt: "", options: { maxTurns: 0, pathToClaudeCodeExecutable: pathToClaudeCodeExecutable(request) } });
+  const info = await query.accountInfo();
+  query.close?.();
+  write({ type: "result", state: info ? "signed_in" : "signed_out" });
+}
+
+async function handleClaudeListModels(sdk, request) {
+  const query = sdk.query({ prompt: "", options: { maxTurns: 0, pathToClaudeCodeExecutable: pathToClaudeCodeExecutable(request) } });
+  const models = await query.supportedModels();
+  query.close?.();
+  write({
+    type: "result",
+    models: (models ?? []).map((model) => ({
+      id: model.value ?? model.id ?? model.name ?? String(model),
+      name: claudeModelDisplayName(model),
+      reasoning_supported: model.supportsEffort ?? false,
+      supported_effort_levels: Array.isArray(model.supportedEffortLevels) ? model.supportedEffortLevels : null,
+    })),
+  });
+}
+
+async function handleClaudeListThreads(sdk, request) {
   if (typeof sdk.listSessions !== "function") {
     write({ type: "result", threads: [] });
     return;
@@ -306,7 +268,7 @@ async function handleListThreads(sdk, request) {
   });
 }
 
-async function handleReadThread(sdk, request) {
+async function handleClaudeReadThread(sdk, request) {
   if (typeof sdk.getSessionMessages !== "function") {
     throw new Error("Claude Agent SDK does not expose getSessionMessages");
   }
@@ -316,21 +278,21 @@ async function handleReadThread(sdk, request) {
     thread_id: request.thread_id,
     title: request.thread_id,
     messages: (messages ?? []).map((message) => ({
-      role: roleFromSdkMessage(message) ?? "assistant",
+      role: claudeRoleFromSdkMessage(message) ?? "assistant",
       text: textFromContent(message?.message?.content ?? message?.content),
     })).filter((message) => message.text),
   });
 }
 
-async function handleSendPrompt(sdk, request) {
+async function handleClaudeSendPrompt(sdk, request) {
   const stderrChunks = [];
-  const options = buildOptions(request);
+  const options = buildClaudeOptions(request);
   options.stderr = (data) => {
     if (typeof data === "string" && data.length > 0) stderrChunks.push(data);
   };
 
   const query = sdk.query({
-    prompt: await buildPrompt(request),
+    prompt: await buildClaudePrompt(request),
     options,
   });
 
@@ -351,8 +313,8 @@ async function handleSendPrompt(sdk, request) {
         if (typeof message.result === "string") reply = message.result;
         continue;
       }
-      emitSdkMessage(message);
-      sawBackgroundableCommand = emitToolEvents(message, commandByToolUseId, query) || sawBackgroundableCommand;
+      emitClaudeSdkMessage(message);
+      sawBackgroundableCommand = emitClaudeToolEvents(message, commandByToolUseId, query) || sawBackgroundableCommand;
       const delta = textFromContent(message?.message?.content ?? message?.content);
       if (message?.type === "assistant" && delta) {
         reply += delta;
@@ -377,33 +339,60 @@ async function handleSendPrompt(sdk, request) {
   }
 }
 
-async function dispatch(request) {
-  const sdk = await loadSdk();
+async function dispatchClaude(request) {
+  const sdk = await loadClaudeSdk();
   switch (request.command) {
     case "auth":
-      return handleAuth(sdk, request);
+      return handleClaudeAuth(sdk, request);
     case "list_models":
-      return handleListModels(sdk, request);
+      return handleClaudeListModels(sdk, request);
     case "list_threads":
-      return handleListThreads(sdk, request);
+      return handleClaudeListThreads(sdk, request);
     case "read_thread":
-      return handleReadThread(sdk, request);
+      return handleClaudeReadThread(sdk, request);
     case "send_prompt":
-      return handleSendPrompt(sdk, request);
+      return handleClaudeSendPrompt(sdk, request);
     default:
-      throw new Error(`Unknown command: ${request.command}`);
+      throw new Error(`Unknown Claude command: ${request.command}`);
   }
 }
 
-const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
-rl.on("line", handleInputLine);
-rl.once("line", async (line) => {
-  try {
-    await dispatch(JSON.parse(line));
-  } catch (err) {
-    write({ type: "error", message: err?.message ?? String(err) });
-    process.exitCode = 1;
-  } finally {
-    if (pendingApprovals.size === 0) rl.close();
+function providerFromRequest(request) {
+  if (request?.provider === "claude") return request.provider;
+  return "claude";
+}
+
+async function dispatch(request) {
+  const provider = providerFromRequest(request);
+  return dispatchClaude(request);
+}
+
+function parseEnvRequest() {
+  const raw = process.env.VERDE_PROVIDER_REQUEST;
+  if (!raw) return null;
+  return JSON.parse(raw);
+}
+
+async function main() {
+  const envRequest = parseEnvRequest();
+  if (envRequest) {
+    await dispatch(envRequest);
+    return;
   }
+
+  const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  rl.on("line", handleInputLine);
+  rl.once("line", async (line) => {
+    try {
+      await dispatch(JSON.parse(line));
+    } catch (err) {
+      fail(err?.message ?? String(err));
+    } finally {
+      if (pendingApprovals.size === 0) rl.close();
+    }
+  });
+}
+
+main().catch((err) => {
+  fail(err?.stack || err?.message || String(err));
 });

--- a/packages/desktop/src/state.zig
+++ b/packages/desktop/src/state.zig
@@ -659,6 +659,17 @@ const PersistedCursorModelOption = struct {
     reasoning_requires_thinking: bool = false,
 };
 
+fn persistedCursorModelCacheNeedsRefresh(options: []const PersistedCursorModelOption) bool {
+    for (options) |option| {
+        if (std.mem.eql(u8, option.value, "composer-2.5-fast") or
+            std.mem.eql(u8, option.value, "composer-2-fast"))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 fn cursorReasoningValueLabel(value: []const u8) []const u8 {
     if (std.mem.eql(u8, value, "low")) return "Low";
     if (std.mem.eql(u8, value, "medium")) return "Medium";
@@ -786,10 +797,11 @@ pub const CODEX_MODEL_OPTIONS = [_]ModelOption{
 };
 
 pub const CURSOR_MODEL_OPTIONS = [_]ModelOption{
-    .{ .label = "Auto", .value = "default" },
-    .{ .label = "Composer 2", .value = DEFAULT_CURSOR_MODEL },
-    .{ .label = "GPT-5.5", .value = "gpt-5.5" },
-    .{ .label = "GPT-5.4", .value = "gpt-5.4" },
+    .{ .label = "Auto", .value = "auto" },
+    .{ .label = "Composer 2.5", .value = "composer-2.5", .cursor_fast_supported = true },
+    .{ .label = "Composer 2", .value = DEFAULT_CURSOR_MODEL, .cursor_fast_supported = true },
+    .{ .label = "GPT-5.5", .value = "gpt-5.5-medium", .cursor_fast_supported = true },
+    .{ .label = "GPT-5.4", .value = "gpt-5.4-medium", .cursor_fast_supported = true },
     .{ .label = "Claude Opus 4.7", .value = "claude-opus-4-7" },
     .{ .label = "Claude Sonnet 4.5", .value = "claude-sonnet-4-5" },
 };
@@ -3529,6 +3541,8 @@ pub const AppState = struct {
             .allocate = .alloc_always,
         });
         defer parsed.deinit();
+
+        if (persistedCursorModelCacheNeedsRefresh(parsed.value)) return;
 
         self.clearCursorModelOptions();
         errdefer self.clearCursorModelOptions();
@@ -8520,7 +8534,7 @@ pub const AppState = struct {
                 break :blk std.fmt.allocPrint(self.allocator, "opencode --session {s}\n", .{thread_id});
             },
             .claude => std.fmt.allocPrint(self.allocator, "claude --resume {s}\n", .{thread_id}),
-            .cursor => std.fmt.allocPrint(self.allocator, "cursor-agent --resume {s}\n", .{thread_id}),
+            .cursor => std.fmt.allocPrint(self.allocator, "agent --resume {s}\n", .{thread_id}),
         };
     }
 
@@ -11115,9 +11129,9 @@ fn importThreadFailureMessage(provider: Provider, err: anyerror) []const u8 {
             else => "Failed to load Claude threads.",
         },
         .cursor => switch (err) {
-            error.FileNotFound => "Node was not found on PATH for Cursor.",
-            error.CursorSignedOut => "Cursor is not authenticated.",
-            error.UnsupportedOperation => "Cursor thread imports are not supported yet.",
+            error.FileNotFound => "Cursor CLI `agent` was not found on PATH.",
+            error.CursorSignedOut => "Cursor is not authenticated. Run `agent login` or set CURSOR_API_KEY.",
+            error.UnsupportedOperation => "Cursor CLI does not support thread imports in this version.",
             else => "Failed to load Cursor threads.",
         },
     };
@@ -11239,9 +11253,9 @@ fn syncThreadFailureMessage(provider: Provider, err: anyerror) []const u8 {
             else => "Failed to sync the Claude thread.",
         },
         .cursor => switch (err) {
-            error.FileNotFound => "Node was not found on PATH for Cursor.",
-            error.CursorSignedOut => "Cursor is not authenticated.",
-            error.UnsupportedOperation => "Cursor thread sync is not supported yet.",
+            error.FileNotFound => "Cursor CLI `agent` was not found on PATH.",
+            error.CursorSignedOut => "Cursor is not authenticated. Run `agent login` or set CURSOR_API_KEY.",
+            error.UnsupportedOperation => "Cursor CLI does not support thread sync in this version.",
             else => "Failed to sync the Cursor thread.",
         },
     };

--- a/packages/desktop/src/ui/chat_panel.zig
+++ b/packages/desktop/src/ui/chat_panel.zig
@@ -489,6 +489,7 @@ fn transcriptMarkdownBubbleHit(
     var content_y = column.y - scroll_y;
 
     for (thread.messages.items, 0..) |message, msg_idx| {
+        if (message.role == .system and shouldHideCursorLifecycleSystemEvent(message.author, message.body)) continue;
         const item_h = transcriptCommittedMessageHeight(state, msg_idx, message, column.w);
         if (message.role == .system and shouldRenderPaletteCommandRow(message.author, message.body)) {
             content_y += item_h + theme.scaledUi(12.0);
@@ -507,6 +508,7 @@ fn transcriptMarkdownBubbleHit(
 
     const base_idx = thread.messages.items.len;
     for (send_state.pending_events.items, 0..) |event, pi| {
+        if (event.role == .system and shouldHideCursorLifecycleSystemEvent(event.author, event.body)) continue;
         const msg_idx = base_idx + pi;
         const item_h = transcriptMessageHeight(null, null, event.body, event.role, column.w, event.author, false);
         if (event.role == .system and shouldRenderPaletteCommandRow(event.author, event.body)) {
@@ -706,6 +708,7 @@ fn transcriptMarkdownMessageSnapshot(state: *app_state.AppState, message_index: 
     const n = thread.messages.items.len;
     if (message_index < n) {
         const m = thread.messages.items[message_index];
+        if (m.role == .system and shouldHideCursorLifecycleSystemEvent(m.author, m.body)) return null;
         if (m.role == .system and shouldRenderPaletteCommandRow(m.author, m.body)) return null;
         if (m.role != .assistant) return null;
         const body_trim = std.mem.trim(u8, m.body, "\n\r\t ");
@@ -721,6 +724,7 @@ fn transcriptMarkdownMessageSnapshot(state: *app_state.AppState, message_index: 
     const pi = message_index - n;
     if (pi < send_state.pending_events.items.len) {
         const ev = send_state.pending_events.items[pi];
+        if (ev.role == .system and shouldHideCursorLifecycleSystemEvent(ev.author, ev.body)) return null;
         if (ev.role == .system and shouldRenderPaletteCommandRow(ev.author, ev.body)) return null;
         if (ev.role != .assistant) return null;
         const body_trim = std.mem.trim(u8, ev.body, "\n\r\t ");
@@ -1426,6 +1430,7 @@ fn renderTranscript(state: *app_state.AppState, rect: palette.Rect, pane_id: ?ap
 
     var content_y = column.y - scroll_y;
     for (thread.messages.items, 0..) |message, msg_idx| {
+        if (message.role == .system and shouldHideCursorLifecycleSystemEvent(message.author, message.body)) continue;
         const item_h = transcriptCommittedMessageHeight(state, msg_idx, message, column.w);
         if (content_y + item_h >= column.y and content_y <= column.y + column.h) {
             renderTranscriptMessage(state, column, content_y, item_h, message, clip, msg_idx);
@@ -1481,6 +1486,7 @@ fn snapTranscriptScrollY(value: f32, max_scroll: ?f32) f32 {
 fn transcriptContentHeight(state: *app_state.AppState, thread: anytype, width: f32) f32 {
     var total: f32 = theme.scaledUi(4.0);
     for (thread.messages.items, 0..) |message, message_index| {
+        if (message.role == .system and shouldHideCursorLifecycleSystemEvent(message.author, message.body)) continue;
         total += transcriptCommittedMessageHeight(state, message_index, message, width) + theme.scaledUi(12.0);
     }
     total += transcriptPendingStreamHeight(state, thread, width);
@@ -1496,6 +1502,7 @@ fn transcriptPendingStreamHeight(state: *app_state.AppState, thread: *const app_
     const base = thread.messages.items.len;
     var total: f32 = 0;
     for (send_state.pending_events.items, 0..) |event, pi| {
+        if (event.role == .system and shouldHideCursorLifecycleSystemEvent(event.author, event.body)) continue;
         const msg_idx = base + pi;
         total += transcriptMessageHeight(state, msg_idx, event.body, event.role, column_width, event.author, false) + theme.scaledUi(12.0);
     }
@@ -1515,6 +1522,7 @@ fn renderPendingTranscriptStream(state: *app_state.AppState, thread: *const app_
     var y = content_y;
     const pending_count = send_state.pending_events.items.len;
     for (send_state.pending_events.items, 0..) |event, pi| {
+        if (event.role == .system and shouldHideCursorLifecycleSystemEvent(event.author, event.body)) continue;
         const msg_idx = base_message_index + pi;
         const item_h = transcriptMessageHeight(state, msg_idx, event.body, event.role, column.w, event.author, false);
         if (event.role == .system and shouldRenderPaletteCommandRow(event.author, event.body)) {
@@ -1591,12 +1599,54 @@ fn isCommandLikeShellBody(body_raw: []const u8) bool {
 
 fn shouldRenderPaletteCommandRow(author: []const u8, body_raw: []const u8) bool {
     if (isCommandSystemEvent(author)) return true;
+    if (isCursorToolSystemEvent(author, body_raw)) return true;
     return isCommandLikeShellBody(body_raw);
 }
 
-/// Label shown after `>_` in the compact command row (Codex-native titles preserved; shell-like bodies default to "Ran command").
+fn isCursorToolSystemEvent(author_raw: []const u8, body_raw: []const u8) bool {
+    const author = std.mem.trim(u8, author_raw, "\n\r\t ");
+    const body = std.mem.trim(u8, body_raw, "\n\r\t ");
+    if (author.len == 0 or body.len == 0) return false;
+    if (std.mem.eql(u8, author, "System") or
+        std.mem.eql(u8, author, "Conversation interrupted") or
+        std.mem.eql(u8, author, "Cursor"))
+    {
+        return false;
+    }
+
+    const known_tools = [_][]const u8{
+        "Read",
+        "Read File",
+        "Grep",
+        "Glob",
+        "Shell",
+        "Edit",
+        "Write",
+        "LS",
+        "List",
+        "WebFetch",
+        "Web Search",
+    };
+    for (known_tools) |tool| {
+        if (std.ascii.eqlIgnoreCase(author, tool)) return true;
+    }
+    if (std.mem.indexOf(u8, body, "{\"command\"") != null) return true;
+    if (std.mem.endsWith(u8, body, ": {}")) return true;
+    return false;
+}
+
+fn shouldHideCursorLifecycleSystemEvent(author: []const u8, body_raw: []const u8) bool {
+    _ = author;
+    const body = std.mem.trim(u8, body_raw, "\n\r\t ");
+    return std.mem.eql(u8, body, "pending") or
+        std.mem.eql(u8, body, "in_progress") or
+        std.mem.eql(u8, body, "completed");
+}
+
+/// Label shown after `>_` in the compact command row (Codex-native titles preserved; Cursor/shell-like bodies default to "Ran command").
 fn paletteCommandRowDisplayAuthor(original_author: []const u8, body_raw: []const u8) []const u8 {
     if (isCommandSystemEvent(original_author)) return original_author;
+    if (isCursorToolSystemEvent(original_author, body_raw)) return "Ran command";
     if (isCommandLikeShellBody(body_raw)) return "Ran command";
     return original_author;
 }
@@ -1767,7 +1817,7 @@ fn renderTranscriptMessage(state: *app_state.AppState, column: palette.Rect, y: 
     const role_label = switch (message.role) {
         .user => "You",
         .assistant => if (message.author.len > 0) message.author else "Assistant",
-        .system => "System",
+        .system => if (message.author.len > 0) message.author else "System",
     };
     renderTranscriptBubbleFromParts(state, column, y, height, message.role, role_label, message.body, false, false, clip, message_index, false);
     renderTranscriptImages(state, column, y, height, message, clip);
@@ -2148,21 +2198,63 @@ fn renderCommandEventRow(
     queueCardChevron(state, chev_cx, chev_cy, expanded, paletteColor(theme.COLOR_TEXT_SUBTLE));
 
     const text_x = status_cx + status_dia * 0.5 + theme.scaledUi(10.0);
-    const text_w = @max((bubble.x + bubble.w - pad_x - chev_box_w - theme.scaledUi(6.0)) - text_x, theme.scaledUi(40.0));
+    const text_right = bubble.x + bubble.w - pad_x - chev_box_w - theme.scaledUi(6.0);
+    const text_w = @max(text_right - text_x, theme.scaledUi(40.0));
+    const header_text_clip = intersectClipRect(clip, .{
+        .x = text_x,
+        .y = bubble.y,
+        .w = @max(text_right - text_x, 0.0),
+        .h = header_h,
+    });
     const text_color = if (failed) paletteColor(theme.COLOR_DIFF_REMOVE) else paletteColor(theme.COLOR_TEXT_MUTED);
 
-    const header_text = std.fmt.allocPrint(state.allocator, ">_ {s} - {s}", .{ label, body }) catch null;
-    defer if (header_text) |t| state.allocator.free(t);
-
-    const display_text = truncateMonoToWidth(state.allocator, header_text orelse body, text_w, font_size);
-    defer if (display_text.allocated) state.allocator.free(display_text.text);
+    const mono_w = font_size * 0.55;
+    const text_y = bubble.y + pad_y + (line_h - font_size * 1.25) * 0.5;
+    const icon_text = ">_";
+    const icon_w = @as(f32, @floatFromInt(icon_text.len)) * mono_w;
+    const gap = theme.scaledUi(7.0);
+    const label_x = text_x + icon_w + gap;
+    const label_w = @as(f32, @floatFromInt(label.len)) * mono_w;
+    const separator_gap = theme.scaledUi(8.0);
+    const separator = "-";
+    const separator_w = @as(f32, @floatFromInt(separator.len)) * mono_w;
+    const separator_x = label_x + label_w + separator_gap;
+    const body_x = separator_x + separator_w + separator_gap;
+    const body_w = @max(text_right - body_x, 0.0);
 
     queueFixedTextLine(state, snapRect(.{
         .x = text_x,
-        .y = bubble.y + pad_y + (line_h - font_size * 1.25) * 0.5,
-        .w = text_w,
+        .y = text_y,
+        .w = @min(icon_w, text_w),
         .h = font_size * 1.25,
-    }), display_text.text, text_color, font_size, clip);
+    }), icon_text, text_color, font_size, header_text_clip);
+
+    if (label_x < text_right) {
+        queueFixedTextLine(state, snapRect(.{
+            .x = label_x,
+            .y = text_y,
+            .w = @min(label_w, @max(text_right - label_x, 0.0)),
+            .h = font_size * 1.25,
+        }), label, text_color, font_size, header_text_clip);
+    }
+
+    if (body_w > mono_w * 3.0 and body.len > 0) {
+        queueFixedTextLine(state, snapRect(.{
+            .x = separator_x,
+            .y = text_y,
+            .w = @min(separator_w, @max(text_right - separator_x, 0.0)),
+            .h = font_size * 1.25,
+        }), separator, text_color, font_size, header_text_clip);
+
+        const display_body = truncateMonoToWidth(state.allocator, body, body_w, font_size);
+        defer if (display_body.allocated) state.allocator.free(display_body.text);
+        queueFixedTextLine(state, snapRect(.{
+            .x = body_x,
+            .y = text_y,
+            .w = body_w,
+            .h = font_size * 1.25,
+        }), display_body.text, paletteColor(theme.COLOR_TEXT_SUBTLE), font_size, header_text_clip);
+    }
 
     state.recordCardToggleHit(.{
         .rect = .{ .x = bubble.x, .y = bubble.y, .w = bubble.w, .h = header_h },
@@ -2179,6 +2271,20 @@ fn renderCommandEventRow(
         };
         renderWrappedBody(state, inner, body, paletteColor(theme.COLOR_TEXT_MUTED), font_size, clip);
     }
+}
+
+fn intersectClipRect(parent: ?palette.Rect, child: palette.Rect) ?palette.Rect {
+    const p = parent orelse return child;
+    const x = @max(p.x, child.x);
+    const y = @max(p.y, child.y);
+    const right = @min(p.x + p.w, child.x + child.w);
+    const bottom = @min(p.y + p.h, child.y + child.h);
+    return .{
+        .x = x,
+        .y = y,
+        .w = @max(right - x, 0.0),
+        .h = @max(bottom - y, 0.0),
+    };
 }
 
 /// Right-pointing triangle when collapsed, down-pointing when expanded.

--- a/packages/desktop/src/utils.zig
+++ b/packages/desktop/src/utils.zig
@@ -1160,10 +1160,24 @@ fn formatSendWorkerError(
     err: anyerror,
 ) ![]u8 {
     return switch (err) {
-        error.FileNotFound => std.fmt.allocPrint(
-            allocator,
-            "{s} CLI was not found. Install it and make sure it is available on PATH for packaged app launches.",
-            .{providerLabel(provider)},
+        error.FileNotFound => switch (provider) {
+            .claude => allocator.dupe(
+                u8,
+                "Node was not found on PATH. Install Node.js and make sure packaged app launches can find the node executable.",
+            ),
+            .cursor => allocator.dupe(
+                u8,
+                "Cursor CLI was not found. Install Cursor CLI, make sure `agent` is on PATH, then run `agent login`.",
+            ),
+            else => std.fmt.allocPrint(
+                allocator,
+                "{s} CLI was not found. Install it and make sure it is available on PATH for packaged app launches.",
+                .{providerLabel(provider)},
+            ),
+        },
+        error.ProviderBridgeNotFound => allocator.dupe(
+            u8,
+            "The bundled Claude provider bridge was not found. Rebuild or reinstall Verde so provider_bridge.mjs is installed.",
         ),
         error.OpencodeServerUnavailable => allocator.dupe(
             u8,
@@ -1179,11 +1193,11 @@ fn formatSendWorkerError(
         ),
         error.CursorSignedOut => allocator.dupe(
             u8,
-            "Cursor is not authenticated. Set CURSOR_API_KEY or sign in before sending.",
+            "Cursor is not authenticated. Run `agent login` or set CURSOR_API_KEY before sending.",
         ),
-        error.CursorBridgeFailed => allocator.dupe(
+        error.CursorAcpFailed => allocator.dupe(
             u8,
-            "Cursor provider request failed. Check Cursor authentication and @cursor/sdk availability.",
+            "Cursor ACP request failed. Check that the Cursor CLI works with `agent status` and `agent acp`.",
         ),
         else => std.fmt.allocPrint(allocator, "Provider request failed: {s}", .{@errorName(err)}),
     };

--- a/scripts/dev/check-desktop-build-deps.sh
+++ b/scripts/dev/check-desktop-build-deps.sh
@@ -17,8 +17,8 @@ need_cmd() {
 
 need_cmd bun
 
-if [[ ! -d "$REPO_ROOT/node_modules/@cursor/sdk" ]]; then
-  echo "missing Cursor SDK runtime dependencies: node_modules/@cursor/sdk" >&2
+if [[ ! -d "$REPO_ROOT/node_modules/@anthropic-ai/claude-agent-sdk" ]]; then
+  echo "missing provider bridge build dependencies in node_modules" >&2
   echo "run: BUN_TMPDIR=/tmp/verde-bun-tmp bun install --production" >&2
   exit 1
 fi

--- a/scripts/release/install-linux-local.sh
+++ b/scripts/release/install-linux-local.sh
@@ -113,10 +113,9 @@ EOF
 if [[ -e "$SCRIPT_DIR/share/verde/VERSION" ]]; then
   install -m 644 "$SCRIPT_DIR/share/verde/VERSION" "$PREFIX/share/verde/VERSION"
 fi
-if [[ -d "$SCRIPT_DIR/share/verde/node_modules" ]]; then
-  rm -rf "$PREFIX/share/verde/node_modules"
-  mkdir -p "$PREFIX/share/verde/node_modules"
-  cp -a "$SCRIPT_DIR/share/verde/node_modules/." "$PREFIX/share/verde/node_modules/"
+rm -rf "$PREFIX/share/verde/node_modules"
+if [[ -e "$SCRIPT_DIR/share/verde/provider_bridge.mjs" ]]; then
+  install -m 644 "$SCRIPT_DIR/share/verde/provider_bridge.mjs" "$PREFIX/share/verde/provider_bridge.mjs"
 fi
 assert_no_cef_payload "$PREFIX"
 

--- a/scripts/release/package-linux.sh
+++ b/scripts/release/package-linux.sh
@@ -102,19 +102,6 @@ copy_runtime_library() {
   fi
 }
 
-copy_node_runtime() {
-  local destination_dir="$1"
-  local source_dir="$REPO_ROOT/node_modules"
-
-  if [[ ! -d "$source_dir/@cursor/sdk" ]]; then
-    echo "missing Cursor SDK runtime dependencies; run bun install --production before packaging" >&2
-    exit 1
-  fi
-
-  mkdir -p "$destination_dir"
-  cp -a "$source_dir/." "$destination_dir/"
-}
-
 assert_no_cef_payload() {
   local root_dir="$1"
   local cef_payload=(
@@ -202,9 +189,14 @@ chmod 755 "$PACKAGE_ROOT/bin/verde-launch"
 install -m 644 "$REPO_ROOT/packages/desktop/src/assets/verde_logo.png" "$PACKAGE_ROOT/share/pixmaps/verde.png"
 install -m 644 "$REPO_ROOT/packages/desktop/src/assets/verde_logo.png" "$PACKAGE_ROOT/share/icons/hicolor/256x256/apps/verde.png"
 printf '%s\n' "$VERSION" > "$PACKAGE_ROOT/share/verde/VERSION"
-copy_node_runtime "$PACKAGE_ROOT/share/verde/node_modules"
+install -m 644 "$PREFIX_DIR/share/verde/provider_bridge.mjs" "$PACKAGE_ROOT/share/verde/provider_bridge.mjs"
 install -m 755 "$REPO_ROOT/scripts/release/install-linux-local.sh" "$PACKAGE_ROOT/install-local.sh"
 install -m 644 "$REPO_ROOT/README.md" "$PACKAGE_ROOT/README.md"
+
+if [[ -e "$PACKAGE_ROOT/share/verde/node_modules" ]]; then
+  echo "package unexpectedly contains share/verde/node_modules" >&2
+  exit 1
+fi
 
 normalize_fff_dependency \
   "$PACKAGE_ROOT/bin/verde" \

--- a/scripts/release/package-macos-app.sh
+++ b/scripts/release/package-macos-app.sh
@@ -78,19 +78,6 @@ set_macos_build_version() {
   chmod 755 "$binary"
 }
 
-copy_node_runtime() {
-  local destination_dir="$1"
-  local source_dir="$REPO_ROOT/node_modules"
-
-  if [[ ! -d "$source_dir/@cursor/sdk" ]]; then
-    echo "missing Cursor SDK runtime dependencies; run bun install --production before packaging" >&2
-    exit 1
-  fi
-
-  mkdir -p "$destination_dir"
-  cp -a "$source_dir/." "$destination_dir/"
-}
-
 assert_no_cef_payload() {
   local app_dir="$1"
   local macos_dir="$app_dir/Contents/MacOS"
@@ -170,7 +157,11 @@ if [[ "$BROWSER_BACKEND" == "cef" ]]; then
   fi
 fi
 assert_no_cef_payload "$APP_DIR"
-copy_node_runtime "$APP_DIR/Contents/Resources/node_modules"
+install -m 644 "$PREFIX_DIR/share/verde/provider_bridge.mjs" "$APP_DIR/Contents/Resources/provider_bridge.mjs"
+if [[ -e "$APP_DIR/Contents/Resources/node_modules" ]]; then
+  echo "app unexpectedly contains Contents/Resources/node_modules" >&2
+  exit 1
+fi
 set_macos_build_version "$APP_DIR/Contents/MacOS/verde"
 
 cat > "$APP_DIR/Contents/Info.plist" <<EOF


### PR DESCRIPTION
## Summary
- replace Cursor provider bridge with Cursor CLI ACP integration
- bundle the shared provider bridge for Claude at build time
- render provider tool events as compact command rows

## Verification
- zig fmt --check packages/desktop/src/providers/cursor.zig packages/desktop/src/ui/chat_panel.zig
- zig build --release=safe -Dbrowser-backend=native_webview --summary all
- manual Cursor and Claude provider smoke testing