### PR TITLE
Fix Windows test directory permissions

### DIFF
--- a/packages/desktop/src/state/storage.zig
+++ b/packages/desktop/src/state/storage.zig
@@ -1503,8 +1503,8 @@ test "effective projection store is independent from pref artifacts" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try tmp.dir.createDir(std.testing.io, "pref", .fromMode(0o755));
-    try tmp.dir.createDir(std.testing.io, "store", .fromMode(0o755));
+    try tmp.dir.createDir(std.testing.io, "pref", std.Io.File.Permissions.default_dir);
+    try tmp.dir.createDir(std.testing.io, "store", std.Io.File.Permissions.default_dir);
     var root_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
     const root_len = try tmp.dir.realPath(std.testing.io, &root_buf);
     const pref_path = try std.fs.path.join(allocator, &.{ root_buf[0..root_len], "pref" });


### PR DESCRIPTION
## Summary
- replace POSIX-only test directory modes with Zig 0.16 cross-platform defaults
- restore Windows x86-64 test compilation for the v0.1.111 release

## Verification
- `mise run build-windows`
- `mise run build`