### PR TITLE
Clarify Windows preview installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The desktop app lives in [`packages/desktop/`](packages/desktop). Verde's UI is 
 - **Scriptable.** Every running instance exposes per-user local control through
   `verde live` (Windows named pipes or Unix sockets); `verde state` inspects the
   persisted state without launching the app.
-- **Native, not Electron.** A single Zig + SDL3 binary built on Verde's own Palette UI framework.
+- **Native, not Electron.** A Zig + SDL3 app built on Verde's own Palette UI framework.
 
 ## Getting Started
 
@@ -32,7 +32,7 @@ Verde talks to provider runtimes on your machine rather than bundling its own ho
 
 ## Install
 
-Install the latest release from the website:
+On Linux, install the latest release from the website:
 
 ```bash
 curl -fsSL https://verdeai.dev/install.sh | sh
@@ -42,17 +42,41 @@ Or download a release from [GitHub Releases](https://github.com/JonathanRiche/ve
 
 - Linux: download `verde-v<version>-linux-x86_64.tar.gz`, extract it, then run `./install-local.sh`.
 - macOS: download the `.dmg` or `.zip` for your architecture, then move `Verde.app` into `Applications`.
-- Windows x64 preview: verify and extract the ZIP, then run `install.ps1` to
-  install for the current user and create the `Verde.Desktop` Start Menu
-  identity. `app\Verde.exe` is the desktop entry point and `bin\verde.exe` is
-  the console CLI. Preview artifacts are currently unsigned, so Windows may
-  show an unknown-publisher or SmartScreen warning. Confirm the adjacent
-  SHA-256 file matches the ZIP before choosing **More info → Run anyway**.
+- Windows x64 preview: download `verde-v<version>-windows-x86_64.zip` and its
+  adjacent `.sha256` file. Verify and extract the ZIP, then run the included
+  `install.ps1`. The script copies the complete package to
+  `%LOCALAPPDATA%\Programs\Verde` and creates a Start Menu shortcut; it does not
+  require administrator access.
 - Arch Linux: install [`verde-bin`](https://aur.archlinux.org/packages/verde-bin) from the AUR.
 
 ```bash
 yay -S verde-bin
 ```
+
+For Windows, open Windows PowerShell in the download directory and run:
+
+```powershell
+$zip = Get-Item .\verde-v*-windows-x86_64.zip
+$expected = ((Get-Content "$($zip.FullName).sha256" -Raw) -split '\s+')[0]
+$actual = (Get-FileHash $zip.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($actual -ne $expected.ToLowerInvariant()) { throw "ZIP checksum mismatch" }
+Expand-Archive $zip.FullName -DestinationPath '.\Verde' -Force
+$root = Get-ChildItem '.\Verde' -Directory | Select-Object -First 1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $root 'install.ps1')
+```
+
+Launch **Verde** from the Start Menu afterward. The GUI executable is
+`%LOCALAPPDATA%\Programs\Verde\app\Verde.exe`; the console CLI is
+`%LOCALAPPDATA%\Programs\Verde\bin\verde.exe` and is not automatically added to
+`PATH`. The package also contains adjacent runtime DLLs, so do not copy either
+EXE out of its directory or run it from inside Explorer's compressed-folder
+view. You can run `app\Verde.exe` directly from the extracted tree for a
+portable test without installing it.
+
+Check `WINDOWS-SIGNING.json` inside the extracted package for its signing
+state. If the release is unsigned, Windows may show an unknown-publisher or
+SmartScreen warning; verify the adjacent `.sha256` file before choosing
+**More info → Run anyway**.
 
 The Windows preview requires the Microsoft Edge WebView2 Evergreen Runtime;
 the packaged `WebView2Loader.dll` is only its application loader. Verde live

--- a/notes/windows-preview-release.md
+++ b/notes/windows-preview-release.md
@@ -33,17 +33,16 @@ preview asset directory, use:
 npm run package:npm -- --platform windows-x64 <version> <release-assets-dir> <output-dir>
 ```
 
-Native Windows CI runs `scripts\dev\smoke-windows.ps1`, which launches the GUI
-from an absent persisted-state database, requires the runtime to report zero
-workspaces while opening the browser, waits through the console CLI for
-WebView2 to report a ready native child view, and verifies a
-navigation-completed JavaScript evaluation. It writes cleanup/status evidence
+Before a release, `scripts\dev\smoke-windows.ps1` can launch the GUI from an
+absent persisted-state database, require the runtime to report zero workspaces
+while opening the browser, wait through the console CLI for WebView2 to report
+a ready native child view, verify a navigation-completed JavaScript evaluation,
+and exercise the persistent terminal session. It writes cleanup/status evidence
 below `.zig-cache\windows-smoke\evidence` and copies the pref-directory
-`verde.stderr.log` there when that log exists. A missing diagnostics log is
-recorded but does not invalidate otherwise successful browser readiness. This
-is an automated startup-readiness gate only. It does not claim physical D3D12
-rendering, DPI, keyboard/IME, pointer/clipboard, focus, overlay z-order, or
-repeated-lifecycle validation; those remain in `WINDOWS-TESTING.md`.
+`verde.stderr.log` there when that log exists. This is a startup-readiness gate,
+not a substitute for physical D3D12 rendering, DPI, keyboard/IME,
+pointer/clipboard, focus, overlay z-order, or repeated-lifecycle validation;
+those remain in `WINDOWS-TESTING.md`.
 
 Verde live and session control use current-logon named pipes and require no
 firewall exception. Codex app-server and OpenCode use separate loopback-only
@@ -62,27 +61,21 @@ timestamping. A stable installer is deferred until certificate ownership,
 upgrade/downgrade behavior, uninstall cleanup, shortcut migration, and toast
 activation are validated.
 
-## GitHub Actions setup
+## GitHub Actions release flow
 
-The `Windows native smoke` workflow runs its `Windows build and smoke` job on
-every pull request, merge-queue check, push to `master`, and manual dispatch.
-It uses the native MSVC toolchain on `windows-2022`, compiles the Windows test
-targets, exercises WebView2 and ConPTY at runtime, and validates an extracted
-deterministic ZIP.
-PR packages are unsigned and retained for seven days; executable ZIPs are not
-uploaded from untrusted fork pull requests.
+The repository does not run an automatic pull-request or `master`-push build.
+The `Release` workflow is the build gate for Linux, both macOS architectures,
+and Windows. Its Windows job uses the native MSVC toolchain on `windows-2022`,
+compiles the Windows test targets, builds the package, and verifies the
+extracted deterministic ZIP. Run `scripts\dev\smoke-windows.ps1` explicitly on
+a Windows test host when runtime WebView2 and ConPTY readiness must be repeated
+before tagging.
 
-After the workflow has completed once on the pull request, configure the
-repository's `master` branch protection or ruleset to require the `Windows build
-and smoke` check, shown under the `Windows native smoke` workflow. The workflow
-intentionally has no path filter so a required check cannot remain pending when
-an unrelated-looking change affects shared build or provider code.
-
-The `Release` workflow builds Linux, both macOS architectures, and Windows. A
-manual dispatch is an unsigned rehearsal with a `manual-*` version. Only a
-GitHub `push` event for a `v*` tag can receive the Windows signing material or
-publish a release. Signing is optional; configure both of these Actions
-repository secrets together when ready to enable it:
+A manual Release dispatch is an unsigned rehearsal with a `manual-*` version;
+it uploads artifacts but does not publish a GitHub release. Only a GitHub
+`push` event for a `v*` tag can receive the Windows signing material and publish
+the release. Signing is optional; configure both of these Actions repository
+secrets together when ready to enable it:
 
 - `WINDOWS_SIGNING_CERTIFICATE_BASE64`: base64-encoded Authenticode PFX.
 - `WINDOWS_SIGNING_CERTIFICATE_PASSWORD`: password for that PFX.

--- a/notes/windows_test_handoff.md
+++ b/notes/windows_test_handoff.md
@@ -1,10 +1,10 @@
-# Verde Windows internal-preview test handoff
+# Verde Windows preview test handoff
 
-This handoff is for the first x86-64 Windows internal preview. It is a test
-build, not a stable release. The purpose of this round is to find native
-Windows defects in rendering, WebView2, ConPTY, provider process management,
-local named-pipe control, paths, and packaging before the port is called
-stable.
+This handoff is for the first x86-64 Windows preview. It is a preview release,
+not a declaration of stable Windows support. The purpose of this round is to
+find native Windows defects in rendering, WebView2, ConPTY, provider process
+management, local named-pipe control, paths, and packaging before the port is
+called stable.
 
 ## What the tester should receive
 
@@ -12,7 +12,7 @@ stable.
 - `verde-<version>-windows-x86_64.zip.sha256`
 - the signing state from the person who produced the archive: either a valid
   Authenticode identity or an explicit statement that this is an unsigned
-  internal preview
+  Windows preview
 
 After extraction, the package manifest and `SHA256SUMS.txt` are authoritative
 for its contents. The desktop entry point is `app\Verde.exe`; the console entry
@@ -333,5 +333,5 @@ summary containing:
 - configurations tested (OS/GPU/DPI/shells/providers);
 - blockers that prevented rows from running;
 - orphan processes or handle/resource symptoms;
-- whether the build is suitable for another internal preview only, or is ready
+- whether the build is suitable for another preview only, or is ready
   to advance toward signed installer/stable-release validation.


### PR DESCRIPTION
## Summary
- document the exact Windows ZIP verification, extraction, and installer flow
- explain that the complete package is installed, not a standalone EXE
- update preview notes for the release-only GitHub Actions policy
- remove stale internal-preview wording

## Verification
- documentation-only change
- git diff --check