### PR TITLE
fix(website): give published themes real diff and selection colors

### DIFF
--- a/packages/website/src/lib/theme-package.test.ts
+++ b/packages/website/src/lib/theme-package.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, test } from 'bun:test'
 
 import { portableThemePackage, themeImportCommand, themePackageUrl } from './theme-package'
 
+function hexChannels(hex: string): [number, number, number] {
+  const value = hex.replace('#', '')
+  return [
+    Number.parseInt(value.slice(0, 2), 16),
+    Number.parseInt(value.slice(2, 4), 16),
+    Number.parseInt(value.slice(4, 6), 16),
+  ]
+}
+
+function luminance(hex: string): number {
+  const [r, g, b] = hexChannels(hex)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
 const kanagawa = {
   slug: 'kanagawa',
   name: 'Kanagawa',
@@ -26,6 +40,55 @@ describe('portable website themes', () => {
       accent_dim: '#7e9cd836',
       warning: '#c0a36e',
     })
+  })
+
+  test('give diffs their own semantic colors instead of the accent', () => {
+    const colors = portableThemePackage(kanagawa).theme.colors
+
+    // Additions and removals must be distinguishable from each other, and
+    // must not be painted the accent — Kanagawa's accent is blue, so reusing
+    // it rendered added lines blue and left removals undefined.
+    expect(colors.diff_add).toBeDefined()
+    expect(colors.diff_remove).toBeDefined()
+    expect(colors.diff_add).not.toBe(colors.diff_remove)
+    expect(colors.diff_add).not.toBe(colors.accent)
+    expect(colors.diff_remove).not.toBe(colors.accent)
+
+    // diff_add reads green, diff_remove reads red.
+    const [addR, addG, addB] = hexChannels(colors.diff_add!)
+    expect(addG).toBeGreaterThan(addR)
+    expect(addG).toBeGreaterThan(addB)
+
+    const [remR, remG, remB] = hexChannels(colors.diff_remove!)
+    expect(remR).toBeGreaterThan(remG)
+    expect(remR).toBeGreaterThan(remB)
+  })
+
+  test('keep selection a wash so selected text stays legible', () => {
+    const colors = portableThemePackage(kanagawa).theme.colors
+
+    expect(colors.selection).not.toBe(colors.accent)
+    expect(colors.selection).not.toBe(colors.diff_add)
+  })
+
+  test('tone diff colors for light themes as well as dark', () => {
+    const latte = {
+      slug: 'catppuccin-latte',
+      name: 'Catppuccin Latte',
+      bg: '#eff1f5',
+      accent: '#1e66f5',
+      fg: '#4c4f69',
+      warm: '#df8e1d',
+    }
+
+    const dark = portableThemePackage(kanagawa).theme.colors
+    const light = portableThemePackage(latte).theme.colors
+
+    // The same base green must resolve differently per theme, and stay darker
+    // than the background it sits on for a light theme.
+    expect(light.diff_add).not.toBe(dark.diff_add)
+    expect(luminance(light.diff_add!)).toBeLessThan(luminance(light.background!))
+    expect(luminance(dark.diff_add!)).toBeGreaterThan(luminance(dark.background!))
   })
 
   test('exposes stable production URLs and import commands', () => {

--- a/packages/website/src/lib/theme-package.ts
+++ b/packages/website/src/lib/theme-package.ts
@@ -46,6 +46,14 @@ function lighten(hex: string, amount: number): string {
   ) as [number, number, number])
 }
 
+/* Diff colors carry fixed semantic meaning — additions read green, removals
+   read red — so they can't be derived from the four Omarchy palette colors.
+   These bases are toned toward the theme's own foreground, which keeps them
+   legible on light and dark backgrounds alike: on a dark theme fg lightens
+   them, on a light theme fg darkens them. */
+const DIFF_ADD_BASE = '#3fb950'
+const DIFF_REMOVE_BASE = '#f85149'
+
 /** Build the same semantic palette Verde derives from an Omarchy colors.toml. */
 export function portableThemePackage(theme: PortableThemeSource): PortableThemePackage {
   const panelMuted = lighten(theme.bg, 0.12)
@@ -67,8 +75,12 @@ export function portableThemePackage(theme: PortableThemeSource): PortableThemeP
         border: mix(theme.accent, theme.bg, 0.44),
         border_muted: panelMuted,
         warning: theme.warm,
-        diff_add: theme.accent,
-        selection: theme.accent,
+        diff_add: mix(DIFF_ADD_BASE, theme.fg, 0.2),
+        diff_remove: mix(DIFF_REMOVE_BASE, theme.fg, 0.2),
+        // A selection is a fill sitting behind text, so it has to stay a wash
+        // rather than the full-strength accent — otherwise selected text loses
+        // all contrast against it.
+        selection: mix(theme.accent, theme.bg, 0.78),
       },
     },
   }


### PR DESCRIPTION
## Problem

`portableThemePackage()` in `packages/website/src/lib/theme-package.ts` builds every theme served from `/themes/<slug>.json`. Three of the fifteen tokens were wrong:

```ts
diff_add: theme.accent,   // additions painted the accent color
selection: theme.accent,  // identical to accent AND to diff_add
// diff_remove — absent entirely
```

Because all ~20 published themes flow through this one function, they all inherit it. Concretely, after `verde theme import https://verdeai.dev/themes/kanagawa.json`:

- **Added lines render blue.** Kanagawa's accent is `#7e9cd8`, so `diff_add` is blue — additions don't read as additions.
- **`diff_remove` is missing**, so removed lines fall back to a built-in default that was never toned for the active theme.
- **`selection` equals `accent` equals `diff_add`** — three distinct roles, one color. A full-strength accent as a selection fill also leaves selected text with very little contrast against it.

I hit this while theming Verde locally and traced it back from the served JSON to this function.

## Fix

Diff colors carry fixed semantic meaning — additions read green, removals read red — so they genuinely can't be derived from the four Omarchy palette colors. They now come from green/red bases toned toward the theme's **own foreground**:

```ts
diff_add: mix(DIFF_ADD_BASE, theme.fg, 0.2),
diff_remove: mix(DIFF_REMOVE_BASE, theme.fg, 0.2),
```

Toning toward `fg` rather than `bg` is what makes this work in both directions: on a dark theme `fg` is light, so the color lightens and stays legible; on a light theme `fg` is dark, so it darkens. One rule, correct for both.

`selection` becomes a wash of the accent toward the background, so it reads as a highlight rather than a block of solid accent.

## Result

| Theme | accent | diff_add | diff_remove | selection |
|---|---|---|---|---|
| Kanagawa | `#7e9cd8` | `#5ebf65` | `#f26c60` | `#343b4f` |
| Catppuccin Latte | `#1e66f5` | `#42a455` | `#d6514f` | `#c1d2f5` |
| Gruvbox | `#7daea3` | `#5dba5e` | `#f16759` | `#3b4543` |
| Rosé Pine | `#56949f` | `#44a458` | `#d85153` | `#d6dfdc` |

Greens read green, reds read red, and each stays on the correct side of its background's luminance — light themes get darker diff colors, dark themes lighter ones.

## Tests

Three tests added to `theme-package.test.ts`, covering: diffs are defined, distinct from each other and from the accent, and channel-wise actually green/red; selection is distinct from both; and the same base resolves differently for a light vs. dark theme with correct luminance direction.

Verified the tests fail against the current code (2 of 3 fail on `master`) and pass with the fix. Full `packages/website` suite passes — 6 tests, 25 assertions.

## Scope

Deliberately left alone, but worth flagging as possible follow-ups:

- `panel: theme.bg` — identical to `background`, so tiled panes have no surface separation and rely entirely on the border.
- `border_muted` is assigned the same `panelMuted` value as `panel_muted`.

Both may well be intentional, and neither is a semantic error like the diff colors, so they seemed out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)