### PR TITLE
Add one-command Windows installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,21 @@ Verde talks to provider runtimes on your machine rather than bundling its own ho
 
 ## Install
 
-On Linux, install the latest release from the website:
+On Linux or macOS, install the latest release from the website:
 
 ```bash
 curl -fsSL https://verdeai.dev/install.sh | sh
 ```
+
+On Windows x64, open PowerShell and run:
+
+```powershell
+irm https://verdeai.dev/install.ps1 | iex
+```
+
+The Windows installer downloads and verifies the latest package, installs it
+for the current user, adds a Start Menu shortcut, and launches Verde. It does
+not require administrator access.
 
 Or download a release from [GitHub Releases](https://github.com/JonathanRiche/verde/releases).
 
@@ -53,7 +63,8 @@ Or download a release from [GitHub Releases](https://github.com/JonathanRiche/ve
 yay -S verde-bin
 ```
 
-For Windows, open Windows PowerShell in the download directory and run:
+For a manual Windows install, open Windows PowerShell in the download directory
+and run:
 
 ```powershell
 $zip = Get-Item .\verde-v*-windows-x86_64.zip

--- a/packages/website/src/content/docs/quickstart.md
+++ b/packages/website/src/content/docs/quickstart.md
@@ -8,16 +8,27 @@ slug: quickstart
 
 ## Install
 
-Verde ships as a single native binary. Install the latest release from the website:
+Install the latest Verde release from the website.
+
+On Linux or macOS:
 
 ```bash
 curl -fsSL https://verdeai.dev/install.sh | sh
 ```
 
-The installer detects your platform, downloads the matching release artifact from
-GitHub, and drops Verde into `~/.local` (Linux) or `/Applications` (macOS). For
-other paths — Arch Linux via the AUR, an npm launcher, a custom prefix, or a
-source build — see the [install section on the homepage](/#install).
+On Windows x64, open PowerShell and run:
+
+```powershell
+irm https://verdeai.dev/install.ps1 | iex
+```
+
+The installers download the matching release artifact from GitHub and verify it
+before installation. Linux installs into `~/.local`, macOS installs into
+`/Applications`, and Windows installs the complete app and runtime package into
+`%LOCALAPPDATA%\Programs\Verde`, creates a Start Menu shortcut, and launches the
+app. The Windows install does not require administrator access. For other paths
+— Arch Linux via the AUR, an npm launcher, a custom prefix, or a source build —
+see the [install section on the homepage](/#install).
 
 On Linux, the embedded browser pane uses the system WPE WebKit runtime. The
 installer will warn if the required libraries are missing and print the package

--- a/packages/website/src/install.ps1
+++ b/packages/website/src/install.ps1
@@ -1,0 +1,120 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$Repository = "JonathanRiche/verde"
+$ReleaseApi = "https://api.github.com/repos/$Repository/releases/latest"
+$InstallRoot = Join-Path $env:LOCALAPPDATA "Programs\Verde"
+$TemporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("verde-install-" + [Guid]::NewGuid().ToString("N"))
+
+function Write-Step([string]$Message) {
+  Write-Host "verde install: $Message"
+}
+
+if (-not [string]::Equals($env:OS, "Windows_NT", [StringComparison]::OrdinalIgnoreCase)) {
+  throw "This installer must run on Windows."
+}
+
+$Architectures = @($env:PROCESSOR_ARCHITECTURE, $env:PROCESSOR_ARCHITEW6432)
+if ($Architectures -notcontains "AMD64") {
+  throw "Verde Windows releases currently support x64 Windows only."
+}
+
+# Windows PowerShell 5.1 may otherwise negotiate an obsolete TLS version.
+[Net.ServicePointManager]::SecurityProtocol =
+  [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+$Headers = @{
+  Accept = "application/vnd.github+json"
+  "User-Agent" = "Verde-Web-Installer"
+  "X-GitHub-Api-Version" = "2022-11-28"
+}
+
+New-Item -ItemType Directory -Force -Path $TemporaryRoot | Out-Null
+
+try {
+  Write-Step "Finding the latest release..."
+  $Release = Invoke-RestMethod -Uri $ReleaseApi -Headers $Headers
+  $Tag = [string]$Release.tag_name
+  if ([string]::IsNullOrWhiteSpace($Tag)) {
+    throw "The latest GitHub release did not include a tag."
+  }
+
+  $ArchiveName = "verde-$Tag-windows-x86_64.zip"
+  $ChecksumName = "$ArchiveName.sha256"
+  $ArchiveAsset = @($Release.assets) | Where-Object { $_.name -eq $ArchiveName } | Select-Object -First 1
+  $ChecksumAsset = @($Release.assets) | Where-Object { $_.name -eq $ChecksumName } | Select-Object -First 1
+  if ($null -eq $ArchiveAsset -or $null -eq $ChecksumAsset) {
+    throw "Release $Tag does not include the expected Windows x64 package and checksum."
+  }
+
+  $ArchivePath = Join-Path $TemporaryRoot $ArchiveName
+  $ChecksumPath = Join-Path $TemporaryRoot $ChecksumName
+  Write-Step "Downloading Verde $Tag for Windows x64..."
+  Invoke-WebRequest -Uri $ArchiveAsset.browser_download_url -OutFile $ArchivePath -UseBasicParsing
+  Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -OutFile $ChecksumPath -UseBasicParsing
+
+  Write-Step "Verifying the package checksum..."
+  $ExpectedHash = ((Get-Content -LiteralPath $ChecksumPath -Raw) -split "\s+")[0].ToLowerInvariant()
+  if ($ExpectedHash -notmatch "^[0-9a-f]{64}$") {
+    throw "The release checksum is not a valid SHA-256 digest."
+  }
+  $ActualHash = (Get-FileHash -LiteralPath $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($ActualHash -ne $ExpectedHash) {
+    throw "Package checksum mismatch: expected $ExpectedHash, got $ActualHash."
+  }
+
+  $ExtractPath = Join-Path $TemporaryRoot "extracted"
+  Expand-Archive -LiteralPath $ArchivePath -DestinationPath $ExtractPath -Force
+  $PackageRoots = @(
+    Get-ChildItem -LiteralPath $ExtractPath -Directory |
+      Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName "install.ps1") -PathType Leaf }
+  )
+  if ($PackageRoots.Count -ne 1) {
+    throw "The release archive did not contain exactly one installable Verde package."
+  }
+  $PackageRoot = $PackageRoots[0].FullName
+
+  $SigningNoticePath = Join-Path $PackageRoot "WINDOWS-SIGNING.json"
+  if (-not (Test-Path -LiteralPath $SigningNoticePath -PathType Leaf)) {
+    throw "The release package is missing WINDOWS-SIGNING.json."
+  }
+  $SigningNotice = Get-Content -LiteralPath $SigningNoticePath -Raw | ConvertFrom-Json
+  if ($SigningNotice.signed -eq $true) {
+    foreach ($RelativeExecutable in @("app\Verde.exe", "bin\verde.exe")) {
+      $ExecutablePath = Join-Path $PackageRoot $RelativeExecutable
+      $Signature = Get-AuthenticodeSignature -FilePath $ExecutablePath
+      if ($Signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+        throw "Authenticode verification failed for ${RelativeExecutable}: $($Signature.Status)."
+      }
+    }
+    Write-Step "Verified the signed Verde executables."
+  } else {
+    Write-Warning "This release is unsigned. Its downloaded ZIP passed the published SHA-256 checksum."
+  }
+
+  $PackagedInstaller = Join-Path $PackageRoot "install.ps1"
+  $WindowsPowerShell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+  if (-not (Test-Path -LiteralPath $WindowsPowerShell -PathType Leaf)) {
+    throw "Windows PowerShell was not found at $WindowsPowerShell."
+  }
+
+  Write-Step "Installing Verde for the current user..."
+  & $WindowsPowerShell -NoProfile -ExecutionPolicy Bypass -File $PackagedInstaller
+  if ($LASTEXITCODE -ne 0) {
+    throw "The packaged Verde installer exited with code $LASTEXITCODE."
+  }
+
+  $InstalledExecutable = Join-Path $InstallRoot "app\Verde.exe"
+  if (-not (Test-Path -LiteralPath $InstalledExecutable -PathType Leaf)) {
+    throw "Installation completed without creating $InstalledExecutable."
+  }
+
+  Write-Step "Installed Verde $Tag."
+  Write-Step "CLI: $(Join-Path $InstallRoot 'bin\verde.exe') (not added to PATH)"
+  if ($env:VERDE_INSTALL_NO_LAUNCH -ne "1") {
+    Write-Step "Launching Verde..."
+    Start-Process -FilePath $InstalledExecutable
+  }
+} finally {
+  Remove-Item -LiteralPath $TemporaryRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/packages/website/src/routeTree.gen.ts
+++ b/packages/website/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as InstallDotshRouteImport } from './routes/install[.]sh'
+import { Route as InstallDotps1RouteImport } from './routes/install[.]ps1'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DocsIndexRouteImport } from './routes/docs/index'
@@ -30,6 +31,11 @@ const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
 const InstallDotshRoute = InstallDotshRouteImport.update({
   id: '/install.sh',
   path: '/install.sh',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const InstallDotps1Route = InstallDotps1RouteImport.update({
+  id: '/install.ps1',
+  path: '/install.ps1',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AboutRoute = AboutRouteImport.update({
@@ -56,6 +62,7 @@ const DocsSlugRoute = DocsSlugRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/install.ps1': typeof InstallDotps1Route
   '/install.sh': typeof InstallDotshRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
@@ -65,6 +72,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/install.ps1': typeof InstallDotps1Route
   '/install.sh': typeof InstallDotshRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
@@ -75,6 +83,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/install.ps1': typeof InstallDotps1Route
   '/install.sh': typeof InstallDotshRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
@@ -86,6 +95,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/about'
+    | '/install.ps1'
     | '/install.sh'
     | '/llms-full.txt'
     | '/llms.txt'
@@ -95,6 +105,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/about'
+    | '/install.ps1'
     | '/install.sh'
     | '/llms-full.txt'
     | '/llms.txt'
@@ -104,6 +115,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/about'
+    | '/install.ps1'
     | '/install.sh'
     | '/llms-full.txt'
     | '/llms.txt'
@@ -114,6 +126,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  InstallDotps1Route: typeof InstallDotps1Route
   InstallDotshRoute: typeof InstallDotshRoute
   LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute
   LlmsDottxtRoute: typeof LlmsDottxtRoute
@@ -142,6 +155,13 @@ declare module '@tanstack/solid-router' {
       path: '/install.sh'
       fullPath: '/install.sh'
       preLoaderRoute: typeof InstallDotshRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/install.ps1': {
+      id: '/install.ps1'
+      path: '/install.ps1'
+      fullPath: '/install.ps1'
+      preLoaderRoute: typeof InstallDotps1RouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about': {
@@ -178,6 +198,7 @@ declare module '@tanstack/solid-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  InstallDotps1Route: InstallDotps1Route,
   InstallDotshRoute: InstallDotshRoute,
   LlmsFullDottxtRoute: LlmsFullDottxtRoute,
   LlmsDottxtRoute: LlmsDottxtRoute,

--- a/packages/website/src/routes/install[.]ps1.ts
+++ b/packages/website/src/routes/install[.]ps1.ts
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/solid-router'
+
+import installScript from '../install.ps1?raw'
+
+export const Route = createFileRoute('/install.ps1')({
+  server: {
+    handlers: {
+      GET: async () =>
+        new Response(installScript, {
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Cache-Control': 'public, max-age=600',
+          },
+        }),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- serve a PowerShell bootstrapper at `/install.ps1`
- verify the latest Windows release checksum and signed executables when applicable
- invoke the packaged per-user installer and launch Verde
- document `irm https://verdeai.dev/install.ps1 | iex` in the README and quickstart

## Verification
- parsed `packages/website/src/install.ps1` with PowerShell 7.6.3
- `bun run build` in `packages/website`
- previewed the production build and confirmed `/install.ps1` returns HTTP 200 and a byte-identical, parseable script
- confirmed the live v0.1.98 release publishes the expected ZIP and `.sha256` asset names
- `git diff --check`

No GitHub workflow was added or changed.