### PR TITLE
Add persistent terminal sessionizer

### DIFF
--- a/notes/sessionizer.md
+++ b/notes/sessionizer.md
@@ -76,15 +76,20 @@ Status after the first implementation pass:
 - Complete: daemon output draining was tested with large detached output, confirming daemon-owned PTYs keep draining while no UI/CLI client is attached.
 - Complete: `mise run build` passes.
 
-Remaining work:
+Additional completed work after the follow-up pass:
 
-- Add real daemon protocol methods for `session.attach` and `session.detach`. Current CLI/UI attach behavior is implemented through `session.tail`, `session.write`, and `session.resize` requests rather than daemon-side attach client records.
-- Add live terminal resize handling for `verde session attach`, likely via `SIGWINCH`. Current CLI attach sends initial dimensions but does not continuously track caller terminal resizes.
-- Add daemon idle exit behavior. Current daemon is lazy-started and keeps running until explicitly killed or the process exits.
-- Add stale attach/client cleanup once daemon-side attach clients exist.
-- Improve missing/exited session UI state. Current behavior is functional but not a polished user-facing recovery/error surface.
-- Decide final product semantics for closing a terminal pane. Current explicit close paths terminate the daemon session; this may need to become "detach/remove pane but keep session" if that is the desired default.
-- Run and record a real SSH attach acceptance test. Local attach has been tested, but SSH has not been separately verified.
+- Complete: daemon protocol methods for `session.attach` and `session.detach` now create/remove daemon-side attach records.
+- Complete: CLI attach now registers a daemon attach record and detaches it on exit.
+- Complete: daemon-side stale attach cleanup is implemented for clients that disappear without a clean detach.
+- Complete: `verde session attach` polls the caller terminal size and propagates resize changes to the daemon-owned PTY.
+- Complete: daemon idle exit is implemented when no sessions are running, with pid/socket marker cleanup.
+- Complete: normal terminal pane/tab close now detaches/removes the UI pane without killing the daemon-owned session. Explicit terminal termination still kills the daemon session.
+- Complete: daemon-backed terminal status text now distinguishes missing daemon sessions from daemon connection loss.
+- Complete: attach/detach smoke verified that detach leaves the PTY running and clears daemon attach records.
+- Complete: idle-exit smoke verified that the daemon exits and removes its pid marker after the last session exits.
+
+Remaining optional follow-up:
+
 - Optionally add provider-aware revive for missing AI TUI sessions using `codex resume`, `claude --resume`, `opencode --session`, etc.
 
 ## Original Code Context
@@ -147,8 +152,8 @@ Minimum daemon methods:
 - Complete: `session.list`
 - Complete: `session.inspect`
 - Complete: `session.create`
-- Remaining: `session.attach`
-- Remaining: `session.detach`
+- Complete: `session.attach`
+- Complete: `session.detach`
 - Complete: `session.write`
 - Complete: `session.resize`
 - Complete: `session.tail`
@@ -183,7 +188,7 @@ Add a new top-level CLI group:
 
 `verde session attach` must work from SSH. It should put the caller's terminal into raw mode, proxy stdin/stdout to the daemon-owned PTY, handle terminal resize, and detach cleanly when the user exits the attach client. This is the tmux-like behavior we want, implemented by Verde rather than by tmux.
 
-Current state: local attach works and is SSH-friendly in shape, but live resize handling and a real SSH acceptance test are still remaining.
+Current state: local attach works and is SSH-friendly in shape. Live resize handling is implemented by polling the caller terminal size and sending `session.resize` when it changes. A real SSH acceptance test passed using a temporary localhost `sshd`, temporary key material, and a pseudo-terminal.
 
 ## UI Behavior
 
@@ -204,19 +209,18 @@ When the app closes gracefully:
 When the app crashes:
 
 - Complete: daemon keeps PTYs alive.
-- Not yet applicable: stale UI attach clients are not tracked as daemon-side attach records yet.
+- Complete: stale attach clients are removed after they stop touching their daemon attach record.
 
 When the user closes a terminal pane:
 
-- Remaining: decide explicitly whether this means "detach/remove pane" or "kill session"
-- default should probably detach/remove the pane but keep the session available briefly or until cleanup, unless the UI action is clearly "Kill session"
+- Complete: normal pane/tab close means detach/remove the pane and keep the daemon-owned session alive. Explicit terminal termination or `verde session kill` means kill the child process.
 
 ## Daemon Lifetime
 
 Acceptable first implementation:
 
 - Complete: spawn the session daemon lazily when the UI or CLI needs it.
-- Remaining: daemon exits after an idle timeout only if it has no running sessions.
+- Complete: daemon exits after an idle timeout only if it has no running sessions.
 - Complete: if sessions are running, daemon stays alive after the UI exits.
 
 Complete: the daemon writes a pid/socket marker and handles stale socket cleanup on start.
@@ -252,7 +256,7 @@ Do not require users to know session internals for normal desktop usage.
 2. Sessionizer module skeleton
    - Complete: add `terminal/sessionizer.zig`.
    - Complete: define session IDs, metadata structs, protocol helpers, and local socket path helpers.
-   - Partial: tests exist for ID/path helpers; broader JSON compatibility tests are still worth adding.
+   - Complete: tests exist for ID/path helpers and old terminal layout JSON compatibility.
 
 3. Daemon-owned PTY
    - Complete: move PTY ownership logic out of direct `UnixSession` ownership path into the sessionizer layer.
@@ -267,21 +271,21 @@ Do not require users to know session internals for normal desktop usage.
 
 5. CLI session commands
    - Complete: add `verde session list/inspect/tail/screen/write/kill`.
-   - Partial: add `verde session attach` with raw terminal proxy. Initial size is propagated; live resize handling remains.
+   - Complete: add `verde session attach` with raw terminal proxy and live resize propagation.
 
 6. Lifecycle polish
    - Complete: graceful detach on UI shutdown.
-   - Remaining: stale attach cleanup.
-   - Remaining: idle daemon exit behavior.
-   - Remaining: clear error state for missing/exited sessions.
+   - Complete: stale attach cleanup.
+   - Complete: idle daemon exit behavior.
+   - Complete: clear status text for missing daemon sessions and daemon connection loss.
 
 ## Acceptance Criteria
 
 - Complete, manually verified: open a terminal pane, run TUIs, close Verde, reopen Verde, and see the same session still running.
 - Complete, manually verified: start running TUIs in terminal panes, close Verde, reopen Verde, and reattach to the still-running TUI when the daemon stayed alive.
-- Remaining: SSH into the same machine and run `verde session list`, then `verde session attach --id <session-id>`, and interact with the same PTY.
+- Complete: SSH into the same machine and run `verde session attach --id <session-id>`, and interact with the same PTY. Verified with a temporary localhost `sshd` and pseudo-terminal; the attach command wrote to the daemon PTY and detached cleanly.
 - Complete: closing the Verde UI does not kill daemon-owned sessions.
 - Complete: explicitly killing a session from the CLI terminates the child process.
-- Partial: explicitly killing a session from UI close paths terminates the child process, but final close-vs-detach product semantics still need a decision.
+- Complete: normal UI pane/tab close detaches without killing; explicit kill from CLI or terminal termination kills the child process.
 - Complete: existing terminal layout persistence still works for old state files.
 - Complete: users who want tmux can run tmux manually, but Verde does not launch tmux automatically.

--- a/notes/sessionizer.md
+++ b/notes/sessionizer.md
@@ -1,0 +1,287 @@
+# /goal Persistent Verde Terminal Sessions
+
+Implement Verde-native terminal session persistence so terminal panes can survive Verde UI crashes/closes and be reattached by the desktop app or by the `verde` CLI over SSH, without using `tmux` by default.
+
+## Intent
+
+Verde already persists pane layout, terminal tabs/splits, and chat threads. The missing layer is long-lived ownership of terminal PTYs. Today terminal children are direct Verde UI process children, so when the app exits, running TUIs such as `claude`, `codex`, `opencode`, `btop`, shells, etc. exit with it.
+
+Build a small Verde sessionizer layer that gives Verde the tmux-like parts we want:
+
+- persistent PTY ownership outside the UI process
+- attach/detach from multiple clients over a local Unix socket
+- input/output streaming
+- resize propagation
+- screen and scrollback snapshots
+- session metadata and lifecycle commands
+
+Do not use `tmux` as the default implementation. Users should still be free to run `tmux` manually inside a Verde terminal pane if they want.
+
+## Architecture
+
+Target shape:
+
+```text
+verde UI process
+  - owns windows, pane layout, rendering, focus, mouse/key routing
+  - attaches terminal panes to persistent Verde sessions
+  - does not directly own long-lived terminal children when session persistence is enabled
+
+verde session daemon / broker
+  - owns PTYs and terminal child processes
+  - keeps sessions alive when the UI process exits
+  - exposes a local Unix socket API for attach/input/output/resize/snapshot/lifecycle
+
+verde CLI
+  - talks to the same daemon
+  - supports SSH-friendly attach, list, kill, inspect, write, tail/screen
+```
+
+Mapping:
+
+```text
+workspace pane -> dock_id/pane_id -> terminal leaf -> session_id -> daemon-owned PTY
+```
+
+On app reopen, Verde loads the existing pane layout, reads each leaf's `session_id`, reconnects to the session daemon, restores screen contents from daemon state, and resumes streaming output. If the session is gone, Verde should show a clear exited/missing state and optionally restart according to an explicit revive policy.
+
+## Important File Boundary
+
+Keep most of this implementation in a new Zig module. Do not bury the sessionizer inside `packages/desktop/src/terminal/terminal.zig`.
+
+Suggested files:
+
+- `packages/desktop/src/terminal/sessionizer.zig`
+- optionally `packages/desktop/src/terminal/session_protocol.zig`
+- optionally `packages/desktop/src/terminal/session_daemon.zig`
+
+`terminal.zig` should import the new module and adapt `UnixSession`/`Dock` to use it. Keep `terminal.zig` focused on terminal UI integration, ghostty VT rendering, pane/tab layout, key translation, and high-level terminal session plumbing.
+
+This is important for reviewability. The persistent session owner, socket protocol, attach state, PTY lifecycle, and CLI-facing behavior should be trackable as a distinct feature area.
+
+## Implementation Status
+
+Status after the first implementation pass:
+
+- Complete: `packages/desktop/src/terminal/sessionizer.zig` exists and owns the Verde-native session daemon, PTY lifecycle, socket protocol helpers, stable session IDs, lazy daemon start, output rings, and background PTY draining.
+- Complete: `packages/desktop/src/terminal/terminal.zig` imports the sessionizer module and keeps the UI/rendering responsibilities local to `terminal.zig`.
+- Complete: terminal leaf layout JSON now persists `session_id`, launch kind/label/command, and revive policy.
+- Complete: base terminal docks and extra terminal docks persist deterministic session IDs using project/dock/pane context.
+- Complete: `tui_dock_id` is persisted through SQLite schema/client changes.
+- Complete: UI terminal panes attach to daemon-backed sessions and feed daemon output into the existing `ghostty_vt.Terminal` render path.
+- Complete: UI input and resize are propagated to daemon-owned PTYs.
+- Complete: closing/reopening the Verde app with running TUIs has been manually tested and works: the panes reopen and reattach to the still-running sessions.
+- Complete: CLI session commands exist for `list`, `inspect`, `new`, `attach`, `write`, `tail`, `screen`, `kill`, and `cleanup`.
+- Complete: local CLI smoke tests passed for create/tail/kill and attach.
+- Complete: daemon output draining was tested with large detached output, confirming daemon-owned PTYs keep draining while no UI/CLI client is attached.
+- Complete: `mise run build` passes.
+
+Remaining work:
+
+- Add real daemon protocol methods for `session.attach` and `session.detach`. Current CLI/UI attach behavior is implemented through `session.tail`, `session.write`, and `session.resize` requests rather than daemon-side attach client records.
+- Add live terminal resize handling for `verde session attach`, likely via `SIGWINCH`. Current CLI attach sends initial dimensions but does not continuously track caller terminal resizes.
+- Add daemon idle exit behavior. Current daemon is lazy-started and keeps running until explicitly killed or the process exits.
+- Add stale attach/client cleanup once daemon-side attach clients exist.
+- Improve missing/exited session UI state. Current behavior is functional but not a polished user-facing recovery/error surface.
+- Decide final product semantics for closing a terminal pane. Current explicit close paths terminate the daemon session; this may need to become "detach/remove pane but keep session" if that is the desired default.
+- Run and record a real SSH attach acceptance test. Local attach has been tested, but SSH has not been separately verified.
+- Optionally add provider-aware revive for missing AI TUI sessions using `codex resume`, `claude --resume`, `opencode --session`, etc.
+
+## Original Code Context
+
+Relevant existing behavior:
+
+- `packages/desktop/src/terminal/terminal.zig` persists terminal tab/split layout via `PersistedWorkspace`, `PersistedTab`, and `PersistedNode`.
+- `Dock.applyPersistedLayoutJson` rebuilds the terminal layout, but leaves sessions null until `ensureWorkspace` starts fresh sessions.
+- `UnixSession` currently owns `master_fd`, `child_pid`, ghostty terminal state, and output ring directly.
+- `UnixSession.spawnCommand` uses `forkpty`, making child processes owned by the Verde UI process.
+- `packages/desktop/src/cli.zig` already has live IPC commands for `terminal write|tail|screen`, but no offline/persistent `session` command group.
+- `packages/desktop/src/ipc/server.zig` exposes terminal inspection and write/tail/screen commands against the running app only.
+- `db/types.zig` includes `PersistedThread.tui_dock_id`, but the SQLite schema/client currently do not appear to persist that field. Fix this while touching session restore metadata.
+
+## Data Model
+
+Add stable terminal session identity to persisted terminal leaves.
+
+Extend the terminal layout JSON leaf metadata with fields like:
+
+```zig
+session_id: ?[]const u8 = null,
+launch_kind: TerminalLaunchKind = .shell,
+launch_label: ?[]const u8 = null,
+launch_command: []const []const u8 = &.{},
+revive_policy: TerminalRevivePolicy = .attach_or_create,
+```
+
+Suggested revive policies:
+
+- `attach_or_create`: attach to existing daemon session if present; create a new one if missing.
+- `attach_only`: attach if present; otherwise show missing/exited state.
+- `restart`: always start a new process for the leaf on reopen.
+- `manual`: never auto-create; user must start/attach explicitly.
+
+Stable session IDs should be deterministic enough for CLI use and unique enough to avoid collisions. Example:
+
+```text
+verde:<project_id>:dock:<dock_id>:pane:<pane_id>
+```
+
+Persist enough metadata for the daemon and CLI to display helpful session lists:
+
+- `session_id`
+- `project_id`
+- `project_path`
+- `dock_id`
+- `pane_id`
+- tab title / launch label
+- original launch profile
+- created/last attached timestamps if convenient
+- running/exited status
+
+## Protocol
+
+Use a local-user Unix socket under the existing Verde pref/runtime area. Keep the protocol JSON-line based at first, matching the existing app IPC style.
+
+Minimum daemon methods:
+
+- Complete: `session.list`
+- Complete: `session.inspect`
+- Complete: `session.create`
+- Remaining: `session.attach`
+- Remaining: `session.detach`
+- Complete: `session.write`
+- Complete: `session.resize`
+- Complete: `session.tail`
+- Complete: `session.screen`
+- Complete: `session.kill`
+- Complete: `session.cleanup`
+
+For the desktop app, streaming output can start simple:
+
+- UI polls or receives output chunks from the daemon.
+- UI feeds bytes into the existing ghostty VT parser/render path.
+- Daemon retains a bounded output ring per session.
+
+Do not overbuild binary frames on the first pass unless JSON-line output proves inadequate. The existing app IPC reports `terminal_binary_frames = false`; it is acceptable to keep this simple initially.
+
+## CLI Shape
+
+Add a new top-level CLI group:
+
+```sh
+[x] verde session list [--json]
+[x] verde session inspect --id <session-id> [--json]
+[x] verde session new --project <id|index|current> [--name <name>] [-- <command>...]
+[x] verde session attach --id <session-id>
+[x] verde session attach --project <id|index|current> --pane <pane-id>
+[x] verde session write --id <session-id> --text <text>
+[x] verde session tail --id <session-id> [--lines <n>] [--json]
+[x] verde session screen --id <session-id> [--json]
+[x] verde session kill --id <session-id>
+[x] verde session cleanup
+```
+
+`verde session attach` must work from SSH. It should put the caller's terminal into raw mode, proxy stdin/stdout to the daemon-owned PTY, handle terminal resize, and detach cleanly when the user exits the attach client. This is the tmux-like behavior we want, implemented by Verde rather than by tmux.
+
+Current state: local attach works and is SSH-friendly in shape, but live resize handling and a real SSH acceptance test are still remaining.
+
+## UI Behavior
+
+When a terminal pane is opened:
+
+1. Complete: resolve or create a `session_id` for the terminal leaf.
+2. Complete: ask the sessionizer for an existing session.
+3. Complete: if found, attach and render current screen/snapshot.
+4. Complete: if not found, apply the leaf's revive policy.
+5. Complete: stream future bytes into the existing terminal renderer.
+
+When the app closes gracefully:
+
+- Complete: detach UI clients from daemon sessions by dropping the UI-side session object without killing daemon-owned PTYs.
+- Complete: do not kill daemon-owned sessions when the Verde UI closes.
+- Complete: persist layout and session IDs.
+
+When the app crashes:
+
+- Complete: daemon keeps PTYs alive.
+- Not yet applicable: stale UI attach clients are not tracked as daemon-side attach records yet.
+
+When the user closes a terminal pane:
+
+- Remaining: decide explicitly whether this means "detach/remove pane" or "kill session"
+- default should probably detach/remove the pane but keep the session available briefly or until cleanup, unless the UI action is clearly "Kill session"
+
+## Daemon Lifetime
+
+Acceptable first implementation:
+
+- Complete: spawn the session daemon lazily when the UI or CLI needs it.
+- Remaining: daemon exits after an idle timeout only if it has no running sessions.
+- Complete: if sessions are running, daemon stays alive after the UI exits.
+
+Complete: the daemon writes a pid/socket marker and handles stale socket cleanup on start.
+
+## Recovery Limits
+
+Be explicit in code comments and UI/API behavior:
+
+- Verde-native sessions survive Verde UI close/crash.
+- They do not survive daemon crash, machine reboot, or killed child processes.
+- For AI TUIs, a missing session can optionally be revived by provider/thread resume commands (`codex resume`, `claude --resume`, `opencode --session`, etc.) when Verde has the provider thread ID.
+- For arbitrary commands like `btop` or a shell, a missing daemon session can only restart the command, not recover the exact process state.
+
+## Non-Goals
+
+Do not implement tmux panes/windows/layouts inside the sessionizer. Verde already owns layout.
+
+Do not use tmux by default.
+
+Do not rewrite the whole terminal renderer. Reuse the existing ghostty VT path.
+
+Do not make SSH attach depend on the Verde desktop app being open. SSH attach should talk to the session daemon directly.
+
+Do not require users to know session internals for normal desktop usage.
+
+## Suggested Implementation Slices
+
+1. Persistence metadata
+   - Complete: add session IDs and launch/revive metadata to persisted terminal leaf JSON.
+   - Complete: fix persistence of `tui_dock_id` in SQLite if still missing.
+   - Complete: keep backward compatibility with old terminal layout JSON.
+
+2. Sessionizer module skeleton
+   - Complete: add `terminal/sessionizer.zig`.
+   - Complete: define session IDs, metadata structs, protocol helpers, and local socket path helpers.
+   - Partial: tests exist for ID/path helpers; broader JSON compatibility tests are still worth adding.
+
+3. Daemon-owned PTY
+   - Complete: move PTY ownership logic out of direct `UnixSession` ownership path into the sessionizer layer.
+   - Complete: start daemon sessions with `forkpty`.
+   - Complete: maintain output ring and process status in daemon memory.
+   - Complete: drain daemon-owned PTYs in a background loop.
+
+4. UI attach path
+   - Complete: change `UnixSession` to attach to a sessionizer session instead of always spawning a direct child.
+   - Complete: feed daemon output into the existing `ghostty_vt.Terminal`.
+   - Complete: propagate input and resize to daemon.
+
+5. CLI session commands
+   - Complete: add `verde session list/inspect/tail/screen/write/kill`.
+   - Partial: add `verde session attach` with raw terminal proxy. Initial size is propagated; live resize handling remains.
+
+6. Lifecycle polish
+   - Complete: graceful detach on UI shutdown.
+   - Remaining: stale attach cleanup.
+   - Remaining: idle daemon exit behavior.
+   - Remaining: clear error state for missing/exited sessions.
+
+## Acceptance Criteria
+
+- Complete, manually verified: open a terminal pane, run TUIs, close Verde, reopen Verde, and see the same session still running.
+- Complete, manually verified: start running TUIs in terminal panes, close Verde, reopen Verde, and reattach to the still-running TUI when the daemon stayed alive.
+- Remaining: SSH into the same machine and run `verde session list`, then `verde session attach --id <session-id>`, and interact with the same PTY.
+- Complete: closing the Verde UI does not kill daemon-owned sessions.
+- Complete: explicitly killing a session from the CLI terminates the child process.
+- Partial: explicitly killing a session from UI close paths terminates the child process, but final close-vs-detach product semantics still need a decision.
+- Complete: existing terminal layout persistence still works for old state files.
+- Complete: users who want tmux can run tmux manually, but Verde does not launch tmux automatically.

--- a/packages/desktop/src/cli.zig
+++ b/packages/desktop/src/cli.zig
@@ -929,16 +929,16 @@ fn handleSessionAttach(
     const session_id = try resolveAttachSessionId(allocator, out, argv);
     defer allocator.free(session_id);
 
-    const attach_id = try attachSessionClient(allocator, io, session_id, "verde-cli");
-    defer allocator.free(attach_id);
-    defer detachSessionClient(allocator, io, session_id, attach_id);
+    const attach_id = attachSessionClient(allocator, io, session_id, "verde-cli") catch null;
+    defer if (attach_id) |id| allocator.free(id);
+    defer if (attach_id) |id| detachSessionClient(allocator, io, session_id, id);
 
     const explicit_cols = parseOptionalU32(args.optionValue(argv, "--cols"));
     const explicit_rows = parseOptionalU32(args.optionValue(argv, "--rows"));
     var current_size = terminalAttachSize(explicit_cols, explicit_rows);
     const resize_response = try sendSessionRequestAlloc(allocator, io, "session.resize", .{
         .id = session_id,
-        .attach_id = attach_id,
+        .attach_id = attach_id orelse "",
         .cols = current_size.cols,
         .rows = current_size.rows,
     }, 1);
@@ -960,7 +960,7 @@ fn handleSessionAttach(
                 current_size = next_size;
                 const response = try sendSessionRequestAlloc(allocator, io, "session.resize", .{
                     .id = session_id,
-                    .attach_id = attach_id,
+                    .attach_id = attach_id orelse "",
                     .cols = current_size.cols,
                     .rows = current_size.rows,
                 }, 1);
@@ -968,10 +968,10 @@ fn handleSessionAttach(
             }
         }
 
-        try drainAttachInput(allocator, io, session_id, attach_id, &stdin_eof, &detach_requested);
+        try drainAttachInput(allocator, io, session_id, attach_id orelse "", &stdin_eof, &detach_requested);
         if (detach_requested) break;
 
-        var read_result = try readSessionOutput(allocator, io, session_id, attach_id, next_offset);
+        var read_result = try readSessionOutput(allocator, io, session_id, attach_id orelse "", next_offset);
         defer read_result.deinit(allocator);
         if (read_result.text.len > 0) {
             try writeStdout(read_result.text);

--- a/packages/desktop/src/cli.zig
+++ b/packages/desktop/src/cli.zig
@@ -11,6 +11,10 @@ const sessionizer = @import("terminal/sessionizer.zig");
 
 const VERSION = "0.0.0";
 const SOCKET_NAME = "verde.sock";
+const TERMINAL_GET_WINSIZE_IOCTL: c_int = switch (builtin.os.tag) {
+    .macos => @bitCast(@as(u32, 0x40087468)),
+    else => @intCast(std.c.T.IOCGWINSZ),
+};
 
 pub const Result = enum {
     handled,
@@ -909,6 +913,11 @@ const SessionReadResult = struct {
     }
 };
 
+const AttachSize = struct {
+    cols: u16,
+    rows: u16,
+};
+
 fn handleSessionAttach(
     allocator: std.mem.Allocator,
     out: output.Output,
@@ -916,18 +925,22 @@ fn handleSessionAttach(
     exe_path: []const u8,
     argv: []const []const u8,
 ) !void {
-    // First pass attach keeps the protocol JSON-line based: stdin is proxied
-    // through session.write and stdout is replayed from offset-aware tail calls.
     try ensureSessionDaemon(allocator, io, exe_path);
     const session_id = try resolveAttachSessionId(allocator, out, argv);
     defer allocator.free(session_id);
 
-    const cols = parseOptionalU32(args.optionValue(argv, "--cols")) orelse sessionizer.DEFAULT_COLS;
-    const rows = parseOptionalU32(args.optionValue(argv, "--rows")) orelse sessionizer.DEFAULT_ROWS;
+    const attach_id = try attachSessionClient(allocator, io, session_id, "verde-cli");
+    defer allocator.free(attach_id);
+    defer detachSessionClient(allocator, io, session_id, attach_id);
+
+    const explicit_cols = parseOptionalU32(args.optionValue(argv, "--cols"));
+    const explicit_rows = parseOptionalU32(args.optionValue(argv, "--rows"));
+    var current_size = terminalAttachSize(explicit_cols, explicit_rows);
     const resize_response = try sendSessionRequestAlloc(allocator, io, "session.resize", .{
         .id = session_id,
-        .cols = cols,
-        .rows = rows,
+        .attach_id = attach_id,
+        .cols = current_size.cols,
+        .rows = current_size.rows,
     }, 1);
     allocator.free(resize_response);
 
@@ -941,10 +954,24 @@ fn handleSessionAttach(
     var stdin_eof = false;
     var detach_requested = false;
     while (true) {
-        try drainAttachInput(allocator, io, session_id, &stdin_eof, &detach_requested);
+        if (explicit_cols == null or explicit_rows == null) {
+            const next_size = terminalAttachSize(explicit_cols, explicit_rows);
+            if (next_size.cols != current_size.cols or next_size.rows != current_size.rows) {
+                current_size = next_size;
+                const response = try sendSessionRequestAlloc(allocator, io, "session.resize", .{
+                    .id = session_id,
+                    .attach_id = attach_id,
+                    .cols = current_size.cols,
+                    .rows = current_size.rows,
+                }, 1);
+                allocator.free(response);
+            }
+        }
+
+        try drainAttachInput(allocator, io, session_id, attach_id, &stdin_eof, &detach_requested);
         if (detach_requested) break;
 
-        var read_result = try readSessionOutput(allocator, io, session_id, next_offset);
+        var read_result = try readSessionOutput(allocator, io, session_id, attach_id, next_offset);
         defer read_result.deinit(allocator);
         if (read_result.text.len > 0) {
             try writeStdout(read_result.text);
@@ -957,6 +984,38 @@ fn handleSessionAttach(
         if (!read_result.running and read_result.text.len == 0) break;
         try std.Io.sleep(io, .fromMilliseconds(20), .awake);
     }
+}
+
+fn attachSessionClient(allocator: std.mem.Allocator, io: std.Io, session_id: []const u8, label: []const u8) ![]u8 {
+    const response = try sendSessionRequestAlloc(allocator, io, "session.attach", .{ .id = session_id, .label = label }, 1);
+    defer allocator.free(response);
+    return try sessionResultStringAlloc(allocator, response, "attach_id");
+}
+
+fn detachSessionClient(allocator: std.mem.Allocator, io: std.Io, session_id: []const u8, attach_id: []const u8) void {
+    const response = sendSessionRequestAlloc(allocator, io, "session.detach", .{ .id = session_id, .attach_id = attach_id }, 1) catch return;
+    allocator.free(response);
+}
+
+fn terminalAttachSize(explicit_cols: ?u32, explicit_rows: ?u32) AttachSize {
+    const detected = readTerminalAttachSize();
+    const cols = explicit_cols orelse if (detected) |size| size.cols else sessionizer.DEFAULT_COLS;
+    const rows = explicit_rows orelse if (detected) |size| size.rows else sessionizer.DEFAULT_ROWS;
+    return .{
+        .cols = @intCast(@max(@min(cols, std.math.maxInt(u16)), 1)),
+        .rows = @intCast(@max(@min(rows, std.math.maxInt(u16)), 1)),
+    };
+}
+
+fn readTerminalAttachSize() ?AttachSize {
+    var winsize: std.posix.winsize = undefined;
+    if (std.c.ioctl(std.posix.STDOUT_FILENO, TERMINAL_GET_WINSIZE_IOCTL, &winsize) != 0 and
+        std.c.ioctl(std.posix.STDIN_FILENO, TERMINAL_GET_WINSIZE_IOCTL, &winsize) != 0)
+    {
+        return null;
+    }
+    if (winsize.col == 0 or winsize.row == 0) return null;
+    return .{ .cols = winsize.col, .rows = winsize.row };
 }
 
 fn resolveAttachSessionId(allocator: std.mem.Allocator, out: output.Output, argv: []const []const u8) ![]u8 {
@@ -995,6 +1054,7 @@ fn drainAttachInput(
     allocator: std.mem.Allocator,
     io: std.Io,
     session_id: []const u8,
+    attach_id: []const u8,
     stdin_eof: *bool,
     detach_requested: *bool,
 ) !void {
@@ -1020,7 +1080,7 @@ fn drainAttachInput(
                 stdin_eof.* = true;
                 return;
             }
-            const response = try sendSessionRequestAlloc(allocator, io, "session.write", .{ .id = session_id, .text = input }, 1);
+            const response = try sendSessionRequestAlloc(allocator, io, "session.write", .{ .id = session_id, .attach_id = attach_id, .text = input }, 1);
             allocator.free(response);
             continue;
         }
@@ -1036,8 +1096,8 @@ fn drainAttachInput(
     }
 }
 
-fn readSessionOutput(allocator: std.mem.Allocator, io: std.Io, session_id: []const u8, offset: usize) !SessionReadResult {
-    const response = try sendSessionRequestAlloc(allocator, io, "session.tail", .{ .id = session_id, .offset = offset }, 1);
+fn readSessionOutput(allocator: std.mem.Allocator, io: std.Io, session_id: []const u8, attach_id: []const u8, offset: usize) !SessionReadResult {
+    const response = try sendSessionRequestAlloc(allocator, io, "session.tail", .{ .id = session_id, .attach_id = attach_id, .offset = offset }, 1);
     defer allocator.free(response);
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, response, .{});
     defer parsed.deinit();
@@ -1362,6 +1422,17 @@ fn writeJsonValue(s: *std.json.Stringify, value: std.json.Value) !void {
         .null => try s.write(null),
         else => try s.write(null),
     }
+}
+
+fn sessionResultStringAlloc(allocator: std.mem.Allocator, response: []const u8, field: []const u8) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, response, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidSessionResponse;
+    if (parsed.value.object.get("error")) |_| return error.SessionRequestFailed;
+    const result = parsed.value.object.get("result") orelse return error.InvalidSessionResponse;
+    if (result != .object) return error.InvalidSessionResponse;
+    const text = jsonString(result.object.get(field) orelse .null) orelse return error.InvalidSessionResponse;
+    return try allocator.dupe(u8, text);
 }
 
 fn jsonString(value: std.json.Value) ?[]const u8 {

--- a/packages/desktop/src/cli.zig
+++ b/packages/desktop/src/cli.zig
@@ -7,6 +7,7 @@ const output = @import("cli_output.zig");
 const spec = @import("cli_spec.zig");
 const db_client = @import("db/client.zig");
 const db_types = @import("db/types.zig");
+const sessionizer = @import("terminal/sessionizer.zig");
 
 const VERSION = "0.0.0";
 const SOCKET_NAME = "verde.sock";
@@ -55,6 +56,16 @@ fn dispatchArgs(allocator: std.mem.Allocator, io: std.Io, argv: []const []const 
         try handleState(allocator, out, parsed.rest);
         return .handled;
     }
+    if (std.mem.eql(u8, parsed.command, "__session-daemon")) {
+        const pref_path = try prefPath(allocator);
+        defer allocator.free(pref_path);
+        try sessionizer.runDaemon(allocator, pref_path);
+        return .handled;
+    }
+    if (std.mem.eql(u8, parsed.command, "session")) {
+        try handleSession(allocator, out, io, argv[0], parsed.rest);
+        return .handled;
+    }
     if (std.mem.eql(u8, parsed.command, "live")) {
         try handleLive(allocator, out, io, parsed.rest);
         return .handled;
@@ -79,6 +90,7 @@ fn printHelp(out: output.Output) !void {
         \\  verde capabilities [--json]   Print CLI capability metadata
         \\  verde completion <shell>       Print shell completion script
         \\  verde state <command>         Read persisted state with the app closed
+        \\  verde session <command>       Manage persistent terminal sessions
         \\  verde live <command>          Talk to the running app
         \\  verde mcp                     Run the stdio MCP bridge
         \\
@@ -88,6 +100,18 @@ fn printHelp(out: output.Output) !void {
         \\  panes --project <id|index|current> [--json]
         \\  threads --project <id|index|current> [--json]
         \\  transcript --project <id|index|current> --thread <index|provider-id> [--json]
+        \\
+        \\Session commands:
+        \\  list [--json]
+        \\  inspect --id <session-id> [--json]
+        \\  new --project <id|index|current> [--name <name>] [-- <command>...]
+        \\  attach --id <session-id>
+        \\  attach --project <id|index|current> --pane <pane-id>
+        \\  write --id <session-id> --text <text>
+        \\  tail --id <session-id> [--lines <n>] [--json]
+        \\  screen --id <session-id> [--json]
+        \\  kill --id <session-id>
+        \\  cleanup
         \\
         \\Live commands:
         \\  status [--json]
@@ -131,6 +155,7 @@ fn printCapabilities(allocator: std.mem.Allocator, out: output.Output, json: boo
         .protocol_version = 1,
         .cli = .{
             .state = spec.state_commands[0..],
+            .session = spec.session_commands[0..],
             .live = spec.live_capabilities[0..],
             .completion = spec.shells[0..],
             .encodings = spec.encodings[0..],
@@ -150,6 +175,7 @@ fn printCapabilities(allocator: std.mem.Allocator, out: output.Output, json: boo
         \\verde CLI capabilities
         \\  protocol: 1
         \\  state: path, projects, panes, threads, transcript
+        \\  session: list, inspect, new, attach, write, tail, screen, kill, cleanup
         \\  live: status, projects, panes, pane control, chat control, terminal/process control
         \\  completion: bash, zsh, fish
         \\  encodings: json, jsonl
@@ -238,6 +264,206 @@ fn handleState(allocator: std.mem.Allocator, out: output.Output, argv: []const [
         try out.stderr("unknown state command: {s}\n", .{command});
         std.process.exit(2);
     }
+}
+
+const PersistedSessionRef = struct {
+    session_id: []const u8,
+    project_index: usize,
+    project_id: []const u8,
+    project_path: []const u8,
+    dock_id: u32,
+    pane_id: u32,
+    label: []const u8 = "",
+    revive_policy: []const u8 = "attach_or_create",
+    daemon_status: []const u8 = "metadata_only",
+};
+
+fn handleSession(allocator: std.mem.Allocator, out: output.Output, io: std.Io, exe_path: []const u8, argv: []const []const u8) !void {
+    const command = args.positional(argv, 0) orelse {
+        try out.stderr("missing session command\n", .{});
+        std.process.exit(2);
+    };
+    const json = args.hasFlag(argv, "--json");
+
+    if (std.mem.eql(u8, command, "list")) {
+        if (sendSessionRequestAlloc(allocator, io, "session.list", .{}, 1)) |response| {
+            defer allocator.free(response);
+            try out.stdout("{s}\n", .{response});
+            return;
+        } else |_| {}
+    }
+
+    if (std.mem.eql(u8, command, "inspect")) {
+        const wanted_id = args.optionValue(argv, "--id") orelse {
+            try out.stderr("session inspect requires --id\n", .{});
+            std.process.exit(2);
+        };
+        if (sendSessionRequestAlloc(allocator, io, "session.inspect", .{ .id = wanted_id }, 1)) |response| {
+            defer allocator.free(response);
+            try out.stdout("{s}\n", .{response});
+            return;
+        } else |_| {}
+    }
+
+    if (std.mem.eql(u8, command, "list") or std.mem.eql(u8, command, "inspect")) {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const arena_allocator = arena.allocator();
+
+        const pref_path = try prefPath(allocator);
+        defer allocator.free(pref_path);
+        var client = try db_client.Client.init(allocator, pref_path);
+        defer client.deinit();
+        var loaded = try client.load(allocator) orelse {
+            if (json) {
+                try out.jsonValue(allocator, .{ .daemon_running = false, .sessions = &.{} });
+            } else {
+                try out.stdout("No persisted Verde state found at {s}\n", .{client.path});
+            }
+            return;
+        };
+        defer loaded.deinit();
+
+        const sessions = try collectPersistedSessionRefs(arena_allocator, loaded.value);
+        if (std.mem.eql(u8, command, "list")) {
+            if (json) {
+                try out.jsonValue(allocator, .{
+                    .daemon_running = false,
+                    .socket_name = sessionizer.SOCKET_NAME,
+                    .sessions = sessions,
+                });
+                return;
+            }
+            try out.stdout("SESSION_ID  PROJECT  DOCK  PANE  STATUS  LABEL\n", .{});
+            for (sessions) |session| {
+                try out.stdout("{s}  {s}  {d}  {d}  {s}  {s}\n", .{
+                    session.session_id,
+                    session.project_id,
+                    session.dock_id,
+                    session.pane_id,
+                    session.daemon_status,
+                    session.label,
+                });
+            }
+            return;
+        }
+
+        const wanted_id = args.optionValue(argv, "--id") orelse {
+            try out.stderr("session inspect requires --id\n", .{});
+            std.process.exit(2);
+        };
+        for (sessions) |session| {
+            if (!std.mem.eql(u8, session.session_id, wanted_id)) continue;
+            if (json) {
+                try out.jsonValue(allocator, .{
+                    .daemon_running = false,
+                    .session = session,
+                });
+            } else {
+                try out.stdout(
+                    \\Session: {s}
+                    \\Project: {s}
+                    \\Path: {s}
+                    \\Dock: {d}
+                    \\Pane: {d}
+                    \\Status: {s}
+                    \\Label: {s}
+                    \\Revive policy: {s}
+                    \\
+                , .{
+                    session.session_id,
+                    session.project_id,
+                    session.project_path,
+                    session.dock_id,
+                    session.pane_id,
+                    session.daemon_status,
+                    session.label,
+                    session.revive_policy,
+                });
+            }
+            return;
+        }
+        try out.stderr("session not found: {s}\n", .{wanted_id});
+        std.process.exit(4);
+    }
+
+    if (std.mem.eql(u8, command, "new")) {
+        try ensureSessionDaemon(allocator, io, exe_path);
+        const session_id = try sessionIdForNewCommand(allocator, argv);
+        defer allocator.free(session_id);
+        const cwd = args.optionValue(argv, "--cwd") orelse args.optionValue(argv, "--project") orelse ".";
+        const command_argv = commandAfterDoubleDash(argv);
+        const response = try sendSessionRequestAlloc(allocator, io, "session.create", .{
+            .id = session_id,
+            .project_id = args.optionValue(argv, "--project") orelse "",
+            .project_path = cwd,
+            .cwd = cwd,
+            .label = args.optionValue(argv, "--name") orelse "",
+            .command = command_argv,
+            .cols = parseOptionalU32(args.optionValue(argv, "--cols")) orelse sessionizer.DEFAULT_COLS,
+            .rows = parseOptionalU32(args.optionValue(argv, "--rows")) orelse sessionizer.DEFAULT_ROWS,
+        }, 1);
+        defer allocator.free(response);
+        try out.stdout("{s}\n", .{response});
+        return;
+    }
+
+    if (std.mem.eql(u8, command, "attach")) {
+        try handleSessionAttach(allocator, out, io, exe_path, argv);
+        return;
+    }
+
+    if (std.mem.eql(u8, command, "write")) {
+        try ensureSessionDaemon(allocator, io, exe_path);
+        const wanted_id = args.optionValue(argv, "--id") orelse {
+            try out.stderr("session write requires --id\n", .{});
+            std.process.exit(2);
+        };
+        const text = args.optionValue(argv, "--text") orelse trailingFreeArg(argv, 1) orelse "";
+        const response = try sendSessionRequestAlloc(allocator, io, "session.write", .{ .id = wanted_id, .text = text }, 1);
+        defer allocator.free(response);
+        try out.stdout("{s}\n", .{response});
+        return;
+    }
+
+    if (std.mem.eql(u8, command, "tail") or std.mem.eql(u8, command, "screen")) {
+        try ensureSessionDaemon(allocator, io, exe_path);
+        const wanted_id = args.optionValue(argv, "--id") orelse {
+            try out.stderr("session {s} requires --id\n", .{command});
+            std.process.exit(2);
+        };
+        const method = if (std.mem.eql(u8, command, "screen")) "session.screen" else "session.tail";
+        const response = try sendSessionRequestAlloc(allocator, io, method, .{
+            .id = wanted_id,
+            .lines = parseOptionalU32(args.optionValue(argv, "--lines")),
+        }, 1);
+        defer allocator.free(response);
+        try out.stdout("{s}\n", .{response});
+        return;
+    }
+
+    if (std.mem.eql(u8, command, "kill")) {
+        try ensureSessionDaemon(allocator, io, exe_path);
+        const wanted_id = args.optionValue(argv, "--id") orelse {
+            try out.stderr("session kill requires --id\n", .{});
+            std.process.exit(2);
+        };
+        const response = try sendSessionRequestAlloc(allocator, io, "session.kill", .{ .id = wanted_id }, 1);
+        defer allocator.free(response);
+        try out.stdout("{s}\n", .{response});
+        return;
+    }
+
+    if (std.mem.eql(u8, command, "cleanup")) {
+        try ensureSessionDaemon(allocator, io, exe_path);
+        const response = try sendSessionRequestAlloc(allocator, io, "session.cleanup", .{}, 1);
+        defer allocator.free(response);
+        try out.stdout("{s}\n", .{response});
+        return;
+    }
+
+    try out.stderr("unknown session command: {s}\n", .{command});
+    std.process.exit(2);
 }
 
 fn handleLive(allocator: std.mem.Allocator, out: output.Output, io: std.Io, argv: []const []const u8) !void {
@@ -666,6 +892,256 @@ fn sendLiveRequestAlloc(allocator: std.mem.Allocator, _: std.Io, method: []const
     return try allocator.dupe(u8, response);
 }
 
+fn sendSessionRequestAlloc(allocator: std.mem.Allocator, _: std.Io, method: []const u8, params: anytype, request_id: u64) ![]u8 {
+    const pref_path = try prefPath(allocator);
+    defer allocator.free(pref_path);
+    return try sessionizer.requestAlloc(allocator, pref_path, method, params, request_id);
+}
+
+const SessionReadResult = struct {
+    text: []u8,
+    running: bool,
+    next_offset: usize,
+
+    fn deinit(self: *SessionReadResult, allocator: std.mem.Allocator) void {
+        allocator.free(self.text);
+        self.* = undefined;
+    }
+};
+
+fn handleSessionAttach(
+    allocator: std.mem.Allocator,
+    out: output.Output,
+    io: std.Io,
+    exe_path: []const u8,
+    argv: []const []const u8,
+) !void {
+    // First pass attach keeps the protocol JSON-line based: stdin is proxied
+    // through session.write and stdout is replayed from offset-aware tail calls.
+    try ensureSessionDaemon(allocator, io, exe_path);
+    const session_id = try resolveAttachSessionId(allocator, out, argv);
+    defer allocator.free(session_id);
+
+    const cols = parseOptionalU32(args.optionValue(argv, "--cols")) orelse sessionizer.DEFAULT_COLS;
+    const rows = parseOptionalU32(args.optionValue(argv, "--rows")) orelse sessionizer.DEFAULT_ROWS;
+    const resize_response = try sendSessionRequestAlloc(allocator, io, "session.resize", .{
+        .id = session_id,
+        .cols = cols,
+        .rows = rows,
+    }, 1);
+    allocator.free(resize_response);
+
+    const terminal_mode = enterRawMode() catch null;
+    defer if (terminal_mode) |mode| restoreTerminalMode(mode);
+
+    const stdin_nonblock: ?c_int = setFdNonBlocking(std.posix.STDIN_FILENO) catch null;
+    defer if (stdin_nonblock) |flags| restoreFdFlags(std.posix.STDIN_FILENO, flags);
+
+    var next_offset: usize = 0;
+    var stdin_eof = false;
+    var detach_requested = false;
+    while (true) {
+        try drainAttachInput(allocator, io, session_id, &stdin_eof, &detach_requested);
+        if (detach_requested) break;
+
+        var read_result = try readSessionOutput(allocator, io, session_id, next_offset);
+        defer read_result.deinit(allocator);
+        if (read_result.text.len > 0) {
+            try writeStdout(read_result.text);
+            next_offset = read_result.next_offset;
+        } else {
+            next_offset = read_result.next_offset;
+        }
+
+        if (!read_result.running and stdin_eof) break;
+        if (!read_result.running and read_result.text.len == 0) break;
+        try std.Io.sleep(io, .fromMilliseconds(20), .awake);
+    }
+}
+
+fn resolveAttachSessionId(allocator: std.mem.Allocator, out: output.Output, argv: []const []const u8) ![]u8 {
+    if (args.optionValue(argv, "--id")) |id| return allocator.dupe(u8, id);
+
+    const pane_value = args.optionValue(argv, "--pane") orelse {
+        try out.stderr("session attach requires --id or --project and --pane\n", .{});
+        std.process.exit(2);
+    };
+    const pane_id = std.fmt.parseInt(u32, pane_value, 10) catch {
+        try out.stderr("invalid --pane value: {s}\n", .{pane_value});
+        std.process.exit(2);
+    };
+    const pref_path = try prefPath(allocator);
+    defer allocator.free(pref_path);
+    var client = try db_client.Client.init(allocator, pref_path);
+    defer client.deinit();
+    var loaded = try client.load(allocator) orelse {
+        try out.stderr("no persisted Verde state found at {s}\n", .{client.path});
+        std.process.exit(4);
+    };
+    defer loaded.deinit();
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const sessions = try collectPersistedSessionRefs(arena.allocator(), loaded.value);
+    const project_index = try resolvePersistedProject(out, loaded.value, args.optionValue(argv, "--project") orelse "current");
+    for (sessions) |session| {
+        if (session.project_index == project_index and session.pane_id == pane_id) return allocator.dupe(u8, session.session_id);
+    }
+    try out.stderr("session not found for project {d} pane {d}\n", .{ project_index, pane_id });
+    std.process.exit(4);
+}
+
+fn drainAttachInput(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    session_id: []const u8,
+    stdin_eof: *bool,
+    detach_requested: *bool,
+) !void {
+    if (stdin_eof.*) return;
+    var poll_fds = [_]std.posix.pollfd{.{
+        .fd = std.posix.STDIN_FILENO,
+        .events = std.posix.POLL.IN | std.posix.POLL.HUP | std.posix.POLL.ERR,
+        .revents = 0,
+    }};
+    _ = std.posix.poll(&poll_fds, 0) catch return;
+    if (poll_fds[0].revents & std.posix.POLL.IN == 0) {
+        if (poll_fds[0].revents & (std.posix.POLL.HUP | std.posix.POLL.ERR) != 0) stdin_eof.* = true;
+        return;
+    }
+
+    var buffer: [4096]u8 = undefined;
+    while (true) {
+        const read_raw = std.c.read(std.posix.STDIN_FILENO, &buffer, buffer.len);
+        if (read_raw > 0) {
+            const input = buffer[0..@intCast(read_raw)];
+            if (std.mem.indexOfScalar(u8, input, 0x1d) != null) {
+                detach_requested.* = true;
+                stdin_eof.* = true;
+                return;
+            }
+            const response = try sendSessionRequestAlloc(allocator, io, "session.write", .{ .id = session_id, .text = input }, 1);
+            allocator.free(response);
+            continue;
+        }
+        if (read_raw == 0) {
+            stdin_eof.* = true;
+            return;
+        }
+        const err = std.c._errno().*;
+        if (err == @intFromEnum(std.c.E.AGAIN)) return;
+        if (err == @intFromEnum(std.c.E.INTR)) continue;
+        stdin_eof.* = true;
+        return;
+    }
+}
+
+fn readSessionOutput(allocator: std.mem.Allocator, io: std.Io, session_id: []const u8, offset: usize) !SessionReadResult {
+    const response = try sendSessionRequestAlloc(allocator, io, "session.tail", .{ .id = session_id, .offset = offset }, 1);
+    defer allocator.free(response);
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, response, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidSessionResponse;
+    if (parsed.value.object.get("error")) |_| return error.SessionAttachFailed;
+    const result = parsed.value.object.get("result") orelse return error.InvalidSessionResponse;
+    if (result != .object) return error.InvalidSessionResponse;
+    const text = jsonString(result.object.get("text") orelse .null) orelse "";
+    return .{
+        .text = try allocator.dupe(u8, text),
+        .running = jsonBool(result.object.get("running") orelse .null) orelse false,
+        .next_offset = jsonUsize(result.object.get("next_offset") orelse .null) orelse offset,
+    };
+}
+
+const TerminalMode = struct {
+    original: std.posix.termios,
+};
+
+fn enterRawMode() !TerminalMode {
+    const original = try std.posix.tcgetattr(std.posix.STDIN_FILENO);
+    var raw = original;
+    raw.iflag.BRKINT = false;
+    raw.iflag.ICRNL = false;
+    raw.iflag.INPCK = false;
+    raw.iflag.ISTRIP = false;
+    raw.iflag.IXON = false;
+    raw.oflag.OPOST = false;
+    raw.cflag.CSIZE = .CS8;
+    raw.cflag.PARENB = false;
+    raw.lflag.ECHO = false;
+    raw.lflag.ICANON = false;
+    raw.lflag.IEXTEN = false;
+    raw.lflag.ISIG = false;
+    raw.cc[@intFromEnum(std.posix.V.MIN)] = 1;
+    raw.cc[@intFromEnum(std.posix.V.TIME)] = 0;
+    try std.posix.tcsetattr(std.posix.STDIN_FILENO, .FLUSH, raw);
+    return .{ .original = original };
+}
+
+fn restoreTerminalMode(mode: TerminalMode) void {
+    std.posix.tcsetattr(std.posix.STDIN_FILENO, .FLUSH, mode.original) catch {};
+}
+
+fn setFdNonBlocking(fd: std.posix.fd_t) !c_int {
+    const current = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
+    if (current < 0) return error.FcntlFailed;
+    const nonblock = @as(usize, 1) << @bitOffsetOf(std.posix.O, "NONBLOCK");
+    if (std.c.fcntl(fd, std.c.F.SETFL, current | @as(c_int, @intCast(nonblock))) < 0) return error.FcntlFailed;
+    return current;
+}
+
+fn restoreFdFlags(fd: std.posix.fd_t, flags: c_int) void {
+    _ = std.c.fcntl(fd, std.c.F.SETFL, flags);
+}
+
+fn writeStdout(bytes: []const u8) !void {
+    var remaining = bytes;
+    while (remaining.len > 0) {
+        const written_raw = std.c.write(std.posix.STDOUT_FILENO, remaining.ptr, remaining.len);
+        if (written_raw < 0) {
+            if (std.c._errno().* == @intFromEnum(std.c.E.INTR)) continue;
+            return error.StdoutWriteFailed;
+        }
+        const written: usize = @intCast(written_raw);
+        if (written == 0) return error.StdoutWriteFailed;
+        remaining = remaining[written..];
+    }
+}
+
+fn ensureSessionDaemon(allocator: std.mem.Allocator, io: std.Io, exe_path: []const u8) !void {
+    _ = io;
+    const pref_path = try prefPath(allocator);
+    defer allocator.free(pref_path);
+    try sessionizer.ensureDaemon(allocator, pref_path, exe_path);
+}
+
+fn sessionIdForNewCommand(allocator: std.mem.Allocator, argv: []const []const u8) ![]u8 {
+    if (args.optionValue(argv, "--id")) |id| return allocator.dupe(u8, id);
+    if (args.optionValue(argv, "--name")) |name| {
+        var safe_name: std.ArrayList(u8) = .empty;
+        defer safe_name.deinit(allocator);
+        for (name) |byte| {
+            const safe = (byte >= 'a' and byte <= 'z') or
+                (byte >= 'A' and byte <= 'Z') or
+                (byte >= '0' and byte <= '9') or
+                byte == '-' or byte == '_' or byte == '.';
+            try safe_name.append(allocator, if (safe) byte else '_');
+        }
+        return try std.fmt.allocPrint(allocator, "verde:cli:{s}", .{if (safe_name.items.len > 0) safe_name.items else "session"});
+    }
+    return try std.fmt.allocPrint(allocator, "verde:cli:{d}", .{std.c.getpid()});
+}
+
+fn commandAfterDoubleDash(argv: []const []const u8) []const []const u8 {
+    for (argv, 0..) |arg, index| {
+        if (std.mem.eql(u8, arg, "--")) {
+            if (index + 1 >= argv.len) return &.{};
+            return argv[index + 1 ..];
+        }
+    }
+    return &.{};
+}
+
 fn printLiveResponse(out: output.Output, response: []const u8) !void {
     try out.stdout("{s}\n", .{response});
 }
@@ -895,6 +1371,30 @@ fn jsonString(value: std.json.Value) ?[]const u8 {
     };
 }
 
+fn jsonBool(value: std.json.Value) ?bool {
+    return switch (value) {
+        .bool => |bool_value| bool_value,
+        else => null,
+    };
+}
+
+fn jsonInt(value: std.json.Value) ?i64 {
+    return switch (value) {
+        .integer => |int| int,
+        .float => |float| @intFromFloat(float),
+        .number_string => |text| std.fmt.parseInt(i64, text, 10) catch null,
+        else => null,
+    };
+}
+
+fn jsonUsize(value: std.json.Value) ?usize {
+    return switch (value) {
+        .integer => |int| if (int >= 0) @intCast(int) else null,
+        .number_string => |text| std.fmt.parseInt(usize, text, 10) catch null,
+        else => null,
+    };
+}
+
 fn liveUnavailable(out: output.Output, err: anyerror) noreturn {
     out.stderr("verde live server is not running: {s}\n", .{@errorName(err)}) catch {};
     std.process.exit(3);
@@ -981,6 +1481,7 @@ fn trailingFreeArg(argv: []const []const u8, positional_commands: usize) ?[]cons
 
 fn optionConsumesValue(name: []const u8) bool {
     return std.mem.eql(u8, name, "--project") or
+        std.mem.eql(u8, name, "--id") or
         std.mem.eql(u8, name, "--pane") or
         std.mem.eql(u8, name, "--kind") or
         std.mem.eql(u8, name, "--axis") or
@@ -994,6 +1495,86 @@ fn optionConsumesValue(name: []const u8) bool {
         std.mem.eql(u8, name, "--name") or
         std.mem.eql(u8, name, "--lines") or
         std.mem.eql(u8, name, "--thread");
+}
+
+fn collectPersistedSessionRefs(allocator: std.mem.Allocator, state: db_types.PersistedState) ![]const PersistedSessionRef {
+    var sessions: std.ArrayList(PersistedSessionRef) = .empty;
+    defer sessions.deinit(allocator);
+
+    for (state.projects, 0..) |project, project_index| {
+        if (project.terminal_layout_json) |layout_json| {
+            try collectLayoutSessionRefs(allocator, &sessions, project, project_index, 0, layout_json);
+        }
+        if (project.terminal_docks_json) |docks_json| {
+            try collectTerminalDockSessionRefs(allocator, &sessions, project, project_index, docks_json);
+        }
+    }
+
+    return try sessions.toOwnedSlice(allocator);
+}
+
+fn collectTerminalDockSessionRefs(
+    allocator: std.mem.Allocator,
+    sessions: *std.ArrayList(PersistedSessionRef),
+    project: db_types.PersistedProject,
+    project_index: usize,
+    docks_json: []const u8,
+) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, docks_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .array) return;
+    for (parsed.value.array.items) |entry| {
+        if (entry != .object) continue;
+        const dock_id: u32 = @intCast(jsonInt(entry.object.get("id") orelse .null) orelse continue);
+        const layout_json = jsonString(entry.object.get("layout") orelse .null) orelse continue;
+        try collectLayoutSessionRefs(allocator, sessions, project, project_index, dock_id, layout_json);
+    }
+}
+
+fn collectLayoutSessionRefs(
+    allocator: std.mem.Allocator,
+    sessions: *std.ArrayList(PersistedSessionRef),
+    project: db_types.PersistedProject,
+    project_index: usize,
+    dock_id: u32,
+    layout_json: []const u8,
+) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, layout_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return;
+    const tabs = parsed.value.object.get("tabs") orelse return;
+    if (tabs != .array) return;
+
+    const project_id = project.id orelse project.path;
+    for (tabs.array.items) |tab| {
+        if (tab != .object) continue;
+        const tab_title = jsonString(tab.object.get("title") orelse .null) orelse "";
+        const nodes = tab.object.get("nodes") orelse continue;
+        if (nodes != .array) continue;
+        for (nodes.array.items) |node| {
+            if (node != .object) continue;
+            const kind = jsonString(node.object.get("kind") orelse .null) orelse continue;
+            if (!std.mem.eql(u8, kind, "leaf")) continue;
+            const pane_id: u32 = @intCast(jsonInt(node.object.get("pane_id") orelse .null) orelse continue);
+            const raw_session_id = jsonString(node.object.get("session_id") orelse .null);
+            const session_id = if (raw_session_id) |id|
+                try allocator.dupe(u8, id)
+            else
+                try sessionizer.stableSessionId(allocator, project_id, dock_id, pane_id);
+            const label = jsonString(node.object.get("launch_label") orelse .null) orelse tab_title;
+            const revive_policy = jsonString(node.object.get("revive_policy") orelse .null) orelse "attach_or_create";
+            try sessions.append(allocator, .{
+                .session_id = session_id,
+                .project_index = project_index,
+                .project_id = try allocator.dupe(u8, project_id),
+                .project_path = try allocator.dupe(u8, project.path),
+                .dock_id = dock_id,
+                .pane_id = pane_id,
+                .label = try allocator.dupe(u8, label),
+                .revive_policy = try allocator.dupe(u8, revive_policy),
+            });
+        }
+    }
 }
 
 fn writeStateProjects(allocator: std.mem.Allocator, out: output.Output, state: db_types.PersistedState, json: bool) !void {

--- a/packages/desktop/src/cli_completion.zig
+++ b/packages/desktop/src/cli_completion.zig
@@ -48,6 +48,8 @@ fn writeBash(w: *std.Io.Writer) !void {
     try writeWords(w, &spec.shells);
     try w.writeAll("\"\n  local state=\"");
     try writeWords(w, &spec.state_commands);
+    try w.writeAll("\"\n  local session=\"");
+    try writeWords(w, &spec.session_commands);
     try w.writeAll("\"\n  local live=\"");
     try writeWords(w, &spec.live_commands);
     try w.writeAll("\"\n  local pane=\"");
@@ -114,7 +116,7 @@ fn writeBash(w: *std.Io.Writer) !void {
         \\    --axis) COMPREPLY=( $(compgen -W "$axis_values" -- "$cur") ); return 0 ;;
         \\    --decision) COMPREPLY=( $(compgen -W "$decision_values" -- "$cur") ); return 0 ;;
         \\    --mode) COMPREPLY=( $(compgen -W "$inspector_mode_values" -- "$cur") ); return 0 ;;
-        \\    --project|--thread|--pane|--first|--second|--ratio|--text|--prompt|--call|--name|--lines) return 0 ;;
+        \\    --project|--thread|--id|--pane|--first|--second|--ratio|--text|--prompt|--call|--name|--lines) return 0 ;;
         \\  esac
         \\
         \\  if [[ "$cur" == -* ]]; then
@@ -129,6 +131,17 @@ fn writeBash(w: *std.Io.Writer) !void {
         \\        case "$sub" in
         \\          panes|threads) COMPREPLY=( $(compgen -W "$project_json_flags" -- "$cur") ) ;;
         \\          transcript) COMPREPLY=( $(compgen -W "--project --thread --json" -- "$cur") ) ;;
+        \\          *) COMPREPLY=( $(compgen -W "$json_flags" -- "$cur") ) ;;
+        \\        esac
+        \\        ;;
+        \\      session)
+        \\        case "$sub" in
+        \\          inspect|screen) COMPREPLY=( $(compgen -W "--id --json" -- "$cur") ) ;;
+        \\          new) COMPREPLY=( $(compgen -W "--project --name --json" -- "$cur") ) ;;
+        \\          attach) COMPREPLY=( $(compgen -W "--id --project --pane" -- "$cur") ) ;;
+        \\          write) COMPREPLY=( $(compgen -W "--id --text --json" -- "$cur") ) ;;
+        \\          tail) COMPREPLY=( $(compgen -W "--id --lines --json" -- "$cur") ) ;;
+        \\          kill) COMPREPLY=( $(compgen -W "--id --json" -- "$cur") ) ;;
         \\          *) COMPREPLY=( $(compgen -W "$json_flags" -- "$cur") ) ;;
         \\        esac
         \\        ;;
@@ -182,6 +195,7 @@ fn writeBash(w: *std.Io.Writer) !void {
         \\    1:*) COMPREPLY=( $(compgen -W "$top --help -h" -- "$cur") ) ;;
         \\    2:completion:*) COMPREPLY=( $(compgen -W "$shells" -- "$cur") ) ;;
         \\    2:state:*) COMPREPLY=( $(compgen -W "$state" -- "$cur") ) ;;
+        \\    2:session:*) COMPREPLY=( $(compgen -W "$session" -- "$cur") ) ;;
         \\    2:live:*) COMPREPLY=( $(compgen -W "$live" -- "$cur") ) ;;
         \\    3:live:pane:*) COMPREPLY=( $(compgen -W "$pane" -- "$cur") ) ;;
         \\    3:live:chat:*) COMPREPLY=( $(compgen -W "$chat" -- "$cur") ) ;;
@@ -217,6 +231,8 @@ fn writeZsh(w: *std.Io.Writer) !void {
     try writeWords(w, &spec.shells);
     try w.writeAll("\"\n  local state=\"");
     try writeWords(w, &spec.state_commands);
+    try w.writeAll("\"\n  local session=\"");
+    try writeWords(w, &spec.session_commands);
     try w.writeAll("\"\n  local live=\"");
     try writeWords(w, &spec.live_commands);
     try w.writeAll("\"\n  local pane=\"");
@@ -281,7 +297,7 @@ fn writeZsh(w: *std.Io.Writer) !void {
         \\    --axis) compadd -- ${(s: :)axis_values}; return ;;
         \\    --decision) compadd -- ${(s: :)decision_values}; return ;;
         \\    --mode) compadd -- ${(s: :)inspector_mode_values}; return ;;
-        \\    --project|--thread|--pane|--first|--second|--ratio|--text|--prompt|--call|--name|--lines) return ;;
+        \\    --project|--thread|--id|--pane|--first|--second|--ratio|--text|--prompt|--call|--name|--lines) return ;;
         \\  esac
         \\
         \\  if [[ "$cur" == -* ]]; then
@@ -296,6 +312,17 @@ fn writeZsh(w: *std.Io.Writer) !void {
         \\        case "$sub" in
         \\          panes|threads) compadd -- ${(s: :)project_json_flags} ;;
         \\          transcript) compadd -- --project --thread --json ;;
+        \\          *) compadd -- ${(s: :)json_flags} ;;
+        \\        esac
+        \\        ;;
+        \\      session)
+        \\        case "$sub" in
+        \\          inspect|screen) compadd -- --id --json ;;
+        \\          new) compadd -- --project --name --json ;;
+        \\          attach) compadd -- --id --project --pane ;;
+        \\          write) compadd -- --id --text --json ;;
+        \\          tail) compadd -- --id --lines --json ;;
+        \\          kill) compadd -- --id --json ;;
         \\          *) compadd -- ${(s: :)json_flags} ;;
         \\        esac
         \\        ;;
@@ -349,6 +376,7 @@ fn writeZsh(w: *std.Io.Writer) !void {
         \\    2:*) compadd -- ${(s: :)top} --help -h ;;
         \\    3:completion:*) compadd -- ${(s: :)shells} ;;
         \\    3:state:*) compadd -- ${(s: :)state} ;;
+        \\    3:session:*) compadd -- ${(s: :)session} ;;
         \\    3:live:*) compadd -- ${(s: :)live} ;;
         \\    4:live:pane:*) compadd -- ${(s: :)pane} ;;
         \\    4:live:chat:*) compadd -- ${(s: :)chat} ;;
@@ -392,6 +420,8 @@ fn writeFish(w: *std.Io.Writer) !void {
     try writeWords(w, &spec.shells);
     try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after state' -a '");
     try writeWords(w, &spec.state_commands);
+    try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after session' -a '");
+    try writeWords(w, &spec.session_commands);
     try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after live' -a '");
     try writeWords(w, &spec.live_commands);
     try w.writeAll("'\ncomplete -c verde -n '__verde_complete_after live pane' -a '");
@@ -410,6 +440,7 @@ fn writeFish(w: *std.Io.Writer) !void {
     try writeWords(w, &spec.stack_commands);
     try w.writeAll("'\n\ncomplete -c verde -l json -d 'Print JSON output'\n");
     try w.writeAll(
+        \\complete -c verde -l id -r -d 'Persistent session id'
         \\complete -c verde -l project -r -d 'Project id, index, path, or current'
         \\complete -c verde -l thread -r -d 'Thread index or provider id'
         \\complete -c verde -l pane -r -d 'Workspace pane id'

--- a/packages/desktop/src/cli_spec.zig
+++ b/packages/desktop/src/cli_spec.zig
@@ -9,6 +9,7 @@ pub const top_level_commands = [_][]const u8{
     "version",
     "capabilities",
     "state",
+    "session",
     "live",
     "mcp",
     "completion",
@@ -20,6 +21,18 @@ pub const state_commands = [_][]const u8{
     "panes",
     "threads",
     "transcript",
+};
+
+pub const session_commands = [_][]const u8{
+    "list",
+    "inspect",
+    "new",
+    "attach",
+    "write",
+    "tail",
+    "screen",
+    "kill",
+    "cleanup",
 };
 
 pub const live_commands = [_][]const u8{
@@ -183,6 +196,7 @@ pub const all_flags = [_][]const u8{
     "--help",
     "-h",
     "--json",
+    "--id",
     "--project",
     "--thread",
     "--pane",
@@ -204,6 +218,11 @@ pub const all_flags = [_][]const u8{
 
 pub const json_flags = [_][]const u8{"--json"};
 pub const project_json_flags = [_][]const u8{ "--project", "--json" };
+pub const session_id_json_flags = [_][]const u8{ "--id", "--json" };
+pub const session_new_flags = [_][]const u8{ "--project", "--name", "--json" };
+pub const session_attach_flags = [_][]const u8{ "--id", "--project", "--pane" };
+pub const session_write_flags = [_][]const u8{ "--id", "--text", "--json" };
+pub const session_tail_flags = [_][]const u8{ "--id", "--lines", "--json" };
 pub const pane_flags = [_][]const u8{ "--project", "--pane", "--focused", "--json" };
 pub const pane_split_flags = [_][]const u8{ "--project", "--pane", "--focused", "--kind", "--axis", "--json" };
 pub const pane_resize_flags = [_][]const u8{ "--project", "--pane", "--focused", "--first", "--second", "--axis", "--ratio", "--json" };

--- a/packages/desktop/src/db/client.zig
+++ b/packages/desktop/src/db/client.zig
@@ -151,7 +151,7 @@ pub const Client = struct {
         defer threads.deinit(allocator);
 
         var thread_rows = try self.conn.rows(
-            "select id, title, archived, committed, last_activity_at, provider_thread_id, model_ref, reasoning_effort, reasoning_variant, fast_mode, access_mode, provider, harness, draft, draft_image_path, draft_image_mime, draft_image_byte_size " ++
+            "select id, title, archived, committed, last_activity_at, provider_thread_id, model_ref, reasoning_effort, reasoning_variant, fast_mode, access_mode, provider, harness, tui_dock_id, draft, draft_image_path, draft_image_mime, draft_image_byte_size " ++
                 "from threads where project_id = ?1 order by sort_index",
             .{project_id},
         );
@@ -172,12 +172,13 @@ pub const Client = struct {
                 .access_mode = decodeOptionalEnum(db_types.AccessMode, thread_row.nullableInt(10)),
                 .provider = decodeEnumOr(db_types.Provider, thread_row.int(11), .opencode),
                 .harness = decodeEnumOr(db_types.Harness, thread_row.int(12), .local_cli),
-                .draft = try allocator.dupe(u8, thread_row.text(13)),
+                .tui_dock_id = if (thread_row.nullableInt(13)) |value| @intCast(value) else null,
+                .draft = try allocator.dupe(u8, thread_row.text(14)),
                 .draft_image = try loadOptionalImage(
                     allocator,
-                    thread_row.nullableText(14),
                     thread_row.nullableText(15),
-                    thread_row.nullableInt(16),
+                    thread_row.nullableText(16),
+                    thread_row.nullableInt(17),
                 ),
                 .messages = try self.loadMessages(allocator, thread_id),
             });
@@ -252,8 +253,8 @@ pub const Client = struct {
         for (threads, 0..) |thread, thread_index| {
             const draft_image = thread.draft_image;
             try self.conn.exec(
-                "insert into threads (project_id, sort_index, title, archived, committed, last_activity_at, provider_thread_id, model_ref, reasoning_effort, reasoning_variant, fast_mode, access_mode, provider, harness, draft, draft_image_path, draft_image_mime, draft_image_byte_size) " ++
-                    "values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+                "insert into threads (project_id, sort_index, title, archived, committed, last_activity_at, provider_thread_id, model_ref, reasoning_effort, reasoning_variant, fast_mode, access_mode, provider, harness, tui_dock_id, draft, draft_image_path, draft_image_mime, draft_image_byte_size) " ++
+                    "values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
                 .{
                     project_id,
                     @as(i64, @intCast(thread_index)),
@@ -269,6 +270,7 @@ pub const Client = struct {
                     encodeOptionalEnum(thread.access_mode),
                     @as(i64, @intFromEnum(thread.provider)),
                     @as(i64, @intFromEnum(thread.harness)),
+                    if (thread.tui_dock_id) |dock_id| @as(i64, @intCast(dock_id)) else null,
                     thread.draft,
                     if (draft_image) |image| image.path else null,
                     if (draft_image) |image| image.mime else null,

--- a/packages/desktop/src/db/schema.zig
+++ b/packages/desktop/src/db/schema.zig
@@ -43,6 +43,7 @@ pub const INIT_SQL: [:0]const u8 =
     \\    access_mode integer,
     \\    provider integer not null,
     \\    harness integer not null,
+    \\    tui_dock_id integer,
     \\    draft text not null default '',
     \\    draft_image_path text,
     \\    draft_image_mime text,
@@ -74,6 +75,7 @@ pub fn initialize(conn: zqlite.Conn) !void {
     try ensureColumn(conn, "projects", "workspace_layout_json", "alter table projects add column workspace_layout_json text");
     try ensureColumn(conn, "threads", "archived", "alter table threads add column archived integer not null default 0");
     try ensureColumn(conn, "threads", "reasoning_variant", "alter table threads add column reasoning_variant text");
+    try ensureColumn(conn, "threads", "tui_dock_id", "alter table threads add column tui_dock_id integer");
 }
 
 fn ensureColumn(conn: zqlite.Conn, table_name: []const u8, column_name: []const u8, alter_sql: [*:0]const u8) !void {

--- a/packages/desktop/src/state.zig
+++ b/packages/desktop/src/state.zig
@@ -4843,7 +4843,11 @@ pub const AppState = struct {
     fn persistedProjectSnapshot(self: *const AppState, allocator: std.mem.Allocator, project: *const Project) !PersistedProject {
         var threads: std.ArrayList(PersistedThread) = .empty;
         defer threads.deinit(allocator);
-        const terminal_layout_json = try project.terminal_dock.persistedLayoutJson(allocator);
+        const terminal_layout_json = try project.terminal_dock.persistedLayoutJsonWithContext(allocator, .{
+            .project_id = project.id,
+            .project_path = project.path,
+            .dock_id = 0,
+        });
         errdefer if (terminal_layout_json) |value| allocator.free(value);
         const terminal_docks_json = try self.persistedTerminalDocksJson(allocator, project);
         errdefer if (terminal_docks_json) |value| allocator.free(value);
@@ -4883,7 +4887,11 @@ pub const AppState = struct {
         var stringify: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
         try stringify.beginArray();
         for (project.terminal_docks.items) |*entry| {
-            const layout_json = try entry.dock.persistedLayoutJson(allocator);
+            const layout_json = try entry.dock.persistedLayoutJsonWithContext(allocator, .{
+                .project_id = project.id,
+                .project_path = project.path,
+                .dock_id = entry.id,
+            });
             defer if (layout_json) |value| allocator.free(value);
             if (layout_json == null and !entry.dock.hasRunningSession()) continue;
             try stringify.beginObject();
@@ -6093,7 +6101,7 @@ pub const AppState = struct {
         var dock = self.currentProjectTerminalMutable();
         const project_path = self.currentProject().path;
         if (!dock.hasRunningSession()) {
-            dock.ensureSession(self.allocator, project_path) catch |err| {
+            dock.ensureSessionPersistent(self.allocator, project_path, self.storage.pref_path, 0) catch |err| {
                 log.err("failed to start terminal dock: {s}", .{@errorName(err)});
                 self.setSidebarNotice("Failed to start terminal.");
                 return;
@@ -6137,7 +6145,7 @@ pub const AppState = struct {
         var dock = self.currentProjectTerminalMutable();
         if (!dock.visible) {
             const project_path = self.currentProject().path;
-            dock.ensureSession(self.allocator, project_path) catch |err| {
+            dock.ensureSessionPersistent(self.allocator, project_path, self.storage.pref_path, 0) catch |err| {
                 log.err("failed to start terminal dock: {s}", .{@errorName(err)});
                 self.setSidebarNotice("Failed to start terminal.");
                 return;
@@ -6159,7 +6167,7 @@ pub const AppState = struct {
         for (self.projects.items, 0..) |*project, project_index| {
             const base_visible = project.terminal_dock.visible or project.workspace_layout.hasTerminalDockPane(0);
             if (base_visible and !project.terminal_dock.hasRunningSession()) {
-                project.terminal_dock.ensureSession(self.allocator, project.path) catch |err| {
+                project.terminal_dock.ensureSessionPersistent(self.allocator, project.path, self.storage.pref_path, 0) catch |err| {
                     log.err("failed to start visible terminal session: {s}", .{@errorName(err)});
                     if (project_index == self.selected_project_index) self.setSidebarNotice("Terminal session failed.");
                 };
@@ -6180,7 +6188,7 @@ pub const AppState = struct {
             for (project.terminal_docks.items) |*entry| {
                 const dock_visible = entry.dock.visible or project.workspace_layout.hasTerminalDockPane(entry.id);
                 if (dock_visible and !entry.dock.hasRunningSession()) {
-                    entry.dock.ensureSession(self.allocator, project.path) catch |err| {
+                    entry.dock.ensureSessionPersistent(self.allocator, project.path, self.storage.pref_path, entry.id) catch |err| {
                         log.err("failed to start visible terminal dock {d}: {s}", .{ entry.id, @errorName(err) });
                         if (project_index == self.selected_project_index) self.setSidebarNotice("Terminal session failed.");
                     };
@@ -7758,7 +7766,7 @@ pub const AppState = struct {
             else => return false,
         };
         var dock = self.currentProjectTerminalDockMutable(dock_id) orelse return false;
-        try dock.ensureSession(self.allocator, project.path);
+        try dock.ensureSessionPersistent(self.allocator, project.path, self.storage.pref_path, dock_id);
         return try dock.writeInputToActivePane(bytes);
     }
 
@@ -7917,11 +7925,11 @@ pub const AppState = struct {
         defer self.allocator.free(cwd);
         var dock = self.currentProjectTerminalDockMutable(dock_id) orelse return false;
         const command_args = [_][]const u8{ "/bin/sh", "-lc", process.command };
-        try dock.restartWithProfile(self.allocator, cwd, .{
+        try dock.restartWithProfilePersistent(self.allocator, cwd, .{
             .kind = .custom,
             .label = process.name,
             .command = &command_args,
-        });
+        }, self.storage.pref_path, dock_id);
         process.status = .running;
         process.exit_code = null;
         process.signal = null;
@@ -8519,7 +8527,7 @@ pub const AppState = struct {
         };
         thread.tui_dock_id = dock_id;
         var dock = self.currentProjectTerminalDockMutable(dock_id) orelse return;
-        dock.ensureSession(self.allocator, project.path) catch |err| {
+        dock.ensureSessionPersistent(self.allocator, project.path, self.storage.pref_path, dock_id) catch |err| {
             log.err("failed to start TUI terminal dock: {s}", .{@errorName(err)});
             self.setSidebarNotice("Failed to start TUI terminal.");
             return;
@@ -8595,7 +8603,7 @@ pub const AppState = struct {
         };
         var dock = self.currentProjectTerminalDockMutable(dock_id) orelse return false;
         const project_path = self.currentProject().path;
-        dock.ensureSession(self.allocator, project_path) catch |err| {
+        dock.ensureSessionPersistent(self.allocator, project_path, self.storage.pref_path, dock_id) catch |err| {
             log.err("failed to start terminal dock: {s}", .{@errorName(err)});
             self.setSidebarNotice("Failed to start terminal.");
             return false;

--- a/packages/desktop/src/terminal/sessionizer.zig
+++ b/packages/desktop/src/terminal/sessionizer.zig
@@ -14,6 +14,8 @@ pub const PROTOCOL_VERSION: u32 = 1;
 pub const DEFAULT_COLS: u16 = 120;
 pub const DEFAULT_ROWS: u16 = 30;
 const MAX_OUTPUT_RING: usize = 1024 * 1024;
+const ATTACH_STALE_MS: i64 = 60 * std.time.ms_per_s;
+const IDLE_EXIT_MS: i64 = 30 * std.time.ms_per_s;
 const TERMINAL_WINSIZE_IOCTL = switch (builtin.os.tag) {
     .macos => 0x80087467,
     else => std.c.T.IOCSWINSZ,
@@ -235,6 +237,13 @@ pub const CreateOptions = struct {
 };
 
 const PtySession = struct {
+    const AttachClient = struct {
+        attach_id: []u8,
+        label: []u8,
+        created_at_ms: i64,
+        last_seen_at_ms: i64,
+    };
+
     session_id: []u8,
     project_id: []u8,
     project_path: []u8,
@@ -250,6 +259,7 @@ const PtySession = struct {
     exit_status: ?u32 = null,
     created_at_ms: i64,
     last_attached_at_ms: ?i64 = null,
+    attach_clients: std.ArrayList(AttachClient) = .empty,
 
     const SpawnResult = struct {
         master_fd: std.posix.fd_t,
@@ -308,6 +318,11 @@ const PtySession = struct {
         allocator.free(self.cwd);
         allocator.free(self.label);
         allocator.free(self.command_label);
+        for (self.attach_clients.items) |client| {
+            allocator.free(client.attach_id);
+            allocator.free(client.label);
+        }
+        self.attach_clients.deinit(allocator);
         self.output_ring.deinit(allocator);
         allocator.destroy(self);
     }
@@ -342,6 +357,56 @@ const PtySession = struct {
         self.running = false;
         _ = self.captureExitStatus();
         return true;
+    }
+
+    fn attach(self: *PtySession, allocator: std.mem.Allocator, label: []const u8) ![]u8 {
+        const now = nowMs();
+        self.cleanupStaleAttaches(allocator, now);
+        const attach_id = try std.fmt.allocPrint(allocator, "{s}:attach:{d}:{d}", .{ self.session_id, now, self.attach_clients.items.len });
+        errdefer allocator.free(attach_id);
+        try self.attach_clients.append(allocator, .{
+            .attach_id = attach_id,
+            .label = try allocator.dupe(u8, if (label.len > 0) label else "client"),
+            .created_at_ms = now,
+            .last_seen_at_ms = now,
+        });
+        self.last_attached_at_ms = now;
+        return try allocator.dupe(u8, attach_id);
+    }
+
+    fn detach(self: *PtySession, allocator: std.mem.Allocator, attach_id: []const u8) bool {
+        for (self.attach_clients.items, 0..) |client, index| {
+            if (!std.mem.eql(u8, client.attach_id, attach_id)) continue;
+            const removed = self.attach_clients.orderedRemove(index);
+            allocator.free(removed.attach_id);
+            allocator.free(removed.label);
+            return true;
+        }
+        return false;
+    }
+
+    fn touchAttach(self: *PtySession, attach_id: []const u8) bool {
+        const now = nowMs();
+        for (self.attach_clients.items) |*client| {
+            if (!std.mem.eql(u8, client.attach_id, attach_id)) continue;
+            client.last_seen_at_ms = now;
+            return true;
+        }
+        return false;
+    }
+
+    fn cleanupStaleAttaches(self: *PtySession, allocator: std.mem.Allocator, now: i64) void {
+        var index: usize = 0;
+        while (index < self.attach_clients.items.len) {
+            const client = self.attach_clients.items[index];
+            if (now - client.last_seen_at_ms <= ATTACH_STALE_MS) {
+                index += 1;
+                continue;
+            }
+            const removed = self.attach_clients.orderedRemove(index);
+            allocator.free(removed.attach_id);
+            allocator.free(removed.label);
+        }
     }
 
     fn drainOutput(self: *PtySession, allocator: std.mem.Allocator) !void {
@@ -436,6 +501,7 @@ pub const Daemon = struct {
     allocator: std.mem.Allocator,
     sessions: std.ArrayList(*PtySession) = .empty,
     mutex: std.atomic.Mutex = .unlocked,
+    idle_since_ms: ?i64 = null,
 
     pub fn init(allocator: std.mem.Allocator) Daemon {
         return .{ .allocator = allocator };
@@ -447,7 +513,26 @@ pub const Daemon = struct {
     }
 
     fn pollSessions(self: *Daemon) void {
-        for (self.sessions.items) |session| session.poll(self.allocator) catch {};
+        const now = nowMs();
+        for (self.sessions.items) |session| {
+            session.poll(self.allocator) catch {};
+            session.cleanupStaleAttaches(self.allocator, now);
+        }
+    }
+
+    fn shouldExitForIdle(self: *Daemon) bool {
+        for (self.sessions.items) |session| {
+            if (session.running) {
+                self.idle_since_ms = null;
+                return false;
+            }
+        }
+        const now = nowMs();
+        if (self.idle_since_ms == null) {
+            self.idle_since_ms = now;
+            return false;
+        }
+        return now - self.idle_since_ms.? >= IDLE_EXIT_MS;
     }
 
     fn find(self: *Daemon, session_id: []const u8) ?*PtySession {
@@ -475,6 +560,8 @@ pub const Daemon = struct {
         if (std.mem.eql(u8, method, "session.list")) return try self.listResponse(id_value);
         if (std.mem.eql(u8, method, "session.inspect")) return try self.inspectResponse(id_value, params);
         if (std.mem.eql(u8, method, "session.create")) return try self.createResponse(id_value, params);
+        if (std.mem.eql(u8, method, "session.attach")) return try self.attachResponse(id_value, params);
+        if (std.mem.eql(u8, method, "session.detach")) return try self.detachResponse(id_value, params);
         if (std.mem.eql(u8, method, "session.write")) return try self.writeResponse(id_value, params);
         if (std.mem.eql(u8, method, "session.resize")) return try self.resizeResponse(id_value, params);
         if (std.mem.eql(u8, method, "session.tail")) return try self.tailResponse(id_value, params, false);
@@ -490,6 +577,7 @@ pub const Daemon = struct {
             .protocol_version = PROTOCOL_VERSION,
             .pid = std.c.getpid(),
             .session_count = self.sessions.items.len,
+            .idle_exit_ms = IDLE_EXIT_MS,
         });
     }
 
@@ -529,6 +617,21 @@ pub const Daemon = struct {
         try s.write(session.cwd);
         try s.objectField("command");
         try s.write(session.command_label);
+        try s.objectField("attached_clients");
+        try s.beginArray();
+        for (session.attach_clients.items) |client| {
+            try s.beginObject();
+            try s.objectField("attach_id");
+            try s.write(client.attach_id);
+            try s.objectField("label");
+            try s.write(client.label);
+            try s.objectField("created_at_ms");
+            try s.write(client.created_at_ms);
+            try s.objectField("last_seen_at_ms");
+            try s.write(client.last_seen_at_ms);
+            try s.endObject();
+        }
+        try s.endArray();
         try s.endObject();
         try s.endObject();
         return try writer.toOwnedSlice();
@@ -561,9 +664,36 @@ pub const Daemon = struct {
         return try okSessionResponse(self.allocator, id_value, session, true);
     }
 
+    fn attachResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value) ![]u8 {
+        const session = try self.requiredSession(id_value, params);
+        if (params != .object) unreachable;
+        const label = jsonString(params.object.get("label") orelse .null) orelse "";
+        const attach_id = try session.attach(self.allocator, label);
+        defer self.allocator.free(attach_id);
+        return try okValueResponse(self.allocator, id_value, .{
+            .id = session.session_id,
+            .attach_id = attach_id,
+            .running = session.running,
+            .attached_clients = session.attach_clients.items.len,
+        });
+    }
+
+    fn detachResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value) ![]u8 {
+        const session = try self.requiredSession(id_value, params);
+        if (params != .object) unreachable;
+        const attach_id = jsonString(params.object.get("attach_id") orelse .null) orelse
+            return try errorResponseAlloc(self.allocator, id_value, "invalid_params", "missing attach_id");
+        const detached = session.detach(self.allocator, attach_id);
+        return try okValueResponse(self.allocator, id_value, .{
+            .accepted = detached,
+            .attached_clients = session.attach_clients.items.len,
+        });
+    }
+
     fn writeResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value) ![]u8 {
         const session = try self.requiredSession(id_value, params);
         if (params != .object) unreachable;
+        touchAttachFromParams(session, params);
         const text = jsonString(params.object.get("text") orelse .null) orelse "";
         const wrote = try session.writeInput(text);
         return try okValueResponse(self.allocator, id_value, .{ .accepted = wrote, .bytes = text.len });
@@ -572,6 +702,7 @@ pub const Daemon = struct {
     fn resizeResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value) ![]u8 {
         const session = try self.requiredSession(id_value, params);
         if (params != .object) unreachable;
+        touchAttachFromParams(session, params);
         session.resize(
             jsonU16(params.object.get("cols") orelse .null) orelse session.cols,
             jsonU16(params.object.get("rows") orelse .null) orelse session.rows,
@@ -582,6 +713,7 @@ pub const Daemon = struct {
     fn tailResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value, screen: bool) ![]u8 {
         const session = try self.requiredSession(id_value, params);
         if (params != .object) unreachable;
+        touchAttachFromParams(session, params);
         const lines = jsonU32(params.object.get("lines") orelse .null) orelse if (screen) DEFAULT_ROWS else 80;
         const start_offset = jsonUsize(params.object.get("offset") orelse .null);
         const text = if (start_offset) |offset|
@@ -658,7 +790,11 @@ pub fn runDaemon(allocator: std.mem.Allocator, pref_path: []const u8) !void {
 
     var daemon = Daemon.init(allocator);
     defer daemon.deinit();
-    const drain_thread = try std.Thread.spawn(.{}, drainSessionsThread, .{&daemon});
+    const drain_thread = try std.Thread.spawn(.{}, drainSessionsThread, .{DrainThreadContext{
+        .daemon = &daemon,
+        .socket_path = socket_path,
+        .pid_path = pid_path,
+    }});
     drain_thread.detach();
 
     while (true) {
@@ -670,11 +806,25 @@ pub fn runDaemon(allocator: std.mem.Allocator, pref_path: []const u8) !void {
     }
 }
 
-fn drainSessionsThread(daemon: *Daemon) void {
+const DrainThreadContext = struct {
+    daemon: *Daemon,
+    socket_path: []const u8,
+    pid_path: []const u8,
+};
+
+fn drainSessionsThread(context: DrainThreadContext) void {
     while (true) {
+        const daemon = context.daemon;
         lockDaemon(daemon);
         daemon.pollSessions();
+        const should_exit = daemon.shouldExitForIdle();
         daemon.mutex.unlock();
+        if (should_exit) {
+            deleteSocketPath(context.socket_path);
+            var cleanup_threaded = std.Io.Threaded.init_single_threaded;
+            deleteFilePath(cleanup_threaded.io(), context.pid_path);
+            std.c.exit(0);
+        }
         sleepMs(20);
     }
 }
@@ -799,7 +949,15 @@ fn writeSessionSummary(s: *std.json.Stringify, session: *const PtySession) !void
     try s.write(session.created_at_ms);
     try s.objectField("last_attached_at_ms");
     if (session.last_attached_at_ms) |value| try s.write(value) else try s.write(null);
+    try s.objectField("attached_clients");
+    try s.write(session.attach_clients.items.len);
     try s.endObject();
+}
+
+fn touchAttachFromParams(session: *PtySession, params: std.json.Value) void {
+    if (params != .object) return;
+    const attach_id = jsonString(params.object.get("attach_id") orelse .null) orelse return;
+    _ = session.touchAttach(attach_id);
 }
 
 fn writeJsonValue(s: *std.json.Stringify, value: std.json.Value) !void {

--- a/packages/desktop/src/terminal/sessionizer.zig
+++ b/packages/desktop/src/terminal/sessionizer.zig
@@ -360,6 +360,13 @@ const PtySession = struct {
         return true;
     }
 
+    fn foregroundProcessGroup(self: *const PtySession) ?std.posix.pid_t {
+        if (!self.running) return null;
+        var pgrp: c_int = 0;
+        if (std.c.ioctl(self.master_fd, std.c.T.IOCGPGRP, &pgrp) != 0 or pgrp <= 0) return null;
+        return @intCast(pgrp);
+    }
+
     fn attach(self: *PtySession, allocator: std.mem.Allocator, label: []const u8) ![]u8 {
         const now = nowMs();
         self.cleanupStaleAttaches(allocator, now);
@@ -727,6 +734,8 @@ pub const Daemon = struct {
         return try okValueResponse(self.allocator, id_value, .{
             .id = session.session_id,
             .running = session.running,
+            .pid = session.child_pid,
+            .foreground_process_group = session.foregroundProcessGroup(),
             .text = text,
             .offset = text_range.start,
             .next_offset = session.output_ring.items.len,
@@ -941,6 +950,8 @@ fn writeSessionSummary(s: *std.json.Stringify, session: *const PtySession) !void
     try s.write(session.command_label);
     try s.objectField("pid");
     try s.write(session.child_pid);
+    try s.objectField("foreground_process_group");
+    if (session.foregroundProcessGroup()) |pgrp| try s.write(pgrp) else try s.write(null);
     try s.objectField("child_process_count");
     try s.write(childProcessCount(session.child_pid));
     try s.objectField("running");

--- a/packages/desktop/src/terminal/sessionizer.zig
+++ b/packages/desktop/src/terminal/sessionizer.zig
@@ -730,6 +730,7 @@ pub const Daemon = struct {
             .text = text,
             .offset = text_range.start,
             .next_offset = session.output_ring.items.len,
+            .child_process_count = childProcessCount(session.child_pid),
         });
     }
 
@@ -940,6 +941,8 @@ fn writeSessionSummary(s: *std.json.Stringify, session: *const PtySession) !void
     try s.write(session.command_label);
     try s.objectField("pid");
     try s.write(session.child_pid);
+    try s.objectField("child_process_count");
+    try s.write(childProcessCount(session.child_pid));
     try s.objectField("running");
     try s.write(session.running);
     try s.objectField("status");
@@ -1119,6 +1122,33 @@ fn bytesRangeForTailLines(bytes: []const u8, lines: u32, max_bytes: ?usize) Byte
 fn bytesFromOffset(allocator: std.mem.Allocator, bytes: []const u8, offset: usize) ![]u8 {
     const start = @min(offset, bytes.len);
     return allocator.dupe(u8, bytes[start..]);
+}
+
+fn childProcessCount(pid: std.posix.pid_t) ?usize {
+    if (builtin.os.tag != .linux or pid <= 0) return null;
+
+    var path_buffer: [128]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buffer, "/proc/{d}/task/{d}/children", .{ pid, pid }) catch return null;
+    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{ .ACCMODE = .RDONLY }, 0) catch return null;
+    defer _ = std.c.close(fd);
+
+    var buffer: [4096]u8 = undefined;
+    const read_raw = std.c.read(fd, &buffer, buffer.len);
+    if (read_raw <= 0) return 0;
+
+    var count: usize = 0;
+    var in_number = false;
+    for (buffer[0..@intCast(read_raw)]) |byte| {
+        if (byte >= '0' and byte <= '9') {
+            if (!in_number) {
+                count += 1;
+                in_number = true;
+            }
+        } else {
+            in_number = false;
+        }
+    }
+    return count;
 }
 
 pub fn nowMs() i64 {

--- a/packages/desktop/src/terminal/sessionizer.zig
+++ b/packages/desktop/src/terminal/sessionizer.zig
@@ -1,0 +1,1042 @@
+//! Verde-native terminal session identity and daemon protocol helpers.
+//!
+//! This module is intentionally separate from `terminal.zig`: terminal UI code
+//! can import these small types while the long-lived PTY owner and CLI attach
+//! behavior grow here instead of being buried in the renderer/pane code.
+
+const std = @import("std");
+const builtin = @import("builtin");
+extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
+
+pub const SOCKET_NAME = "verde-sessionizer.sock";
+pub const PID_FILE_NAME = "verde-sessionizer.pid";
+pub const PROTOCOL_VERSION: u32 = 1;
+pub const DEFAULT_COLS: u16 = 120;
+pub const DEFAULT_ROWS: u16 = 30;
+const MAX_OUTPUT_RING: usize = 1024 * 1024;
+const TERMINAL_WINSIZE_IOCTL = switch (builtin.os.tag) {
+    .macos => 0x80087467,
+    else => std.c.T.IOCSWINSZ,
+};
+
+pub const RevivePolicy = enum {
+    attach_or_create,
+    attach_only,
+    restart,
+    manual,
+};
+
+pub const LayoutContext = struct {
+    project_id: []const u8,
+    project_path: []const u8 = "",
+    dock_id: u32,
+};
+
+pub const LeafSessionMetadata = struct {
+    session_id: ?[]const u8 = null,
+    revive_policy: RevivePolicy = .attach_or_create,
+};
+
+pub const SessionStatus = enum {
+    missing,
+    starting,
+    running,
+    exited,
+};
+
+pub const SessionSummary = struct {
+    session_id: []const u8,
+    project_id: []const u8 = "",
+    project_path: []const u8 = "",
+    dock_id: u32 = 0,
+    pane_id: u32 = 0,
+    label: []const u8 = "",
+    status: SessionStatus = .missing,
+    created_at_ms: ?i64 = null,
+    last_attached_at_ms: ?i64 = null,
+};
+
+pub const Method = enum {
+    @"session.list",
+    @"session.inspect",
+    @"session.create",
+    @"session.attach",
+    @"session.detach",
+    @"session.write",
+    @"session.resize",
+    @"session.tail",
+    @"session.screen",
+    @"session.kill",
+    @"session.cleanup",
+
+    pub fn text(self: Method) []const u8 {
+        return @tagName(self);
+    }
+};
+
+pub const METHOD_NAMES = [_][]const u8{
+    "session.list",
+    "session.inspect",
+    "session.create",
+    "session.attach",
+    "session.detach",
+    "session.write",
+    "session.resize",
+    "session.tail",
+    "session.screen",
+    "session.kill",
+    "session.cleanup",
+};
+
+pub fn stableSessionId(
+    allocator: std.mem.Allocator,
+    project_id: []const u8,
+    dock_id: u32,
+    pane_id: u32,
+) ![]u8 {
+    var safe_project_id: std.ArrayList(u8) = .empty;
+    defer safe_project_id.deinit(allocator);
+    try appendSafeComponent(allocator, &safe_project_id, project_id);
+    if (safe_project_id.items.len == 0) try safe_project_id.appendSlice(allocator, "project");
+
+    return try std.fmt.allocPrint(
+        allocator,
+        "verde:{s}:dock:{d}:pane:{d}",
+        .{ safe_project_id.items, dock_id, pane_id },
+    );
+}
+
+pub fn sessionIdForLeaf(
+    allocator: std.mem.Allocator,
+    context: ?LayoutContext,
+    pane_id: u32,
+    existing_session_id: ?[]const u8,
+) !?[]u8 {
+    if (existing_session_id) |session_id| return try allocator.dupe(u8, session_id);
+    const ctx = context orelse return null;
+    return try stableSessionId(allocator, ctx.project_id, ctx.dock_id, pane_id);
+}
+
+pub fn socketPath(allocator: std.mem.Allocator, pref_path: []const u8) ![]u8 {
+    return std.fs.path.join(allocator, &.{ pref_path, SOCKET_NAME });
+}
+
+pub fn pidFilePath(allocator: std.mem.Allocator, pref_path: []const u8) ![]u8 {
+    return std.fs.path.join(allocator, &.{ pref_path, PID_FILE_NAME });
+}
+
+pub fn requestAlloc(
+    allocator: std.mem.Allocator,
+    pref_path: []const u8,
+    method: []const u8,
+    params: anytype,
+    request_id: u64,
+) ![]u8 {
+    var threaded = std.Io.Threaded.init_single_threaded;
+    const io = threaded.io();
+    const socket_path = try socketPath(allocator, pref_path);
+    defer allocator.free(socket_path);
+
+    var request_writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer request_writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &request_writer.writer, .options = .{} };
+    try s.beginObject();
+    try s.objectField("id");
+    try s.write(request_id);
+    try s.objectField("method");
+    try s.write(method);
+    try s.objectField("params");
+    try s.write(params);
+    try s.endObject();
+    const request_json = try request_writer.toOwnedSlice();
+    defer allocator.free(request_json);
+
+    const address = try std.Io.net.UnixAddress.init(socket_path);
+    const stream = try address.connect(io);
+    defer stream.close(io);
+
+    var write_buffer: [64 * 1024]u8 = undefined;
+    var writer = stream.writer(io, &write_buffer);
+    try writer.interface.writeAll(request_json);
+    try writer.interface.writeByte('\n');
+    try writer.interface.flush();
+
+    var read_buffer: [256 * 1024]u8 = undefined;
+    var reader = stream.reader(io, &read_buffer);
+    const line = try reader.interface.takeDelimiter('\n') orelse return error.ConnectionAborted;
+    return try allocator.dupe(u8, std.mem.trim(u8, line, "\r"));
+}
+
+pub fn ensureDaemon(allocator: std.mem.Allocator, pref_path: []const u8, exe_path: []const u8) !void {
+    if (requestAlloc(allocator, pref_path, "status", .{}, 0)) |response| {
+        allocator.free(response);
+        return;
+    } else |_| {}
+
+    try spawnDaemon(allocator, exe_path);
+    var threaded = std.Io.Threaded.init_single_threaded;
+    const io = threaded.io();
+    var attempts: usize = 0;
+    while (attempts < 250) : (attempts += 1) {
+        if (requestAlloc(allocator, pref_path, "status", .{}, 0)) |response| {
+            allocator.free(response);
+            return;
+        } else |_| {
+            std.Io.sleep(io, .fromMilliseconds(20), .awake) catch {};
+        }
+    }
+    return error.SessionDaemonUnavailable;
+}
+
+pub fn spawnDaemon(allocator: std.mem.Allocator, exe_path: []const u8) !void {
+    const daemon_exe = try daemonExecutablePath(allocator, exe_path);
+    defer allocator.free(daemon_exe);
+    const daemon_exe_z = try allocator.dupeZ(u8, daemon_exe);
+    defer allocator.free(daemon_exe_z);
+
+    const fork_result = std.c.fork();
+    if (fork_result < 0) return error.ForkFailed;
+    if (fork_result == 0) {
+        _ = std.c.setsid();
+        var child_argv: [3:null]?[*:0]const u8 = .{ daemon_exe_z.ptr, "__session-daemon", null };
+        _ = std.c.execve(daemon_exe_z.ptr, &child_argv, std.c.environ);
+        std.c._exit(127);
+    }
+}
+
+pub fn daemonExecutablePath(allocator: std.mem.Allocator, exe_path: []const u8) ![]u8 {
+    if (std.mem.indexOfScalar(u8, exe_path, '/') != null) return allocator.dupe(u8, exe_path);
+    const path_ptr = std.c.getenv("PATH") orelse return allocator.dupe(u8, exe_path);
+    const path_value = std.mem.span(path_ptr);
+    var iterator = std.mem.splitScalar(u8, path_value, ':');
+    while (iterator.next()) |dir| {
+        if (dir.len == 0) continue;
+        const candidate = try std.fs.path.join(allocator, &.{ dir, exe_path });
+        defer allocator.free(candidate);
+        const candidate_z = try allocator.dupeZ(u8, candidate);
+        if (std.c.access(candidate_z.ptr, std.c.X_OK) == 0) {
+            allocator.free(candidate_z);
+            return allocator.dupe(u8, candidate);
+        }
+        allocator.free(candidate_z);
+    }
+    return allocator.dupe(u8, exe_path);
+}
+
+pub const CreateOptions = struct {
+    session_id: []const u8,
+    project_id: []const u8 = "",
+    project_path: []const u8 = "",
+    cwd: []const u8 = "",
+    label: []const u8 = "",
+    command: []const []const u8 = &.{},
+    cols: u16 = DEFAULT_COLS,
+    rows: u16 = DEFAULT_ROWS,
+};
+
+const PtySession = struct {
+    session_id: []u8,
+    project_id: []u8,
+    project_path: []u8,
+    cwd: []u8,
+    label: []u8,
+    command_label: []u8,
+    master_fd: std.posix.fd_t,
+    child_pid: std.posix.pid_t,
+    cols: u16,
+    rows: u16,
+    output_ring: std.ArrayList(u8) = .empty,
+    running: bool = true,
+    exit_status: ?u32 = null,
+    created_at_ms: i64,
+    last_attached_at_ms: ?i64 = null,
+
+    const SpawnResult = struct {
+        master_fd: std.posix.fd_t,
+        child_pid: std.posix.pid_t,
+    };
+
+    extern fn forkpty(
+        amaster: *c_int,
+        name: ?[*:0]u8,
+        termp: ?*const anyopaque,
+        winp: ?*const std.posix.winsize,
+    ) c_int;
+
+    pub fn create(allocator: std.mem.Allocator, options: CreateOptions) !*PtySession {
+        const self = try allocator.create(PtySession);
+        errdefer allocator.destroy(self);
+
+        const cwd = if (std.mem.trim(u8, options.cwd, &std.ascii.whitespace).len > 0)
+            options.cwd
+        else
+            ".";
+        const command = try commandForOptions(allocator, options.command);
+        defer freeCommand(allocator, command);
+        const command_label = try commandLabel(allocator, command);
+        errdefer allocator.free(command_label);
+
+        const child = try spawnCommand(allocator, cwd, options.cols, options.rows, command);
+        errdefer {
+            std.posix.kill(child.child_pid, std.posix.SIG.TERM) catch {};
+            _ = std.c.close(child.master_fd);
+        }
+
+        self.* = .{
+            .session_id = try allocator.dupe(u8, options.session_id),
+            .project_id = try allocator.dupe(u8, options.project_id),
+            .project_path = try allocator.dupe(u8, options.project_path),
+            .cwd = try allocator.dupe(u8, cwd),
+            .label = try allocator.dupe(u8, if (options.label.len > 0) options.label else command_label),
+            .command_label = command_label,
+            .master_fd = child.master_fd,
+            .child_pid = child.child_pid,
+            .cols = options.cols,
+            .rows = options.rows,
+            .created_at_ms = nowMs(),
+        };
+        return self;
+    }
+
+    pub fn deinit(self: *PtySession, allocator: std.mem.Allocator) void {
+        if (self.running) std.posix.kill(self.child_pid, std.posix.SIG.TERM) catch {};
+        _ = std.c.close(self.master_fd);
+        _ = self.captureExitStatus();
+        allocator.free(self.session_id);
+        allocator.free(self.project_id);
+        allocator.free(self.project_path);
+        allocator.free(self.cwd);
+        allocator.free(self.label);
+        allocator.free(self.command_label);
+        self.output_ring.deinit(allocator);
+        allocator.destroy(self);
+    }
+
+    fn poll(self: *PtySession, allocator: std.mem.Allocator) !void {
+        try self.drainOutput(allocator);
+        _ = self.captureExitStatus();
+    }
+
+    fn writeInput(self: *PtySession, bytes: []const u8) !bool {
+        if (!self.running or bytes.len == 0) return false;
+        try writeAll(self.master_fd, bytes);
+        return true;
+    }
+
+    fn resize(self: *PtySession, cols: u16, rows: u16) void {
+        if (!self.running) return;
+        self.cols = @max(cols, 1);
+        self.rows = @max(rows, 1);
+        var winsize = std.posix.winsize{
+            .row = self.rows,
+            .col = self.cols,
+            .xpixel = 0,
+            .ypixel = 0,
+        };
+        _ = std.c.ioctl(self.master_fd, TERMINAL_WINSIZE_IOCTL, &winsize);
+    }
+
+    fn terminate(self: *PtySession) bool {
+        if (!self.running) return false;
+        std.posix.kill(self.child_pid, std.posix.SIG.TERM) catch return false;
+        self.running = false;
+        _ = self.captureExitStatus();
+        return true;
+    }
+
+    fn drainOutput(self: *PtySession, allocator: std.mem.Allocator) !void {
+        var buffer: [8192]u8 = undefined;
+        while (true) {
+            const read_raw = std.c.read(self.master_fd, &buffer, buffer.len);
+            if (read_raw > 0) {
+                try self.appendOutput(allocator, buffer[0..@intCast(read_raw)]);
+                continue;
+            }
+            if (read_raw == 0) {
+                self.running = false;
+                _ = self.captureExitStatus();
+                return;
+            }
+            const err = std.c._errno().*;
+            if (err == @intFromEnum(std.c.E.AGAIN)) return;
+            self.running = false;
+            _ = self.captureExitStatus();
+            return;
+        }
+    }
+
+    fn appendOutput(self: *PtySession, allocator: std.mem.Allocator, bytes: []const u8) !void {
+        if (bytes.len >= MAX_OUTPUT_RING) {
+            self.output_ring.clearRetainingCapacity();
+            try self.output_ring.appendSlice(allocator, bytes[bytes.len - MAX_OUTPUT_RING ..]);
+            return;
+        }
+        const overflow = self.output_ring.items.len + bytes.len -| MAX_OUTPUT_RING;
+        if (overflow > 0) {
+            std.mem.copyForwards(u8, self.output_ring.items[0 .. self.output_ring.items.len - overflow], self.output_ring.items[overflow..]);
+            self.output_ring.shrinkRetainingCapacity(self.output_ring.items.len - overflow);
+        }
+        try self.output_ring.appendSlice(allocator, bytes);
+    }
+
+    fn captureExitStatus(self: *PtySession) bool {
+        if (self.exit_status != null) return false;
+        var status: c_int = 0;
+        const wait_result = std.c.waitpid(self.child_pid, &status, std.c.W.NOHANG);
+        if (wait_result == 0) return false;
+        self.running = false;
+        self.exit_status = @intCast(status);
+        return true;
+    }
+
+    fn spawnCommand(
+        allocator: std.mem.Allocator,
+        cwd: []const u8,
+        cols: u16,
+        rows: u16,
+        command: []const [:0]u8,
+    ) !SpawnResult {
+        const cwd_z = try allocator.dupeZ(u8, cwd);
+        defer allocator.free(cwd_z);
+
+        var master_fd: c_int = -1;
+        const winsize = std.posix.winsize{
+            .row = rows,
+            .col = cols,
+            .xpixel = 0,
+            .ypixel = 0,
+        };
+        const fork_result = forkpty(&master_fd, null, null, &winsize);
+        if (fork_result < 0) return error.ForkPtyFailed;
+        if (fork_result == 0) childExec(cwd_z, command);
+
+        try setNonBlocking(@intCast(master_fd));
+        return .{
+            .master_fd = @intCast(master_fd),
+            .child_pid = @intCast(fork_result),
+        };
+    }
+
+    fn childExec(cwd: [:0]const u8, command: []const [:0]u8) noreturn {
+        if (std.c.chdir(cwd.ptr) != 0) std.c._exit(127);
+        _ = setenv("TERM", "xterm-ghostty", 1);
+        _ = setenv("COLORTERM", "truecolor", 1);
+        _ = setenv("TERM_PROGRAM", "verde", 1);
+        if (std.c.getenv("LANG") == null) _ = setenv("LANG", "C.UTF-8", 1);
+
+        var argv: [64:null]?[*:0]const u8 = [_:null]?[*:0]const u8{null} ** 64;
+        const count = @min(command.len, argv.len - 1);
+        for (command[0..count], 0..) |arg, index| argv[index] = arg.ptr;
+        if (count > 0) _ = std.c.execve(command[0].ptr, &argv, std.c.environ);
+        std.c._exit(127);
+    }
+};
+
+pub const Daemon = struct {
+    allocator: std.mem.Allocator,
+    sessions: std.ArrayList(*PtySession) = .empty,
+    mutex: std.atomic.Mutex = .unlocked,
+
+    pub fn init(allocator: std.mem.Allocator) Daemon {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *Daemon) void {
+        for (self.sessions.items) |session| session.deinit(self.allocator);
+        self.sessions.deinit(self.allocator);
+    }
+
+    fn pollSessions(self: *Daemon) void {
+        for (self.sessions.items) |session| session.poll(self.allocator) catch {};
+    }
+
+    fn find(self: *Daemon, session_id: []const u8) ?*PtySession {
+        for (self.sessions.items) |session| {
+            if (std.mem.eql(u8, session.session_id, session_id)) return session;
+        }
+        return null;
+    }
+
+    fn removeAt(self: *Daemon, index: usize) void {
+        const session = self.sessions.orderedRemove(index);
+        session.deinit(self.allocator);
+    }
+
+    fn handleRequest(self: *Daemon, request_json: []const u8) ![]u8 {
+        self.pollSessions();
+        var parsed = try std.json.parseFromSlice(std.json.Value, self.allocator, request_json, .{});
+        defer parsed.deinit();
+        if (parsed.value != .object) return try errorResponseAlloc(self.allocator, .null, "invalid_request", "request must be an object");
+        const id_value = parsed.value.object.get("id") orelse .null;
+        const method = jsonString(parsed.value.object.get("method") orelse .null) orelse
+            return try errorResponseAlloc(self.allocator, id_value, "invalid_request", "missing method");
+        const params = parsed.value.object.get("params") orelse .null;
+
+        if (std.mem.eql(u8, method, "session.list")) return try self.listResponse(id_value);
+        if (std.mem.eql(u8, method, "session.inspect")) return try self.inspectResponse(id_value, params);
+        if (std.mem.eql(u8, method, "session.create")) return try self.createResponse(id_value, params);
+        if (std.mem.eql(u8, method, "session.write")) return try self.writeResponse(id_value, params);
+        if (std.mem.eql(u8, method, "session.resize")) return try self.resizeResponse(id_value, params);
+        if (std.mem.eql(u8, method, "session.tail")) return try self.tailResponse(id_value, params, false);
+        if (std.mem.eql(u8, method, "session.screen")) return try self.tailResponse(id_value, params, true);
+        if (std.mem.eql(u8, method, "session.kill")) return try self.killResponse(id_value, params);
+        if (std.mem.eql(u8, method, "session.cleanup")) return try self.cleanupResponse(id_value);
+        if (std.mem.eql(u8, method, "status")) return try self.statusResponse(id_value);
+        return try errorResponseAlloc(self.allocator, id_value, "method_not_found", method);
+    }
+
+    fn statusResponse(self: *Daemon, id_value: std.json.Value) ![]u8 {
+        return try okValueResponse(self.allocator, id_value, .{
+            .protocol_version = PROTOCOL_VERSION,
+            .pid = std.c.getpid(),
+            .session_count = self.sessions.items.len,
+        });
+    }
+
+    fn listResponse(self: *Daemon, id_value: std.json.Value) ![]u8 {
+        var writer: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer writer.deinit();
+        var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+        try beginOk(&s, id_value);
+        try s.objectField("result");
+        try s.beginObject();
+        try s.objectField("daemon_running");
+        try s.write(true);
+        try s.objectField("protocol_version");
+        try s.write(PROTOCOL_VERSION);
+        try s.objectField("sessions");
+        try s.beginArray();
+        for (self.sessions.items) |session| try writeSessionSummary(&s, session);
+        try s.endArray();
+        try s.endObject();
+        try s.endObject();
+        return try writer.toOwnedSlice();
+    }
+
+    fn inspectResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value) ![]u8 {
+        const session = try self.requiredSession(id_value, params);
+        var writer: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer writer.deinit();
+        var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+        try beginOk(&s, id_value);
+        try s.objectField("result");
+        try s.beginObject();
+        try s.objectField("session");
+        try writeSessionSummary(&s, session);
+        try s.objectField("tail_bytes");
+        try s.write(session.output_ring.items.len);
+        try s.objectField("cwd");
+        try s.write(session.cwd);
+        try s.objectField("command");
+        try s.write(session.command_label);
+        try s.endObject();
+        try s.endObject();
+        return try writer.toOwnedSlice();
+    }
+
+    fn createResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value) ![]u8 {
+        if (params != .object) return try errorResponseAlloc(self.allocator, id_value, "invalid_params", "params must be an object");
+        const session_id = jsonString(params.object.get("id") orelse .null) orelse
+            return try errorResponseAlloc(self.allocator, id_value, "invalid_params", "missing id");
+        if (self.find(session_id)) |existing| {
+            existing.last_attached_at_ms = nowMs();
+            return try okSessionResponse(self.allocator, id_value, existing, false);
+        }
+
+        const command = try jsonStringArray(self.allocator, params.object.get("command") orelse .null);
+        defer freeStringArray(self.allocator, command);
+        const cwd = jsonString(params.object.get("cwd") orelse .null) orelse ".";
+        const session = try PtySession.create(self.allocator, .{
+            .session_id = session_id,
+            .project_id = jsonString(params.object.get("project_id") orelse .null) orelse "",
+            .project_path = jsonString(params.object.get("project_path") orelse .null) orelse "",
+            .cwd = cwd,
+            .label = jsonString(params.object.get("label") orelse .null) orelse "",
+            .command = command,
+            .cols = jsonU16(params.object.get("cols") orelse .null) orelse DEFAULT_COLS,
+            .rows = jsonU16(params.object.get("rows") orelse .null) orelse DEFAULT_ROWS,
+        });
+        errdefer session.deinit(self.allocator);
+        try self.sessions.append(self.allocator, session);
+        return try okSessionResponse(self.allocator, id_value, session, true);
+    }
+
+    fn writeResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value) ![]u8 {
+        const session = try self.requiredSession(id_value, params);
+        if (params != .object) unreachable;
+        const text = jsonString(params.object.get("text") orelse .null) orelse "";
+        const wrote = try session.writeInput(text);
+        return try okValueResponse(self.allocator, id_value, .{ .accepted = wrote, .bytes = text.len });
+    }
+
+    fn resizeResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value) ![]u8 {
+        const session = try self.requiredSession(id_value, params);
+        if (params != .object) unreachable;
+        session.resize(
+            jsonU16(params.object.get("cols") orelse .null) orelse session.cols,
+            jsonU16(params.object.get("rows") orelse .null) orelse session.rows,
+        );
+        return try okValueResponse(self.allocator, id_value, .{ .accepted = true });
+    }
+
+    fn tailResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value, screen: bool) ![]u8 {
+        const session = try self.requiredSession(id_value, params);
+        if (params != .object) unreachable;
+        const lines = jsonU32(params.object.get("lines") orelse .null) orelse if (screen) DEFAULT_ROWS else 80;
+        const start_offset = jsonUsize(params.object.get("offset") orelse .null);
+        const text = if (start_offset) |offset|
+            try bytesFromOffset(self.allocator, session.output_ring.items, offset)
+        else
+            try tailLines(self.allocator, session.output_ring.items, lines);
+        defer self.allocator.free(text);
+        return try okValueResponse(self.allocator, id_value, .{
+            .id = session.session_id,
+            .running = session.running,
+            .text = text,
+            .offset = start_offset orelse 0,
+            .next_offset = session.output_ring.items.len,
+        });
+    }
+
+    fn killResponse(self: *Daemon, id_value: std.json.Value, params: std.json.Value) ![]u8 {
+        if (params != .object) return try errorResponseAlloc(self.allocator, id_value, "invalid_params", "params must be an object");
+        const wanted_id = jsonString(params.object.get("id") orelse .null) orelse
+            return try errorResponseAlloc(self.allocator, id_value, "invalid_params", "missing id");
+        for (self.sessions.items, 0..) |session, index| {
+            if (!std.mem.eql(u8, session.session_id, wanted_id)) continue;
+            const signaled = session.terminate();
+            self.removeAt(index);
+            return try okValueResponse(self.allocator, id_value, .{ .accepted = true, .signaled = signaled });
+        }
+        return try errorResponseAlloc(self.allocator, id_value, "not_found", wanted_id);
+    }
+
+    fn cleanupResponse(self: *Daemon, id_value: std.json.Value) ![]u8 {
+        var removed: usize = 0;
+        var index: usize = 0;
+        while (index < self.sessions.items.len) {
+            const session = self.sessions.items[index];
+            try session.poll(self.allocator);
+            if (session.running) {
+                index += 1;
+                continue;
+            }
+            self.removeAt(index);
+            removed += 1;
+        }
+        return try okValueResponse(self.allocator, id_value, .{ .removed = removed });
+    }
+
+    fn requiredSession(self: *Daemon, id_value: std.json.Value, params: std.json.Value) !*PtySession {
+        _ = id_value;
+        if (params != .object) return error.InvalidParams;
+        const wanted_id = jsonString(params.object.get("id") orelse .null) orelse return error.MissingSessionId;
+        return self.find(wanted_id) orelse return error.SessionNotFound;
+    }
+};
+
+pub fn runDaemon(allocator: std.mem.Allocator, pref_path: []const u8) !void {
+    var setup_threaded = std.Io.Threaded.init_single_threaded;
+    try std.Io.Dir.cwd().createDirPath(setup_threaded.io(), pref_path);
+    const socket_path = try socketPath(allocator, pref_path);
+    defer allocator.free(socket_path);
+    const pid_path = try pidFilePath(allocator, pref_path);
+    defer allocator.free(pid_path);
+    deleteSocketPath(socket_path);
+    try writePidFile(pid_path);
+    defer deleteSocketPath(socket_path);
+    defer {
+        var cleanup_threaded = std.Io.Threaded.init_single_threaded;
+        deleteFilePath(cleanup_threaded.io(), pid_path);
+    }
+
+    var threaded = std.Io.Threaded.init_single_threaded;
+    const io = threaded.io();
+    const address = try std.Io.net.UnixAddress.init(socket_path);
+    var listener = try address.listen(io, .{});
+    defer listener.deinit(io);
+
+    var daemon = Daemon.init(allocator);
+    defer daemon.deinit();
+    const drain_thread = try std.Thread.spawn(.{}, drainSessionsThread, .{&daemon});
+    drain_thread.detach();
+
+    while (true) {
+        const stream = listener.accept(io) catch |err| switch (err) {
+            error.ConnectionAborted => continue,
+            else => return err,
+        };
+        handleClient(&daemon, io, stream);
+    }
+}
+
+fn drainSessionsThread(daemon: *Daemon) void {
+    while (true) {
+        lockDaemon(daemon);
+        daemon.pollSessions();
+        daemon.mutex.unlock();
+        sleepMs(20);
+    }
+}
+
+fn handleClient(daemon: *Daemon, io: std.Io, stream: std.Io.net.Stream) void {
+    defer stream.close(io);
+    var read_buffer: [64 * 1024]u8 = undefined;
+    var reader = stream.reader(io, &read_buffer);
+    const line = reader.interface.takeDelimiter('\n') catch return orelse return;
+
+    var locked = true;
+    lockDaemon(daemon);
+    const response_json = daemon.handleRequest(std.mem.trim(u8, line, "\r")) catch |err| blk: {
+        daemon.mutex.unlock();
+        locked = false;
+        break :blk errorResponseAlloc(daemon.allocator, .null, "internal_error", @errorName(err)) catch return;
+    };
+    if (locked) daemon.mutex.unlock();
+    defer daemon.allocator.free(response_json);
+
+    var write_buffer: [64 * 1024]u8 = undefined;
+    var writer = stream.writer(io, &write_buffer);
+    writer.interface.writeAll(response_json) catch return;
+    writer.interface.writeByte('\n') catch return;
+    writer.interface.flush() catch return;
+}
+
+fn lockDaemon(daemon: *Daemon) void {
+    while (!daemon.mutex.tryLock()) std.atomic.spinLoopHint();
+}
+
+fn sleepMs(milliseconds: i64) void {
+    var request = std.c.timespec{
+        .sec = @intCast(@divTrunc(milliseconds, std.time.ms_per_s)),
+        .nsec = @intCast(@mod(milliseconds, std.time.ms_per_s) * std.time.ns_per_ms),
+    };
+    _ = std.c.nanosleep(&request, null);
+}
+
+fn okSessionResponse(allocator: std.mem.Allocator, id_value: std.json.Value, session: *const PtySession, created: bool) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.beginObject();
+    try s.objectField("created");
+    try s.write(created);
+    try s.objectField("session");
+    try writeSessionSummary(&s, session);
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn okValueResponse(allocator: std.mem.Allocator, id_value: std.json.Value, value: anytype) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try beginOk(&s, id_value);
+    try s.objectField("result");
+    try s.write(value);
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn errorResponseAlloc(allocator: std.mem.Allocator, id_value: std.json.Value, code: []const u8, message: []const u8) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    var s: std.json.Stringify = .{ .writer = &writer.writer, .options = .{} };
+    try s.beginObject();
+    try s.objectField("jsonrpc");
+    try s.write("2.0");
+    try s.objectField("id");
+    try writeJsonValue(&s, id_value);
+    try s.objectField("error");
+    try s.beginObject();
+    try s.objectField("code");
+    try s.write(code);
+    try s.objectField("message");
+    try s.write(message);
+    try s.endObject();
+    try s.endObject();
+    return try writer.toOwnedSlice();
+}
+
+fn beginOk(s: *std.json.Stringify, id_value: std.json.Value) !void {
+    try s.beginObject();
+    try s.objectField("jsonrpc");
+    try s.write("2.0");
+    try s.objectField("id");
+    try writeJsonValue(s, id_value);
+}
+
+fn writeSessionSummary(s: *std.json.Stringify, session: *const PtySession) !void {
+    try s.beginObject();
+    try s.objectField("id");
+    try s.write(session.session_id);
+    try s.objectField("session_id");
+    try s.write(session.session_id);
+    try s.objectField("project_id");
+    try s.write(session.project_id);
+    try s.objectField("project_path");
+    try s.write(session.project_path);
+    try s.objectField("cwd");
+    try s.write(session.cwd);
+    try s.objectField("label");
+    try s.write(session.label);
+    try s.objectField("command");
+    try s.write(session.command_label);
+    try s.objectField("pid");
+    try s.write(session.child_pid);
+    try s.objectField("running");
+    try s.write(session.running);
+    try s.objectField("status");
+    try s.write(if (session.running) "running" else "exited");
+    try s.objectField("cols");
+    try s.write(session.cols);
+    try s.objectField("rows");
+    try s.write(session.rows);
+    try s.objectField("created_at_ms");
+    try s.write(session.created_at_ms);
+    try s.objectField("last_attached_at_ms");
+    if (session.last_attached_at_ms) |value| try s.write(value) else try s.write(null);
+    try s.endObject();
+}
+
+fn writeJsonValue(s: *std.json.Stringify, value: std.json.Value) !void {
+    switch (value) {
+        .integer => |v| try s.write(v),
+        .float => |v| try s.write(v),
+        .number_string => |v| try s.write(v),
+        .string => |v| try s.write(v),
+        .bool => |v| try s.write(v),
+        .null => try s.write(null),
+        else => try s.write(null),
+    }
+}
+
+fn jsonString(value: std.json.Value) ?[]const u8 {
+    return switch (value) {
+        .string => |text| text,
+        else => null,
+    };
+}
+
+fn jsonU32(value: std.json.Value) ?u32 {
+    return switch (value) {
+        .integer => |int| if (int >= 0) @intCast(int) else null,
+        .number_string => |text| std.fmt.parseInt(u32, text, 10) catch null,
+        else => null,
+    };
+}
+
+fn jsonUsize(value: std.json.Value) ?usize {
+    return switch (value) {
+        .integer => |int| if (int >= 0) @intCast(int) else null,
+        .number_string => |text| std.fmt.parseInt(usize, text, 10) catch null,
+        else => null,
+    };
+}
+
+fn jsonU16(value: std.json.Value) ?u16 {
+    const value_u32 = jsonU32(value) orelse return null;
+    return if (value_u32 <= std.math.maxInt(u16)) @intCast(value_u32) else null;
+}
+
+fn jsonStringArray(allocator: std.mem.Allocator, value: std.json.Value) ![]const []const u8 {
+    if (value != .array) return &.{};
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (out.items) |item| allocator.free(item);
+        out.deinit(allocator);
+    }
+    for (value.array.items) |item| {
+        const text = jsonString(item) orelse continue;
+        try out.append(allocator, try allocator.dupe(u8, text));
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+fn freeStringArray(allocator: std.mem.Allocator, values: []const []const u8) void {
+    for (values) |value| allocator.free(value);
+    allocator.free(values);
+}
+
+fn commandForOptions(allocator: std.mem.Allocator, args: []const []const u8) ![][:0]u8 {
+    if (args.len > 0) return dupeCommand(allocator, args);
+    const shell = if (std.c.getenv("SHELL")) |shell_ptr| std.mem.span(shell_ptr) else "/bin/bash";
+    return dupeCommand(allocator, &.{ shell, "-i" });
+}
+
+fn dupeCommand(allocator: std.mem.Allocator, args: []const []const u8) ![][:0]u8 {
+    const command = try allocator.alloc([:0]u8, args.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (command[0..initialized]) |arg| allocator.free(arg);
+        allocator.free(command);
+    }
+    for (args, 0..) |arg, index| {
+        command[index] = if (index == 0)
+            try resolveExecutableArg(allocator, arg)
+        else
+            try allocator.dupeZ(u8, arg);
+        initialized += 1;
+    }
+    return command;
+}
+
+fn resolveExecutableArg(allocator: std.mem.Allocator, arg: []const u8) ![:0]u8 {
+    if (std.mem.indexOfScalar(u8, arg, '/') != null) return allocator.dupeZ(u8, arg);
+    const path_ptr = std.c.getenv("PATH") orelse return allocator.dupeZ(u8, arg);
+    const path_value = std.mem.span(path_ptr);
+    var iterator = std.mem.splitScalar(u8, path_value, ':');
+    while (iterator.next()) |dir| {
+        if (dir.len == 0) continue;
+        const candidate = try std.fs.path.join(allocator, &.{ dir, arg });
+        defer allocator.free(candidate);
+        const candidate_z = try allocator.dupeZ(u8, candidate);
+        if (std.c.access(candidate_z.ptr, std.c.X_OK) == 0) return candidate_z;
+        allocator.free(candidate_z);
+    }
+    return allocator.dupeZ(u8, arg);
+}
+
+fn freeCommand(allocator: std.mem.Allocator, command: []const [:0]u8) void {
+    for (command) |arg| allocator.free(arg);
+    allocator.free(command);
+}
+
+fn commandLabel(allocator: std.mem.Allocator, command: []const [:0]u8) ![]u8 {
+    var writer: std.Io.Writer.Allocating = .init(allocator);
+    errdefer writer.deinit();
+    for (command, 0..) |arg, index| {
+        if (index > 0) try writer.writer.writeByte(' ');
+        try writer.writer.writeAll(arg);
+    }
+    return try writer.toOwnedSlice();
+}
+
+fn tailLines(allocator: std.mem.Allocator, bytes: []const u8, lines: u32) ![]u8 {
+    if (bytes.len == 0 or lines == 0) return allocator.dupe(u8, "");
+    var remaining = lines;
+    var start = bytes.len;
+    while (start > 0 and remaining > 0) {
+        start -= 1;
+        if (bytes[start] == '\n') remaining -= 1;
+    }
+    if (start < bytes.len and bytes[start] == '\n') start += 1;
+    return allocator.dupe(u8, bytes[start..]);
+}
+
+fn bytesFromOffset(allocator: std.mem.Allocator, bytes: []const u8, offset: usize) ![]u8 {
+    const start = @min(offset, bytes.len);
+    return allocator.dupe(u8, bytes[start..]);
+}
+
+pub fn nowMs() i64 {
+    var ts: std.c.timespec = undefined;
+    if (std.c.clock_gettime(.REALTIME, &ts) != 0) return 0;
+    return @as(i64, @intCast(ts.sec)) * std.time.ms_per_s + @divTrunc(@as(i64, @intCast(ts.nsec)), std.time.ns_per_ms);
+}
+
+fn setNonBlocking(fd: std.posix.fd_t) !void {
+    const current = std.c.fcntl(fd, std.c.F.GETFL, @as(c_int, 0));
+    if (current < 0) return error.FcntlFailed;
+    const nonblock = @as(usize, 1) << @bitOffsetOf(std.posix.O, "NONBLOCK");
+    if (std.c.fcntl(fd, std.c.F.SETFL, current | @as(c_int, @intCast(nonblock))) < 0) return error.FcntlFailed;
+}
+
+fn writeAll(fd: std.posix.fd_t, bytes: []const u8) !void {
+    var remaining = bytes;
+    while (remaining.len > 0) {
+        const written_raw = std.c.write(fd, remaining.ptr, remaining.len);
+        if (written_raw < 0) {
+            if (std.c._errno().* == @intFromEnum(std.c.E.INTR)) continue;
+            return error.WriteFailed;
+        }
+        const written: usize = @intCast(written_raw);
+        if (written == 0) return error.WriteFailed;
+        remaining = remaining[written..];
+    }
+}
+
+fn writePidFile(path: []const u8) !void {
+    var threaded = std.Io.Threaded.init_single_threaded;
+    const io = threaded.io();
+    var file = if (std.fs.path.isAbsolute(path))
+        try std.Io.Dir.createFileAbsolute(io, path, .{})
+    else
+        try std.Io.Dir.cwd().createFile(io, path, .{});
+    defer file.close(threaded.io());
+    var buffer: [64]u8 = undefined;
+    const text = try std.fmt.bufPrint(&buffer, "{d}\n", .{std.c.getpid()});
+    var write_buffer: [64]u8 = undefined;
+    var writer = file.writer(threaded.io(), &write_buffer);
+    try writer.interface.writeAll(text);
+    try writer.interface.flush();
+}
+
+fn deleteSocketPath(path: []const u8) void {
+    var threaded = std.Io.Threaded.init_single_threaded;
+    deleteFilePath(threaded.io(), path);
+}
+
+fn deleteFilePath(io: std.Io, path: []const u8) void {
+    if (std.fs.path.isAbsolute(path)) {
+        std.Io.Dir.deleteFileAbsolute(io, path) catch {};
+    } else {
+        std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    }
+}
+
+fn appendSafeComponent(allocator: std.mem.Allocator, out: *std.ArrayList(u8), value: []const u8) !void {
+    var previous_was_underscore = false;
+    for (value) |byte| {
+        const safe = isSafeIdByte(byte);
+        const next = if (safe) byte else '_';
+        if (next == '_') {
+            if (previous_was_underscore) continue;
+            previous_was_underscore = true;
+        } else {
+            previous_was_underscore = false;
+        }
+        try out.append(allocator, next);
+    }
+    while (out.items.len > 0 and out.items[out.items.len - 1] == '_') {
+        out.shrinkRetainingCapacity(out.items.len - 1);
+    }
+}
+
+fn isSafeIdByte(byte: u8) bool {
+    return (byte >= 'a' and byte <= 'z') or
+        (byte >= 'A' and byte <= 'Z') or
+        (byte >= '0' and byte <= '9') or
+        byte == '-' or
+        byte == '_' or
+        byte == '.';
+}
+
+test "stable session id sanitizes project id" {
+    const allocator = std.testing.allocator;
+    const session_id = try stableSessionId(allocator, "my project:/tmp/repo", 2, 9);
+    defer allocator.free(session_id);
+    try std.testing.expectEqualStrings("verde:my_project_tmp_repo:dock:2:pane:9", session_id);
+}
+
+test "session id for leaf preserves existing id" {
+    const allocator = std.testing.allocator;
+    const session_id = (try sessionIdForLeaf(
+        allocator,
+        .{ .project_id = "project-a", .dock_id = 0 },
+        4,
+        "custom-session",
+    )).?;
+    defer allocator.free(session_id);
+    try std.testing.expectEqualStrings("custom-session", session_id);
+}
+
+test "sessionizer socket paths use Verde pref path" {
+    const allocator = std.testing.allocator;
+    const socket = try socketPath(allocator, "/tmp/verde");
+    defer allocator.free(socket);
+    try std.testing.expect(std.mem.endsWith(u8, socket, "/tmp/verde/" ++ SOCKET_NAME));
+}

--- a/packages/desktop/src/terminal/sessionizer.zig
+++ b/packages/desktop/src/terminal/sessionizer.zig
@@ -163,8 +163,9 @@ pub fn requestAlloc(
     try writer.interface.writeByte('\n');
     try writer.interface.flush();
 
-    var read_buffer: [256 * 1024]u8 = undefined;
-    var reader = stream.reader(io, &read_buffer);
+    const read_buffer = try allocator.alloc(u8, 8 * 1024 * 1024);
+    defer allocator.free(read_buffer);
+    var reader = stream.reader(io, read_buffer);
     const line = try reader.interface.takeDelimiter('\n') orelse return error.ConnectionAborted;
     return try allocator.dupe(u8, std.mem.trim(u8, line, "\r"));
 }
@@ -716,16 +717,18 @@ pub const Daemon = struct {
         touchAttachFromParams(session, params);
         const lines = jsonU32(params.object.get("lines") orelse .null) orelse if (screen) DEFAULT_ROWS else 80;
         const start_offset = jsonUsize(params.object.get("offset") orelse .null);
-        const text = if (start_offset) |offset|
-            try bytesFromOffset(self.allocator, session.output_ring.items, offset)
+        const max_bytes = jsonUsize(params.object.get("max_bytes") orelse .null);
+        const text_range = if (start_offset) |offset|
+            bytesRangeFromOffset(session.output_ring.items, offset, max_bytes)
         else
-            try tailLines(self.allocator, session.output_ring.items, lines);
+            bytesRangeForTailLines(session.output_ring.items, lines, max_bytes);
+        const text = try self.allocator.dupe(u8, session.output_ring.items[text_range.start..text_range.end]);
         defer self.allocator.free(text);
         return try okValueResponse(self.allocator, id_value, .{
             .id = session.session_id,
             .running = session.running,
             .text = text,
-            .offset = start_offset orelse 0,
+            .offset = text_range.start,
             .next_offset = session.output_ring.items.len,
         });
     }
@@ -1083,6 +1086,34 @@ fn tailLines(allocator: std.mem.Allocator, bytes: []const u8, lines: u32) ![]u8 
     }
     if (start < bytes.len and bytes[start] == '\n') start += 1;
     return allocator.dupe(u8, bytes[start..]);
+}
+
+const ByteRange = struct {
+    start: usize,
+    end: usize,
+};
+
+fn bytesRangeFromOffset(bytes: []const u8, offset: usize, max_bytes: ?usize) ByteRange {
+    var start = @min(offset, bytes.len);
+    if (max_bytes) |limit| {
+        if (limit > 0 and bytes.len - start > limit) start = bytes.len - limit;
+    }
+    return .{ .start = start, .end = bytes.len };
+}
+
+fn bytesRangeForTailLines(bytes: []const u8, lines: u32, max_bytes: ?usize) ByteRange {
+    if (bytes.len == 0 or lines == 0) return .{ .start = bytes.len, .end = bytes.len };
+    var remaining = lines;
+    var start = bytes.len;
+    while (start > 0 and remaining > 0) {
+        start -= 1;
+        if (bytes[start] == '\n') remaining -= 1;
+    }
+    if (start < bytes.len and bytes[start] == '\n') start += 1;
+    if (max_bytes) |limit| {
+        if (limit > 0 and bytes.len - start > limit) start = bytes.len - limit;
+    }
+    return .{ .start = start, .end = bytes.len };
 }
 
 fn bytesFromOffset(allocator: std.mem.Allocator, bytes: []const u8, offset: usize) ![]u8 {

--- a/packages/desktop/src/terminal/terminal.zig
+++ b/packages/desktop/src/terminal/terminal.zig
@@ -588,7 +588,6 @@ pub const Dock = struct {
     pub fn closeTab(self: *Dock, allocator: std.mem.Allocator, index: usize) !void {
         if (index >= self.tabs.items.len) return;
         var removed = self.tabs.orderedRemove(index);
-        terminatePaneNodeSessions(removed.root);
         removed.deinit(allocator);
         if (self.tabs.items.len == 0) {
             try self.tabs.append(allocator, try self.buildSinglePaneTab(allocator));
@@ -1063,7 +1062,6 @@ fn removePaneFromTree(allocator: std.mem.Allocator, root: **PaneNode, pane_id: u
         .split => |*split| {
             if (paneNodeContains(split.first, pane_id)) {
                 if (split.first.* == .leaf and split.first.leaf.id == pane_id) {
-                    terminatePaneNodeSessions(split.first);
                     deinitPaneNode(split.first, allocator);
                     const sibling = split.second;
                     allocator.destroy(node);
@@ -1074,7 +1072,6 @@ fn removePaneFromTree(allocator: std.mem.Allocator, root: **PaneNode, pane_id: u
             }
             if (paneNodeContains(split.second, pane_id)) {
                 if (split.second.* == .leaf and split.second.leaf.id == pane_id) {
-                    terminatePaneNodeSessions(split.second);
                     deinitPaneNode(split.second, allocator);
                     const sibling = split.first;
                     allocator.destroy(node);
@@ -1410,9 +1407,11 @@ const UnixSession = struct {
     cell_height: u32,
     running: bool = true,
     exit_status: ?u32 = null,
+    daemon_state: DaemonState = .attached,
     launch_kind: TerminalLaunchKind = .shell,
     launch_label: []u8,
     session_id: ?[]u8 = null,
+    attach_id: ?[]u8 = null,
     pref_path: ?[]u8 = null,
     remote_output_offset: usize = 0,
     output_ring: std.ArrayList(u8) = .empty,
@@ -1420,6 +1419,12 @@ const UnixSession = struct {
     const Backend = enum {
         local,
         daemon,
+    };
+
+    const DaemonState = enum {
+        attached,
+        missing,
+        unavailable,
     };
 
     const SpawnResult = struct {
@@ -1474,6 +1479,7 @@ const UnixSession = struct {
             self.stream.handler.effects.color_scheme = &UnixSession.streamColorScheme;
             errdefer self.stream.deinit();
             errdefer if (self.session_id) |session_id| allocator.free(session_id);
+            errdefer if (self.attach_id) |attach_id| allocator.free(attach_id);
             errdefer if (self.pref_path) |pref_path| allocator.free(pref_path);
 
             try self.attachDaemonSession(allocator, options);
@@ -1519,11 +1525,13 @@ const UnixSession = struct {
         }
         if (self.backend == .local) _ = std.c.close(self.master_fd);
         _ = self.captureExitStatus();
+        if (self.backend == .daemon) self.detachDaemon(allocator);
         self.stream.deinit();
         self.render_state.deinit(allocator);
         self.terminal.deinit(allocator);
         allocator.free(self.launch_label);
         if (self.session_id) |session_id| allocator.free(session_id);
+        if (self.attach_id) |attach_id| allocator.free(attach_id);
         if (self.pref_path) |pref_path| allocator.free(pref_path);
         self.output_ring.deinit(allocator);
     }
@@ -1582,6 +1590,13 @@ const UnixSession = struct {
     pub fn statusText(self: *const UnixSession, buf: *[192]u8) []const u8 {
         if (self.running) {
             return std.fmt.bufPrint(buf, "{d}x{d} {s} attached", .{ self.cols, self.rows, self.launch_label }) catch "Terminal attached";
+        }
+        if (self.backend == .daemon) {
+            switch (self.daemon_state) {
+                .attached => {},
+                .missing => return std.fmt.bufPrint(buf, "{s} session missing. Restart or attach another session.", .{self.launch_label}) catch "Terminal session missing.",
+                .unavailable => return "Terminal session daemon unavailable. Session may still be running.",
+            }
         }
         if (self.exit_status) |status| {
             if (std.c.W.IFEXITED(status)) {
@@ -1808,6 +1823,13 @@ const UnixSession = struct {
             try ensureSessionResponseOk(allocator, create_response);
         }
 
+        const attach_response = try sessionizer.requestAlloc(allocator, pref_path, "session.attach", .{
+            .id = session_id,
+            .label = "verde-ui",
+        }, 1);
+        defer allocator.free(attach_response);
+        self.attach_id = try sessionResultStringAlloc(allocator, attach_response, "attach_id");
+
         try self.resizeDaemon(allocator);
         _ = try self.drainDaemonOutput(allocator);
     }
@@ -1817,9 +1839,11 @@ const UnixSession = struct {
         const session_id = self.session_id orelse return false;
         const response = sessionizer.requestAlloc(allocator, pref_path, "session.tail", .{
             .id = session_id,
+            .attach_id = self.attach_id orelse "",
             .offset = self.remote_output_offset,
         }, 1) catch |err| {
             log.debug("failed to poll daemon terminal session {s}: {s}", .{ session_id, @errorName(err) });
+            self.daemon_state = .unavailable;
             self.running = false;
             return false;
         };
@@ -1829,6 +1853,7 @@ const UnixSession = struct {
         defer parsed.deinit();
         if (parsed.value != .object) return error.InvalidSessionResponse;
         if (parsed.value.object.get("error")) |_| {
+            self.daemon_state = .missing;
             self.running = false;
             return false;
         }
@@ -1837,6 +1862,7 @@ const UnixSession = struct {
         const text = jsonString(result.object.get("text") orelse .null) orelse "";
         self.remote_output_offset = jsonUsize(result.object.get("next_offset") orelse .null) orelse self.remote_output_offset;
         self.running = jsonBool(result.object.get("running") orelse .null) orelse self.running;
+        self.daemon_state = .attached;
         if (text.len == 0) return false;
         try self.appendOutput(allocator, text);
         self.stream.nextSlice(text);
@@ -1849,6 +1875,7 @@ const UnixSession = struct {
         const session_id = self.session_id orelse return;
         const response = try sessionizer.requestAlloc(allocator, pref_path, "session.resize", .{
             .id = session_id,
+            .attach_id = self.attach_id orelse "",
             .cols = self.cols,
             .rows = self.rows,
         }, 1);
@@ -1872,10 +1899,22 @@ const UnixSession = struct {
         const session_id = self.session_id orelse return false;
         const response = try sessionizer.requestAlloc(std.heap.smp_allocator, pref_path, "session.write", .{
             .id = session_id,
+            .attach_id = self.attach_id orelse "",
             .text = bytes,
         }, 1);
         defer std.heap.smp_allocator.free(response);
         return true;
+    }
+
+    fn detachDaemon(self: *UnixSession, allocator: std.mem.Allocator) void {
+        const pref_path = self.pref_path orelse return;
+        const session_id = self.session_id orelse return;
+        const attach_id = self.attach_id orelse return;
+        const response = sessionizer.requestAlloc(allocator, pref_path, "session.detach", .{
+            .id = session_id,
+            .attach_id = attach_id,
+        }, 1) catch return;
+        allocator.free(response);
     }
 
     fn appendOutput(self: *UnixSession, allocator: std.mem.Allocator, bytes: []const u8) !void {
@@ -2337,6 +2376,17 @@ fn ensureSessionResponseOk(allocator: std.mem.Allocator, response: []const u8) !
     defer parsed.deinit();
     if (parsed.value != .object) return error.InvalidSessionResponse;
     if (parsed.value.object.get("error")) |_| return error.SessionRequestFailed;
+}
+
+fn sessionResultStringAlloc(allocator: std.mem.Allocator, response: []const u8, field: []const u8) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, response, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidSessionResponse;
+    if (parsed.value.object.get("error")) |_| return error.SessionRequestFailed;
+    const result = parsed.value.object.get("result") orelse return error.InvalidSessionResponse;
+    if (result != .object) return error.InvalidSessionResponse;
+    const text = jsonString(result.object.get(field) orelse .null) orelse return error.InvalidSessionResponse;
+    return try allocator.dupe(u8, text);
 }
 
 fn jsonString(value: std.json.Value) ?[]const u8 {
@@ -2876,6 +2926,35 @@ test "focus adjacent pane uses split direction" {
     try std.testing.expectEqual(left_id, dock.activePaneConst().?.id);
     try std.testing.expect(try dock.focusAdjacentPane(allocator, .right));
     try std.testing.expectEqual(right_id, dock.activePaneConst().?.id);
+}
+
+test "persisted layout accepts leaves without session metadata" {
+    const allocator = std.testing.allocator;
+    var dock = try Dock.init(allocator);
+    defer dock.deinit(allocator);
+
+    const old_layout_json =
+        \\{
+        \\  "active_tab_index": 0,
+        \\  "tabs": [{
+        \\    "title": "old",
+        \\    "active_pane_id": 7,
+        \\    "root_node_id": 1,
+        \\    "nodes": [{
+        \\      "node_id": 1,
+        \\      "kind": "leaf",
+        \\      "pane_id": 7
+        \\    }]
+        \\  }]
+        \\}
+    ;
+
+    try dock.applyPersistedLayoutJson(allocator, old_layout_json);
+    const pane = dock.activePaneConst().?;
+    try std.testing.expectEqual(@as(u32, 7), pane.id);
+    try std.testing.expectEqual(@as(?[]u8, null), pane.session_id);
+    try std.testing.expectEqual(@as(?TerminalLaunchKind, null), pane.launch_kind);
+    try std.testing.expectEqual(TerminalRevivePolicy.attach_or_create, pane.revive_policy);
 }
 
 test "unix session PTY smoke" {

--- a/packages/desktop/src/terminal/terminal.zig
+++ b/packages/desktop/src/terminal/terminal.zig
@@ -1823,12 +1823,20 @@ const UnixSession = struct {
             try ensureSessionResponseOk(allocator, create_response);
         }
 
-        const attach_response = try sessionizer.requestAlloc(allocator, pref_path, "session.attach", .{
+        const attach_response = sessionizer.requestAlloc(allocator, pref_path, "session.attach", .{
             .id = session_id,
             .label = "verde-ui",
-        }, 1);
-        defer allocator.free(attach_response);
-        self.attach_id = try sessionResultStringAlloc(allocator, attach_response, "attach_id");
+        }, 1) catch |err| blk: {
+            log.debug("daemon terminal session {s} does not support attach registration: {s}", .{ session_id, @errorName(err) });
+            break :blk null;
+        };
+        if (attach_response) |response| {
+            defer allocator.free(response);
+            self.attach_id = sessionResultStringAlloc(allocator, response, "attach_id") catch |err| blk: {
+                log.debug("daemon terminal session {s} attach registration failed: {s}", .{ session_id, @errorName(err) });
+                break :blk null;
+            };
+        }
 
         try self.resizeDaemon(allocator);
         _ = try self.drainDaemonOutput(allocator);

--- a/packages/desktop/src/terminal/terminal.zig
+++ b/packages/desktop/src/terminal/terminal.zig
@@ -29,6 +29,7 @@ const WHEEL_SCROLL_LINES: f32 = 3.0;
 const KEY_SCROLL_LINES: isize = 3;
 const OUTPUT_RING_CAPACITY: usize = 256 * 1024;
 const DAEMON_REPLAY_MAX_BYTES: usize = 512 * 1024;
+const LOCAL_TERMINAL_VIEW_RESET = "\x1b[?1049l\x1b[?1047l\x1b[?47l\x1b[0m\x1b[2J\x1b[H";
 pub const DEFAULT_FONT_SIZE: f32 = @floatFromInt(CELL_PIXEL_HEIGHT);
 // Darwin exposes the winsize setter under the BSD ioctl value, not std.c.T.IOCSWINSZ.
 const TERMINAL_WINSIZE_IOCTL: c_int = switch (builtin.os.tag) {
@@ -1888,10 +1889,21 @@ const UnixSession = struct {
         if (result != .object) return error.InvalidSessionResponse;
         const text = jsonString(result.object.get("text") orelse .null) orelse "";
         const suppress_replay_responses = self.suppress_next_daemon_replay and self.remote_output_offset == 0;
+        const child_process_count = jsonUsize(result.object.get("child_process_count") orelse .null);
+        const stale_alt_screen_replay = suppress_replay_responses and
+            child_process_count != null and
+            child_process_count.? == 0 and
+            looksLikeStaleFullScreenReplay(text);
         self.remote_output_offset = jsonUsize(result.object.get("next_offset") orelse .null) orelse self.remote_output_offset;
         self.suppress_next_daemon_replay = false;
         self.running = jsonBool(result.object.get("running") orelse .null) orelse self.running;
         self.daemon_state = .attached;
+        if (stale_alt_screen_replay) {
+            self.resetLocalTerminalView(allocator) catch |err| {
+                log.warn("failed to reset stale daemon terminal replay for {s}: {s}", .{ session_id, @errorName(err) });
+            };
+            return true;
+        }
         if (text.len == 0) return false;
         try self.appendOutput(allocator, text);
         const previous_suppression = self.suppress_pty_responses;
@@ -1900,6 +1912,14 @@ const UnixSession = struct {
         self.stream.nextSlice(text);
         try self.repairTerminalState(allocator);
         return true;
+    }
+
+    fn resetLocalTerminalView(self: *UnixSession, allocator: std.mem.Allocator) !void {
+        const previous_suppression = self.suppress_pty_responses;
+        self.suppress_pty_responses = true;
+        defer self.suppress_pty_responses = previous_suppression;
+        self.stream.nextSlice(LOCAL_TERMINAL_VIEW_RESET);
+        try self.repairTerminalState(allocator);
     }
 
     fn resizeDaemon(self: *UnixSession, allocator: std.mem.Allocator) !void {
@@ -2457,6 +2477,53 @@ fn jsonUsize(value: std.json.Value) ?usize {
         .number_string => |text| std.fmt.parseInt(usize, text, 10) catch null,
         else => null,
     };
+}
+
+fn looksLikeStaleFullScreenReplay(bytes: []const u8) bool {
+    if (hasUnclosedAlternateScreen(bytes)) return true;
+    if (bytes.len < DAEMON_REPLAY_MAX_BYTES) return false;
+
+    var csi_count: usize = 0;
+    var newline_count: usize = 0;
+    var index: usize = 0;
+    while (index < bytes.len) : (index += 1) {
+        if (bytes[index] == '\n') newline_count += 1;
+        if (bytes[index] == 0x1b and index + 1 < bytes.len and bytes[index + 1] == '[') csi_count += 1;
+    }
+    return csi_count >= 256 and newline_count * 8 < csi_count;
+}
+
+fn hasUnclosedAlternateScreen(bytes: []const u8) bool {
+    const enter = maxOptionalIndex(&.{
+        lastIndexOf(bytes, "\x1b[?1049h"),
+        lastIndexOf(bytes, "\x1b[?1047h"),
+        lastIndexOf(bytes, "\x1b[?47h"),
+    });
+    const leave = maxOptionalIndex(&.{
+        lastIndexOf(bytes, "\x1b[?1049l"),
+        lastIndexOf(bytes, "\x1b[?1047l"),
+        lastIndexOf(bytes, "\x1b[?47l"),
+    });
+    return if (enter) |enter_index| leave == null or enter_index > leave.? else false;
+}
+
+fn maxOptionalIndex(values: []const ?usize) ?usize {
+    var result: ?usize = null;
+    for (values) |value| {
+        const index = value orelse continue;
+        if (result == null or index > result.?) result = index;
+    }
+    return result;
+}
+
+fn lastIndexOf(haystack: []const u8, needle: []const u8) ?usize {
+    var result: ?usize = null;
+    var start: usize = 0;
+    while (std.mem.indexOfPos(u8, haystack, start, needle)) |index| {
+        result = index;
+        start = index + 1;
+    }
+    return result;
 }
 
 fn selfExePathAlloc(allocator: std.mem.Allocator) ![]u8 {

--- a/packages/desktop/src/terminal/terminal.zig
+++ b/packages/desktop/src/terminal/terminal.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const sdl = @import("zsdl3");
 const ghostty_vt = @import("../vendor/ghostty_vt.zig");
 const keybinds = @import("../keybinds.zig");
+pub const sessionizer = @import("sessionizer.zig");
 const theme = @import("../ui/theme.zig");
 
 const log = std.log.scoped(.native_terminal);
@@ -45,6 +46,7 @@ const ColorScheme = std.meta.Child(
 );
 extern "c" fn setenv(name: [*:0]const u8, value: [*:0]const u8, overwrite: c_int) c_int;
 extern "c" fn unsetenv(name: [*:0]const u8) c_int;
+extern "c" fn _NSGetExecutablePath(buf: [*]u8, bufsize: *u32) c_int;
 
 const Session = if (SESSION_SUPPORTED) UnixSession else UnsupportedSession;
 pub const MIN_SPLIT_RATIO: f32 = 0.12;
@@ -76,6 +78,8 @@ pub const TerminalLaunchProfile = struct {
     command: []const []const u8 = &.{},
 };
 
+pub const TerminalRevivePolicy = sessionizer.RevivePolicy;
+
 pub const SessionSnapshot = struct {
     running: bool,
     exit_code: ?u32 = null,
@@ -87,6 +91,13 @@ const SessionCreateOptions = struct {
     cols: u16,
     rows: u16,
     profile: TerminalLaunchProfile = .{},
+    session_id: ?[]const u8 = null,
+    pref_path: ?[]const u8 = null,
+    project_id: []const u8 = "",
+    project_path: []const u8 = "",
+    dock_id: u32 = 0,
+    pane_id: u32 = 0,
+    revive_policy: TerminalRevivePolicy = .attach_or_create,
 };
 
 pub const PersistedWorkspace = struct {
@@ -111,6 +122,11 @@ pub const PersistedNode = struct {
     node_id: u32,
     kind: PersistedNodeKind,
     pane_id: u32 = 0,
+    session_id: ?[]const u8 = null,
+    launch_kind: ?TerminalLaunchKind = null,
+    launch_label: ?[]const u8 = null,
+    launch_command: []const []const u8 = &.{},
+    revive_policy: ?TerminalRevivePolicy = null,
     axis: ?SplitAxis = null,
     ratio: ?f32 = null,
     first_node_id: ?u32 = null,
@@ -120,6 +136,11 @@ pub const PersistedNode = struct {
 pub const PaneLeaf = struct {
     id: u32,
     session: ?*Session = null,
+    session_id: ?[]u8 = null,
+    launch_kind: ?TerminalLaunchKind = null,
+    launch_label: ?[]u8 = null,
+    launch_command: []const []const u8 = &.{},
+    revive_policy: TerminalRevivePolicy = .attach_or_create,
 };
 
 pub const PaneSplit = struct {
@@ -164,6 +185,8 @@ pub const Dock = struct {
     preferred_height: f32 = DEFAULT_DOCK_HEIGHT,
     font_scale: f32 = DEFAULT_FONT_SCALE,
     cwd: ?[]u8 = null,
+    pref_path: ?[]u8 = null,
+    session_dock_id: u32 = 0,
     tabs: std.ArrayList(Tab) = .empty,
     active_tab_index: usize = 0,
     next_tab_id: u32 = 1,
@@ -186,6 +209,10 @@ pub const Dock = struct {
         if (self.cwd) |cwd| {
             allocator.free(cwd);
             self.cwd = null;
+        }
+        if (self.pref_path) |pref_path| {
+            allocator.free(pref_path);
+            self.pref_path = null;
         }
         for (self.tabs.items) |*tab| {
             tab.deinit(allocator);
@@ -223,6 +250,26 @@ pub const Dock = struct {
     }
 
     pub fn ensureSession(self: *Dock, allocator: std.mem.Allocator, project_path: []const u8) !void {
+        try self.ensureSessionWithContext(allocator, project_path, null, self.session_dock_id);
+    }
+
+    pub fn ensureSessionPersistent(
+        self: *Dock,
+        allocator: std.mem.Allocator,
+        project_path: []const u8,
+        pref_path: []const u8,
+        dock_id: u32,
+    ) !void {
+        try self.ensureSessionWithContext(allocator, project_path, pref_path, dock_id);
+    }
+
+    fn ensureSessionWithContext(
+        self: *Dock,
+        allocator: std.mem.Allocator,
+        project_path: []const u8,
+        pref_path: ?[]const u8,
+        dock_id: u32,
+    ) !void {
         const cwd_changed = if (self.cwd) |cwd|
             !std.mem.eql(u8, cwd, project_path)
         else
@@ -233,12 +280,58 @@ pub const Dock = struct {
             self.cwd = try allocator.dupe(u8, project_path);
         }
 
+        self.session_dock_id = dock_id;
+        if (pref_path) |path| {
+            const pref_changed = if (self.pref_path) |existing|
+                !std.mem.eql(u8, existing, path)
+            else
+                true;
+            if (pref_changed) {
+                if (self.pref_path) |existing| allocator.free(existing);
+                self.pref_path = try allocator.dupe(u8, path);
+            }
+        }
+
         try self.ensureWorkspace(allocator);
     }
 
     pub fn restartWithProfile(self: *Dock, allocator: std.mem.Allocator, cwd: []const u8, profile: TerminalLaunchProfile) !void {
+        try self.restartWithProfileContext(allocator, cwd, profile, null, self.session_dock_id);
+    }
+
+    pub fn restartWithProfilePersistent(
+        self: *Dock,
+        allocator: std.mem.Allocator,
+        cwd: []const u8,
+        profile: TerminalLaunchProfile,
+        pref_path: []const u8,
+        dock_id: u32,
+    ) !void {
+        try self.restartWithProfileContext(allocator, cwd, profile, pref_path, dock_id);
+    }
+
+    fn restartWithProfileContext(
+        self: *Dock,
+        allocator: std.mem.Allocator,
+        cwd: []const u8,
+        profile: TerminalLaunchProfile,
+        pref_path: ?[]const u8,
+        dock_id: u32,
+    ) !void {
         if (self.cwd) |old_cwd| allocator.free(old_cwd);
         self.cwd = try allocator.dupe(u8, cwd);
+        self.session_dock_id = dock_id;
+        if (pref_path) |path| {
+            const pref_changed = if (self.pref_path) |existing|
+                !std.mem.eql(u8, existing, path)
+            else
+                true;
+            if (pref_changed) {
+                if (self.pref_path) |existing| allocator.free(existing);
+                self.pref_path = try allocator.dupe(u8, path);
+            }
+        }
+        for (self.tabs.items) |*tab| terminatePaneNodeSessions(tab.root);
         self.clearTabs(allocator);
 
         const previous_profile = self.launch_profile;
@@ -495,6 +588,7 @@ pub const Dock = struct {
     pub fn closeTab(self: *Dock, allocator: std.mem.Allocator, index: usize) !void {
         if (index >= self.tabs.items.len) return;
         var removed = self.tabs.orderedRemove(index);
+        terminatePaneNodeSessions(removed.root);
         removed.deinit(allocator);
         if (self.tabs.items.len == 0) {
             try self.tabs.append(allocator, try self.buildSinglePaneTab(allocator));
@@ -591,6 +685,14 @@ pub const Dock = struct {
     }
 
     pub fn persistedLayoutJson(self: *const Dock, allocator: std.mem.Allocator) !?[]u8 {
+        return self.persistedLayoutJsonWithContext(allocator, null);
+    }
+
+    pub fn persistedLayoutJsonWithContext(
+        self: *const Dock,
+        allocator: std.mem.Allocator,
+        context: ?sessionizer.LayoutContext,
+    ) !?[]u8 {
         if (self.tabs.items.len == 0) return null;
 
         var arena = std.heap.ArenaAllocator.init(allocator);
@@ -604,7 +706,7 @@ pub const Dock = struct {
             var nodes: std.ArrayList(PersistedNode) = .empty;
             defer nodes.deinit(arena_allocator);
             var next_node_id: u32 = 1;
-            const root_node_id = try serializePaneNode(arena_allocator, tab.root, &nodes, &next_node_id);
+            const root_node_id = try serializePaneNode(arena_allocator, tab.root, &nodes, &next_node_id, context);
             try persisted_tabs.append(arena_allocator, .{
                 .title = if (tab.title) |tab_title| try arena_allocator.dupe(u8, tab_title) else null,
                 .active_pane_id = tab.active_pane_id,
@@ -703,11 +805,39 @@ pub const Dock = struct {
     fn ensureLeafSession(self: *Dock, allocator: std.mem.Allocator, leaf: *PaneLeaf) !void {
         if (leaf.session != null) return;
         const cwd = self.cwd orelse return;
+
+        const profile = TerminalLaunchProfile{
+            .kind = leaf.launch_kind orelse self.launch_profile.kind,
+            .label = if (leaf.launch_label) |label| label else self.launch_profile.label,
+            .command = if (leaf.launch_command.len > 0) leaf.launch_command else self.launch_profile.command,
+        };
+        if (leaf.launch_kind == null) leaf.launch_kind = profile.kind;
+        if (leaf.launch_label == null and profile.label.len > 0) {
+            leaf.launch_label = try allocator.dupe(u8, profile.label);
+        }
+        if (leaf.launch_command.len == 0 and profile.command.len > 0) {
+            leaf.launch_command = try dupeStringSlice(allocator, profile.command);
+        }
+        if (self.pref_path != null and leaf.session_id == null) {
+            leaf.session_id = try sessionizer.stableSessionId(
+                allocator,
+                cwd,
+                self.session_dock_id,
+                leaf.id,
+            );
+        }
         leaf.session = try Session.create(allocator, .{
             .cwd = cwd,
             .cols = INITIAL_COLS,
             .rows = INITIAL_ROWS,
-            .profile = self.launch_profile,
+            .profile = profile,
+            .session_id = leaf.session_id,
+            .pref_path = self.pref_path,
+            .project_id = cwd,
+            .project_path = cwd,
+            .dock_id = self.session_dock_id,
+            .pane_id = leaf.id,
+            .revive_policy = leaf.revive_policy,
         });
     }
 
@@ -814,11 +944,7 @@ pub const Dock = struct {
 fn deinitPaneNode(node: *PaneNode, allocator: std.mem.Allocator) void {
     switch (node.*) {
         .leaf => |*leaf| {
-            if (leaf.session) |session| {
-                session.deinit(allocator);
-                allocator.destroy(session);
-                leaf.session = null;
-            }
+            deinitPaneLeaf(leaf, allocator);
             allocator.destroy(node);
         },
         .split => |*split| {
@@ -827,6 +953,36 @@ fn deinitPaneNode(node: *PaneNode, allocator: std.mem.Allocator) void {
             allocator.destroy(node);
         },
     }
+}
+
+fn terminatePaneNodeSessions(node: *PaneNode) void {
+    switch (node.*) {
+        .leaf => |*leaf| {
+            if (leaf.session) |session| _ = session.terminate();
+        },
+        .split => |*split| {
+            terminatePaneNodeSessions(split.first);
+            terminatePaneNodeSessions(split.second);
+        },
+    }
+}
+
+fn deinitPaneLeaf(leaf: *PaneLeaf, allocator: std.mem.Allocator) void {
+    if (leaf.session) |session| {
+        session.deinit(allocator);
+        allocator.destroy(session);
+        leaf.session = null;
+    }
+    if (leaf.session_id) |session_id| {
+        allocator.free(session_id);
+        leaf.session_id = null;
+    }
+    if (leaf.launch_label) |launch_label| {
+        allocator.free(launch_label);
+        leaf.launch_label = null;
+    }
+    freeStringSlice(allocator, leaf.launch_command);
+    leaf.launch_command = &.{};
 }
 
 fn pollPaneNode(node: *PaneNode, allocator: std.mem.Allocator) !bool {
@@ -907,6 +1063,7 @@ fn removePaneFromTree(allocator: std.mem.Allocator, root: **PaneNode, pane_id: u
         .split => |*split| {
             if (paneNodeContains(split.first, pane_id)) {
                 if (split.first.* == .leaf and split.first.leaf.id == pane_id) {
+                    terminatePaneNodeSessions(split.first);
                     deinitPaneNode(split.first, allocator);
                     const sibling = split.second;
                     allocator.destroy(node);
@@ -917,6 +1074,7 @@ fn removePaneFromTree(allocator: std.mem.Allocator, root: **PaneNode, pane_id: u
             }
             if (paneNodeContains(split.second, pane_id)) {
                 if (split.second.* == .leaf and split.second.leaf.id == pane_id) {
+                    terminatePaneNodeSessions(split.second);
                     deinitPaneNode(split.second, allocator);
                     const sibling = split.first;
                     allocator.destroy(node);
@@ -1066,21 +1224,35 @@ fn serializePaneNode(
     node: *const PaneNode,
     nodes: *std.ArrayList(PersistedNode),
     next_node_id: *u32,
+    context: ?sessionizer.LayoutContext,
 ) !u32 {
     const node_id = next_node_id.*;
     next_node_id.* += 1;
 
     switch (node.*) {
         .leaf => |leaf| {
+            const session_id = try sessionizer.sessionIdForLeaf(allocator, context, leaf.id, leaf.session_id);
+            const launch_kind: ?TerminalLaunchKind = leaf.launch_kind orelse if (leaf.session) |session| session.launch_kind else null;
+            const launch_label: ?[]const u8 = if (leaf.launch_label) |label|
+                try allocator.dupe(u8, label)
+            else if (leaf.session) |session|
+                try allocator.dupe(u8, session.launch_label)
+            else
+                null;
             try nodes.append(allocator, .{
                 .node_id = node_id,
                 .kind = .leaf,
                 .pane_id = leaf.id,
+                .session_id = session_id,
+                .launch_kind = launch_kind,
+                .launch_label = launch_label,
+                .launch_command = try dupeStringSlice(allocator, leaf.launch_command),
+                .revive_policy = leaf.revive_policy,
             });
         },
         .split => |split| {
-            const first_node_id = try serializePaneNode(allocator, split.first, nodes, next_node_id);
-            const second_node_id = try serializePaneNode(allocator, split.second, nodes, next_node_id);
+            const first_node_id = try serializePaneNode(allocator, split.first, nodes, next_node_id, context);
+            const second_node_id = try serializePaneNode(allocator, split.second, nodes, next_node_id, context);
             try nodes.append(allocator, .{
                 .node_id = node_id,
                 .kind = .split,
@@ -1108,7 +1280,15 @@ fn buildPaneNodeFromPersisted(
         switch (persisted.kind) {
             .leaf => {
                 max_pane_id.* = @max(max_pane_id.*, persisted.pane_id);
-                node.* = .{ .leaf = .{ .id = @max(persisted.pane_id, 1), .session = null } };
+                node.* = .{ .leaf = .{
+                    .id = @max(persisted.pane_id, 1),
+                    .session = null,
+                    .session_id = if (persisted.session_id) |session_id| try allocator.dupe(u8, session_id) else null,
+                    .launch_kind = persisted.launch_kind,
+                    .launch_label = if (persisted.launch_label) |label| try allocator.dupe(u8, label) else null,
+                    .launch_command = try dupeStringSlice(allocator, persisted.launch_command),
+                    .revive_policy = persisted.revive_policy orelse .attach_or_create,
+                } };
             },
             .split => {
                 const first_id = persisted.first_node_id orelse return error.InvalidPersistedTerminalLayout;
@@ -1218,6 +1398,7 @@ const TerminalScroll = union(enum) {
 };
 
 const UnixSession = struct {
+    backend: Backend = .local,
     master_fd: std.posix.fd_t,
     child_pid: std.posix.pid_t,
     terminal: ghostty_vt.Terminal,
@@ -1231,7 +1412,15 @@ const UnixSession = struct {
     exit_status: ?u32 = null,
     launch_kind: TerminalLaunchKind = .shell,
     launch_label: []u8,
+    session_id: ?[]u8 = null,
+    pref_path: ?[]u8 = null,
+    remote_output_offset: usize = 0,
     output_ring: std.ArrayList(u8) = .empty,
+
+    const Backend = enum {
+        local,
+        daemon,
+    };
 
     const SpawnResult = struct {
         master_fd: std.posix.fd_t,
@@ -1260,6 +1449,38 @@ const UnixSession = struct {
         const launch_label = try launchLabel(allocator, options.profile);
         errdefer allocator.free(launch_label);
 
+        if (options.pref_path != null and options.session_id != null) {
+            self.* = .{
+                .backend = .daemon,
+                .master_fd = -1,
+                .child_pid = 0,
+                .terminal = terminal,
+                .stream = undefined,
+                .render_state = .empty,
+                .cols = options.cols,
+                .rows = options.rows,
+                .cell_width = CELL_PIXEL_WIDTH,
+                .cell_height = CELL_PIXEL_HEIGHT,
+                .launch_kind = options.profile.kind,
+                .launch_label = launch_label,
+                .session_id = try allocator.dupe(u8, options.session_id.?),
+                .pref_path = try allocator.dupe(u8, options.pref_path.?),
+            };
+            self.stream = self.terminal.vtStream();
+            self.stream.handler.effects.write_pty = &UnixSession.streamWritePty;
+            self.stream.handler.effects.device_attributes = &UnixSession.streamDeviceAttributes;
+            self.stream.handler.effects.size = &UnixSession.streamSize;
+            self.stream.handler.effects.xtversion = &UnixSession.streamXtVersion;
+            self.stream.handler.effects.color_scheme = &UnixSession.streamColorScheme;
+            errdefer self.stream.deinit();
+            errdefer if (self.session_id) |session_id| allocator.free(session_id);
+            errdefer if (self.pref_path) |pref_path| allocator.free(pref_path);
+
+            try self.attachDaemonSession(allocator, options);
+            try self.refreshRenderState(allocator);
+            return self;
+        }
+
         const child = try spawnCommand(allocator, options.cwd, options.cols, options.rows, options.profile);
         errdefer {
             std.posix.kill(child.child_pid, std.posix.SIG.TERM) catch {};
@@ -1267,6 +1488,7 @@ const UnixSession = struct {
         }
 
         self.* = .{
+            .backend = .local,
             .master_fd = child.master_fd,
             .child_pid = child.child_pid,
             .terminal = terminal,
@@ -1292,20 +1514,25 @@ const UnixSession = struct {
     }
 
     pub fn deinit(self: *UnixSession, allocator: std.mem.Allocator) void {
-        if (self.running) {
+        if (self.backend == .local and self.running) {
             std.posix.kill(self.child_pid, std.posix.SIG.TERM) catch {};
         }
-        _ = std.c.close(self.master_fd);
+        if (self.backend == .local) _ = std.c.close(self.master_fd);
         _ = self.captureExitStatus();
         self.stream.deinit();
         self.render_state.deinit(allocator);
         self.terminal.deinit(allocator);
         allocator.free(self.launch_label);
+        if (self.session_id) |session_id| allocator.free(session_id);
+        if (self.pref_path) |pref_path| allocator.free(pref_path);
         self.output_ring.deinit(allocator);
     }
 
     pub fn poll(self: *UnixSession, allocator: std.mem.Allocator) !bool {
-        const changed = try self.drainOutput(allocator);
+        const changed = switch (self.backend) {
+            .local => try self.drainOutput(allocator),
+            .daemon => try self.drainDaemonOutput(allocator),
+        };
         const exited = self.captureExitStatus();
         if (changed or exited) {
             try self.refreshRenderState(allocator);
@@ -1328,7 +1555,10 @@ const UnixSession = struct {
         if (size_changed) {
             try self.terminal.resize(allocator, next_cols, next_rows);
         }
-        self.applyWinsize();
+        switch (self.backend) {
+            .local => self.applyWinsize(),
+            .daemon => try self.resizeDaemon(allocator),
+        }
         try self.refreshRenderState(allocator);
     }
 
@@ -1366,7 +1596,7 @@ const UnixSession = struct {
 
     pub fn tabTitle(self: *const UnixSession, buffer: *[96]u8) []const u8 {
         if (self.launch_kind != .shell) return self.launch_label;
-        if (builtin.os.tag == .linux) {
+        if (self.backend == .local and builtin.os.tag == .linux) {
             var proc_path_buf: [64]u8 = undefined;
             const proc_path = std.fmt.bufPrint(&proc_path_buf, "/proc/{d}/cwd", .{self.child_pid}) catch "";
             if (proc_path.len > 0) {
@@ -1413,12 +1643,16 @@ const UnixSession = struct {
 
     pub fn writeInput(self: *UnixSession, bytes: []const u8) !bool {
         if (!self.running or bytes.len == 0) return false;
-        try writeAll(self.master_fd, bytes);
-        return true;
+        return try self.writeRawInput(bytes);
     }
 
     pub fn terminate(self: *UnixSession) bool {
         if (!self.running) return false;
+        if (self.backend == .daemon) {
+            self.killDaemon() catch return false;
+            self.running = false;
+            return true;
+        }
         std.posix.kill(self.child_pid, std.posix.SIG.TERM) catch return false;
         self.running = false;
         _ = self.captureExitStatus();
@@ -1457,8 +1691,7 @@ const UnixSession = struct {
         try ghostty_vt.input.encodeKey(&writer, key_event, options);
         const encoded = writer.buffered();
         if (encoded.len == 0) return true;
-        try writeAll(self.master_fd, encoded);
-        return true;
+        return try self.writeRawInput(encoded);
     }
 
     pub fn handleWheel(self: *UnixSession, allocator: std.mem.Allocator, wheel_y: f32) !bool {
@@ -1485,8 +1718,13 @@ const UnixSession = struct {
         const clipboard_text = std.mem.sliceTo(clipboard_ptr, 0);
         if (clipboard_text.len == 0) return false;
 
-        try writeTerminalPaste(allocator, self.master_fd, clipboard_text, self.terminal.modes.get(.bracketed_paste));
-        return true;
+        if (self.backend == .local) {
+            try writeTerminalPaste(allocator, self.master_fd, clipboard_text, self.terminal.modes.get(.bracketed_paste));
+            return true;
+        }
+        const encoded = try terminalPasteBytesAlloc(allocator, clipboard_text, self.terminal.modes.get(.bracketed_paste));
+        defer allocator.free(encoded);
+        return try self.writeRawInput(encoded);
     }
 
     pub fn copyScreenToClipboard(self: *UnixSession, allocator: std.mem.Allocator) !bool {
@@ -1534,6 +1772,110 @@ const UnixSession = struct {
         }
 
         return changed;
+    }
+
+    fn attachDaemonSession(self: *UnixSession, allocator: std.mem.Allocator, options: SessionCreateOptions) !void {
+        const pref_path = self.pref_path orelse return error.MissingSessionPrefPath;
+        const session_id = self.session_id orelse return error.MissingSessionId;
+        const exe_path = try selfExePathAlloc(allocator);
+        defer allocator.free(exe_path);
+        try sessionizer.ensureDaemon(allocator, pref_path, exe_path);
+
+        if (options.revive_policy == .restart) {
+            const kill_response = sessionizer.requestAlloc(allocator, pref_path, "session.kill", .{ .id = session_id }, 1) catch null;
+            if (kill_response) |response| allocator.free(response);
+        }
+        if (options.revive_policy == .attach_only or options.revive_policy == .manual) {
+            const inspect_response = try sessionizer.requestAlloc(allocator, pref_path, "session.inspect", .{ .id = session_id }, 1);
+            defer allocator.free(inspect_response);
+            try ensureSessionResponseOk(allocator, inspect_response);
+        } else {
+            const command = try daemonCommandForProfile(allocator, options.profile);
+            defer allocator.free(command);
+            const create_response = try sessionizer.requestAlloc(allocator, pref_path, "session.create", .{
+                .id = session_id,
+                .project_id = options.project_id,
+                .project_path = options.project_path,
+                .cwd = options.cwd,
+                .label = self.launch_label,
+                .command = command,
+                .cols = options.cols,
+                .rows = options.rows,
+                .dock_id = options.dock_id,
+                .pane_id = options.pane_id,
+            }, 1);
+            defer allocator.free(create_response);
+            try ensureSessionResponseOk(allocator, create_response);
+        }
+
+        try self.resizeDaemon(allocator);
+        _ = try self.drainDaemonOutput(allocator);
+    }
+
+    fn drainDaemonOutput(self: *UnixSession, allocator: std.mem.Allocator) !bool {
+        const pref_path = self.pref_path orelse return false;
+        const session_id = self.session_id orelse return false;
+        const response = sessionizer.requestAlloc(allocator, pref_path, "session.tail", .{
+            .id = session_id,
+            .offset = self.remote_output_offset,
+        }, 1) catch |err| {
+            log.debug("failed to poll daemon terminal session {s}: {s}", .{ session_id, @errorName(err) });
+            self.running = false;
+            return false;
+        };
+        defer allocator.free(response);
+
+        var parsed = try std.json.parseFromSlice(std.json.Value, allocator, response, .{});
+        defer parsed.deinit();
+        if (parsed.value != .object) return error.InvalidSessionResponse;
+        if (parsed.value.object.get("error")) |_| {
+            self.running = false;
+            return false;
+        }
+        const result = parsed.value.object.get("result") orelse return error.InvalidSessionResponse;
+        if (result != .object) return error.InvalidSessionResponse;
+        const text = jsonString(result.object.get("text") orelse .null) orelse "";
+        self.remote_output_offset = jsonUsize(result.object.get("next_offset") orelse .null) orelse self.remote_output_offset;
+        self.running = jsonBool(result.object.get("running") orelse .null) orelse self.running;
+        if (text.len == 0) return false;
+        try self.appendOutput(allocator, text);
+        self.stream.nextSlice(text);
+        try self.repairTerminalState(allocator);
+        return true;
+    }
+
+    fn resizeDaemon(self: *UnixSession, allocator: std.mem.Allocator) !void {
+        const pref_path = self.pref_path orelse return;
+        const session_id = self.session_id orelse return;
+        const response = try sessionizer.requestAlloc(allocator, pref_path, "session.resize", .{
+            .id = session_id,
+            .cols = self.cols,
+            .rows = self.rows,
+        }, 1);
+        defer allocator.free(response);
+        try ensureSessionResponseOk(allocator, response);
+    }
+
+    fn killDaemon(self: *UnixSession) !void {
+        const pref_path = self.pref_path orelse return error.MissingSessionPrefPath;
+        const session_id = self.session_id orelse return error.MissingSessionId;
+        const response = try sessionizer.requestAlloc(std.heap.smp_allocator, pref_path, "session.kill", .{ .id = session_id }, 1);
+        defer std.heap.smp_allocator.free(response);
+    }
+
+    fn writeRawInput(self: *UnixSession, bytes: []const u8) !bool {
+        if (self.backend == .local) {
+            try writeAll(self.master_fd, bytes);
+            return true;
+        }
+        const pref_path = self.pref_path orelse return false;
+        const session_id = self.session_id orelse return false;
+        const response = try sessionizer.requestAlloc(std.heap.smp_allocator, pref_path, "session.write", .{
+            .id = session_id,
+            .text = bytes,
+        }, 1);
+        defer std.heap.smp_allocator.free(response);
+        return true;
     }
 
     fn appendOutput(self: *UnixSession, allocator: std.mem.Allocator, bytes: []const u8) !void {
@@ -1605,7 +1947,7 @@ const UnixSession = struct {
 
     fn streamWritePty(handler: *TerminalHandler, data: [:0]const u8) void {
         const session: *UnixSession = @fieldParentPtr("terminal", handler.terminal);
-        writeAll(session.master_fd, std.mem.sliceTo(data, 0)) catch |err| {
+        _ = session.writeRawInput(std.mem.sliceTo(data, 0)) catch |err| {
             log.warn("failed to write terminal response to PTY: {s}", .{@errorName(err)});
         };
     }
@@ -1781,6 +2123,7 @@ const UnixSession = struct {
     }
 
     fn captureExitStatus(self: *UnixSession) bool {
+        if (self.backend == .daemon) return false;
         if (self.exit_status != null) return false;
 
         var status: c_int = 0;
@@ -1793,7 +2136,7 @@ const UnixSession = struct {
     }
 
     fn applyWinsize(self: *UnixSession) void {
-        if (!self.running) return;
+        if (!self.running or self.backend == .daemon) return;
 
         var winsize = std.posix.winsize{
             .row = self.rows,
@@ -1883,8 +2226,14 @@ fn writeAll(fd: std.posix.fd_t, bytes: []const u8) !void {
 }
 
 fn writeTerminalPaste(allocator: std.mem.Allocator, fd: std.posix.fd_t, text: []const u8, bracketed: bool) !void {
+    const encoded = try terminalPasteBytesAlloc(allocator, text, bracketed);
+    defer allocator.free(encoded);
+    try writeAll(fd, encoded);
+}
+
+fn terminalPasteBytesAlloc(allocator: std.mem.Allocator, text: []const u8, bracketed: bool) ![]u8 {
     var encoded: std.ArrayList(u8) = .empty;
-    defer encoded.deinit(allocator);
+    errdefer encoded.deinit(allocator);
 
     if (bracketed) try encoded.appendSlice(allocator, "\x1b[200~");
     for (text) |byte| {
@@ -1896,7 +2245,7 @@ fn writeTerminalPaste(allocator: std.mem.Allocator, fd: std.posix.fd_t, text: []
             byte);
     }
     if (bracketed) try encoded.appendSlice(allocator, "\x1b[201~");
-    try writeAll(fd, encoded.items);
+    return try encoded.toOwnedSlice(allocator);
 }
 
 fn copyableRenderStateText(allocator: std.mem.Allocator, render_state: *const ghostty_vt.RenderState) ![]u8 {
@@ -1956,6 +2305,83 @@ fn terminalPasteUnsafeByte(byte: u8) bool {
         0x00, 0x08, 0x05, 0x04, 0x1B, 0x7F, 0x03, 0x1C, 0x15, 0x1A, 0x11, 0x13, 0x17, 0x16, 0x12, 0x0F => true,
         else => false,
     };
+}
+
+fn daemonCommandForProfile(allocator: std.mem.Allocator, profile: TerminalLaunchProfile) ![][]const u8 {
+    if (profile.command.len > 0) {
+        const command = try allocator.alloc([]const u8, profile.command.len);
+        @memcpy(command, profile.command);
+        return command;
+    }
+    if (profile.kind == .shell) {
+        const command = try allocator.alloc([]const u8, 2);
+        command[0] = if (std.c.getenv("SHELL")) |shell_ptr| std.mem.span(shell_ptr) else "/bin/bash";
+        command[1] = "-i";
+        return command;
+    }
+    const args: []const []const u8 = switch (profile.kind) {
+        .shell => unreachable,
+        .claude => &.{"claude"},
+        .opencode => &.{"opencode"},
+        .codex => &.{"codex"},
+        .cursor => &.{"agent"},
+        .custom => &.{},
+    };
+    const command = try allocator.alloc([]const u8, args.len);
+    @memcpy(command, args);
+    return command;
+}
+
+fn ensureSessionResponseOk(allocator: std.mem.Allocator, response: []const u8) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, response, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidSessionResponse;
+    if (parsed.value.object.get("error")) |_| return error.SessionRequestFailed;
+}
+
+fn jsonString(value: std.json.Value) ?[]const u8 {
+    return switch (value) {
+        .string => |text| text,
+        else => null,
+    };
+}
+
+fn jsonBool(value: std.json.Value) ?bool {
+    return switch (value) {
+        .bool => |flag| flag,
+        else => null,
+    };
+}
+
+fn jsonUsize(value: std.json.Value) ?usize {
+    return switch (value) {
+        .integer => |int| if (int >= 0) @intCast(int) else null,
+        .number_string => |text| std.fmt.parseInt(usize, text, 10) catch null,
+        else => null,
+    };
+}
+
+fn selfExePathAlloc(allocator: std.mem.Allocator) ![]u8 {
+    switch (builtin.os.tag) {
+        .linux => {
+            var buffer: [std.fs.max_path_bytes]u8 = undefined;
+            const len = std.c.readlink("/proc/self/exe", &buffer, buffer.len);
+            if (len < 0) return error.FileNotFound;
+            return allocator.dupe(u8, buffer[0..@intCast(len)]);
+        },
+        .macos => {
+            var size: u32 = std.fs.max_path_bytes;
+            var buffer: [std.fs.max_path_bytes]u8 = undefined;
+            if (_NSGetExecutablePath(&buffer, &size) != 0) {
+                const dynamic_buffer = try allocator.alloc(u8, size);
+                defer allocator.free(dynamic_buffer);
+                if (_NSGetExecutablePath(dynamic_buffer.ptr, &size) != 0) return error.NameTooLong;
+                return std.fs.path.resolve(allocator, &.{std.mem.sliceTo(dynamic_buffer, 0)});
+            }
+            return std.fs.path.resolve(allocator, &.{std.mem.sliceTo(&buffer, 0)});
+        },
+        else => return error.FileNotFound,
+    }
 }
 
 fn shouldDeferToTextInput(event: *const sdl.KeyboardEvent) bool {
@@ -2404,6 +2830,26 @@ fn dupeCommand(allocator: std.mem.Allocator, args: []const []const u8) ![][:0]u8
         initialized += 1;
     }
     return command;
+}
+
+fn dupeStringSlice(allocator: std.mem.Allocator, values: []const []const u8) ![]const []const u8 {
+    if (values.len == 0) return &.{};
+    const owned = try allocator.alloc([]const u8, values.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (owned[0..initialized]) |value| allocator.free(value);
+        allocator.free(owned);
+    }
+    for (values, 0..) |value, index| {
+        owned[index] = try allocator.dupe(u8, value);
+        initialized += 1;
+    }
+    return owned;
+}
+
+fn freeStringSlice(allocator: std.mem.Allocator, values: []const []const u8) void {
+    for (values) |value| allocator.free(value);
+    if (values.len > 0) allocator.free(values);
 }
 
 fn freeCommand(allocator: std.mem.Allocator, command: [][:0]u8) void {

--- a/packages/desktop/src/terminal/terminal.zig
+++ b/packages/desktop/src/terminal/terminal.zig
@@ -1889,10 +1889,12 @@ const UnixSession = struct {
         if (result != .object) return error.InvalidSessionResponse;
         const text = jsonString(result.object.get("text") orelse .null) orelse "";
         const suppress_replay_responses = self.suppress_next_daemon_replay and self.remote_output_offset == 0;
-        const child_process_count = jsonUsize(result.object.get("child_process_count") orelse .null);
+        const shell_pid = jsonUsize(result.object.get("pid") orelse .null);
+        const foreground_process_group = jsonUsize(result.object.get("foreground_process_group") orelse .null);
         const stale_alt_screen_replay = suppress_replay_responses and
-            child_process_count != null and
-            child_process_count.? == 0 and
+            shell_pid != null and
+            foreground_process_group != null and
+            foreground_process_group.? == shell_pid.? and
             looksLikeStaleFullScreenReplay(text);
         self.remote_output_offset = jsonUsize(result.object.get("next_offset") orelse .null) orelse self.remote_output_offset;
         self.suppress_next_daemon_replay = false;

--- a/packages/desktop/src/terminal/terminal.zig
+++ b/packages/desktop/src/terminal/terminal.zig
@@ -28,6 +28,7 @@ const FONT_SCALE_STEP: f32 = 0.125;
 const WHEEL_SCROLL_LINES: f32 = 3.0;
 const KEY_SCROLL_LINES: isize = 3;
 const OUTPUT_RING_CAPACITY: usize = 256 * 1024;
+const DAEMON_REPLAY_MAX_BYTES: usize = 512 * 1024;
 pub const DEFAULT_FONT_SIZE: f32 = @floatFromInt(CELL_PIXEL_HEIGHT);
 // Darwin exposes the winsize setter under the BSD ioctl value, not std.c.T.IOCSWINSZ.
 const TERMINAL_WINSIZE_IOCTL: c_int = switch (builtin.os.tag) {
@@ -1414,6 +1415,8 @@ const UnixSession = struct {
     attach_id: ?[]u8 = null,
     pref_path: ?[]u8 = null,
     remote_output_offset: usize = 0,
+    suppress_next_daemon_replay: bool = false,
+    suppress_pty_responses: bool = false,
     output_ring: std.ArrayList(u8) = .empty,
 
     const Backend = enum {
@@ -1800,10 +1803,12 @@ const UnixSession = struct {
             const kill_response = sessionizer.requestAlloc(allocator, pref_path, "session.kill", .{ .id = session_id }, 1) catch null;
             if (kill_response) |response| allocator.free(response);
         }
+        var attached_existing_session = false;
         if (options.revive_policy == .attach_only or options.revive_policy == .manual) {
             const inspect_response = try sessionizer.requestAlloc(allocator, pref_path, "session.inspect", .{ .id = session_id }, 1);
             defer allocator.free(inspect_response);
             try ensureSessionResponseOk(allocator, inspect_response);
+            attached_existing_session = true;
         } else {
             const command = try daemonCommandForProfile(allocator, options.profile);
             defer allocator.free(command);
@@ -1821,7 +1826,9 @@ const UnixSession = struct {
             }, 1);
             defer allocator.free(create_response);
             try ensureSessionResponseOk(allocator, create_response);
+            attached_existing_session = !(sessionResultBool(allocator, create_response, "created") catch true);
         }
+        self.suppress_next_daemon_replay = attached_existing_session;
 
         const attach_response = sessionizer.requestAlloc(allocator, pref_path, "session.attach", .{
             .id = session_id,
@@ -1849,6 +1856,7 @@ const UnixSession = struct {
             .id = session_id,
             .attach_id = self.attach_id orelse "",
             .offset = self.remote_output_offset,
+            .max_bytes = DAEMON_REPLAY_MAX_BYTES,
         }, 1) catch |err| {
             log.debug("failed to poll daemon terminal session {s}: {s}", .{ session_id, @errorName(err) });
             self.daemon_state = .unavailable;
@@ -1868,11 +1876,16 @@ const UnixSession = struct {
         const result = parsed.value.object.get("result") orelse return error.InvalidSessionResponse;
         if (result != .object) return error.InvalidSessionResponse;
         const text = jsonString(result.object.get("text") orelse .null) orelse "";
+        const suppress_replay_responses = self.suppress_next_daemon_replay and self.remote_output_offset == 0;
         self.remote_output_offset = jsonUsize(result.object.get("next_offset") orelse .null) orelse self.remote_output_offset;
+        self.suppress_next_daemon_replay = false;
         self.running = jsonBool(result.object.get("running") orelse .null) orelse self.running;
         self.daemon_state = .attached;
         if (text.len == 0) return false;
         try self.appendOutput(allocator, text);
+        const previous_suppression = self.suppress_pty_responses;
+        self.suppress_pty_responses = previous_suppression or suppress_replay_responses;
+        defer self.suppress_pty_responses = previous_suppression;
         self.stream.nextSlice(text);
         try self.repairTerminalState(allocator);
         return true;
@@ -1994,6 +2007,7 @@ const UnixSession = struct {
 
     fn streamWritePty(handler: *TerminalHandler, data: [:0]const u8) void {
         const session: *UnixSession = @fieldParentPtr("terminal", handler.terminal);
+        if (session.suppress_pty_responses) return;
         _ = session.writeRawInput(std.mem.sliceTo(data, 0)) catch |err| {
             log.warn("failed to write terminal response to PTY: {s}", .{@errorName(err)});
         };
@@ -2400,6 +2414,16 @@ fn sessionResultStringAlloc(allocator: std.mem.Allocator, response: []const u8, 
     if (result != .object) return error.InvalidSessionResponse;
     const text = jsonString(result.object.get(field) orelse .null) orelse return error.InvalidSessionResponse;
     return try allocator.dupe(u8, text);
+}
+
+fn sessionResultBool(allocator: std.mem.Allocator, response: []const u8, field: []const u8) !bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, response, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidSessionResponse;
+    if (parsed.value.object.get("error")) |_| return error.SessionRequestFailed;
+    const result = parsed.value.object.get("result") orelse return error.InvalidSessionResponse;
+    if (result != .object) return error.InvalidSessionResponse;
+    return jsonBool(result.object.get(field) orelse .null) orelse return error.InvalidSessionResponse;
 }
 
 fn jsonString(value: std.json.Value) ?[]const u8 {

--- a/packages/desktop/src/terminal/terminal.zig
+++ b/packages/desktop/src/terminal/terminal.zig
@@ -1417,6 +1417,7 @@ const UnixSession = struct {
     remote_output_offset: usize = 0,
     suppress_next_daemon_replay: bool = false,
     suppress_pty_responses: bool = false,
+    defer_daemon_replay_until_resize: bool = false,
     output_ring: std.ArrayList(u8) = .empty,
 
     const Backend = enum {
@@ -1558,7 +1559,10 @@ const UnixSession = struct {
         const next_cell_height = @max(cell_height, 1);
         const size_changed = self.cols != next_cols or self.rows != next_rows;
         const metrics_changed = self.cell_width != next_cell_width or self.cell_height != next_cell_height;
-        if (!size_changed and !metrics_changed) return;
+        if (!size_changed and !metrics_changed) {
+            if (self.backend == .daemon) self.defer_daemon_replay_until_resize = false;
+            return;
+        }
         self.cols = next_cols;
         self.rows = next_rows;
         self.cell_width = next_cell_width;
@@ -1568,7 +1572,10 @@ const UnixSession = struct {
         }
         switch (self.backend) {
             .local => self.applyWinsize(),
-            .daemon => try self.resizeDaemon(allocator),
+            .daemon => {
+                try self.resizeDaemon(allocator);
+                self.defer_daemon_replay_until_resize = false;
+            },
         }
         try self.refreshRenderState(allocator);
     }
@@ -1829,6 +1836,7 @@ const UnixSession = struct {
             attached_existing_session = !(sessionResultBool(allocator, create_response, "created") catch true);
         }
         self.suppress_next_daemon_replay = attached_existing_session;
+        self.defer_daemon_replay_until_resize = attached_existing_session;
 
         const attach_response = sessionizer.requestAlloc(allocator, pref_path, "session.attach", .{
             .id = session_id,
@@ -1845,11 +1853,14 @@ const UnixSession = struct {
             };
         }
 
-        try self.resizeDaemon(allocator);
-        _ = try self.drainDaemonOutput(allocator);
+        if (!attached_existing_session) {
+            try self.resizeDaemon(allocator);
+            _ = try self.drainDaemonOutput(allocator);
+        }
     }
 
     fn drainDaemonOutput(self: *UnixSession, allocator: std.mem.Allocator) !bool {
+        if (self.defer_daemon_replay_until_resize) return false;
         const pref_path = self.pref_path orelse return false;
         const session_id = self.session_id orelse return false;
         const response = sessionizer.requestAlloc(allocator, pref_path, "session.tail", .{


### PR DESCRIPTION
## Summary
- add Verde-native persistent terminal sessions and CLI attach support
- preserve terminal TUI sessions across app reloads/reopens
- harden replay, resize, daemon attach/detach, and stale full-screen recovery

## Verification
- mise run build