### PR TITLE
feat(website): add Mist Deep light theme

### DIFF
--- a/packages/website/src/lib/site-theme.ts
+++ b/packages/website/src/lib/site-theme.ts
@@ -45,7 +45,9 @@ export interface OmarchyTheme {
 }
 
 /* bg/accent/fg/warm are copied verbatim from each theme's Omarchy colors.toml
-   (warm = color3). 'verde' matches the site's own default tokens. */
+   (warm = color3). 'verde' matches the site's own default tokens.
+   'mist-deep' has no upstream colors.toml — it is a Verde-native light theme,
+   so its four values are the source of truth rather than a copy. */
 const OMARCHY_THEMES: OmarchyTheme[] = [
   { slug: 'verde', name: 'Verde default', bg: '#101820', accent: '#50c878', fg: '#eaf0f2', warm: '#e8a44a', fallbackShot: appScreenshot },
   { slug: 'tokyo-night', name: 'Tokyo Night', bg: '#1a1b26', accent: '#7aa2f7', fg: '#a9b1d6', warm: '#e0af68' },
@@ -65,6 +67,7 @@ const OMARCHY_THEMES: OmarchyTheme[] = [
   { slug: 'miasma', name: 'Miasma', bg: '#222222', accent: '#78824b', fg: '#c2c2b0', warm: '#b36d43' },
   { slug: 'retro-82', name: 'Retro 82', bg: '#05182e', accent: '#faa968', fg: '#f6dcac', warm: '#e97b3c' },
   { slug: 'flexoki-light', name: 'Flexoki Light', bg: '#fffcf0', accent: '#205ea6', fg: '#100f0f', warm: '#d0a215' },
+  { slug: 'mist-deep', name: 'Mist Deep', bg: '#eef2f4', accent: '#0f6ac9', fg: '#0d1012', warm: '#a0791a' },
   { slug: 'vantablack', name: 'Vantablack', bg: '#000000', accent: '#8d8d8d', fg: '#ffffff', warm: '#cecece' },
   { slug: 'white', name: 'White', bg: '#ffffff', accent: '#6e6e6e', fg: '#000000', warm: '#4a4a4a' },
 ]


### PR DESCRIPTION
## What

Adds **Mist Deep** to the portable theme catalog — a cool light palette: near-white panels on a soft grey-blue frame with an azure accent.

```ts
{ slug: 'mist-deep', name: 'Mist Deep', bg: '#eef2f4', accent: '#0f6ac9', fg: '#0d1012', warm: '#a0791a' },
```

The catalog is currently 17 dark themes to 3 light ones (Rosé Pine, Catppuccin Latte, Flexoki Light, plus White), so this fills a gap.

## Draft — needs a screenshot asset

Opened as a draft because it is **not functional without `packages/website/src/assets/theme_shots/mist-deep.png`**.

`availableThemes` filters out any entry with no screenshot, and `themeBySlug` reads from that filtered list, so `/themes/<slug>.json` 404s. That is observable in production today:

```
https://verdeai.dev/themes/kanagawa.json          200   (has screenshot)
https://verdeai.dev/themes/catppuccin-latte.json  200   (has screenshot)
https://verdeai.dev/themes/everforest.json        404   (no screenshot)
https://verdeai.dev/themes/nord.json              404   (no screenshot)
https://verdeai.dev/themes/flexoki-light.json     404   (no screenshot)
```

11 of the 20 entries are currently unreachable for this reason. I could not produce the asset myself — all 9 existing shots are exactly **2536×1030**, which looks like a standardized capture, and I found no tooling in the repo that generates them. Happy to add it if you can point me at the process, or feel free to capture it yourself.

## Two things for your call

**1. It is not an Omarchy theme.** The comment above the list says the values are "copied verbatim from each theme's Omarchy colors.toml", and the README frames the catalog as "themes that match your rig." Mist Deep has no upstream `colors.toml` — it is Verde-native. I noted that in the comment, but if you would rather keep the list strictly Omarchy-derived, this belongs somewhere else (or nowhere), and I am happy to close it.

**2. The derivation flattens light themes.** With the current `portableThemePackage()`, `panel` is assigned `theme.bg`, so a light theme's panes get no surface separation and rely entirely on the border. That is more visible on light palettes than dark ones. Separately, #130 fixes `diff_add`/`diff_remove`/`selection` in that same function — if it lands first, this theme picks up proper green/red diff colors instead of an azure `diff_add`.

## Safety

Non-breaking on its own. Without the screenshot the entry is filtered out, so nothing changes in the picker or the routes until the asset is added. `packages/website` suite passes — 6 tests, 25 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)