### PR TITLE
docs: document v0.1.111 features (headless daemon, MCP chat surface, persistence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,16 +172,24 @@ agents:
     hooks: true
 ```
 
+### Headless session daemon
+
+Chat turns and terminal sessions live in a **session daemon**, not the window. The GUI, CLI, MCP bridge, and the experimental web client all attach as detached clients — agent turns keep running and land durably if the window closes, and the daemon drains and upgrades itself when a new Verde version starts. Drafts, image attachments, and transcripts persist across restarts.
+
 ### Scriptable from your shell
 
-Every running instance exposes local IPC (`verde live`). Inspect panes, send prompts, write to terminals, open the browser — from hooks, dotfiles, or automation:
+Every running instance exposes local IPC (`verde live`). Inspect panes, open chats, send prompts, steer a running turn, write to terminals, open the browser — from hooks, dotfiles, or automation:
 
 ```bash
 verde live status --json
+verde live chat open --workspace $WS --provider codex --model gpt-5.6-sol --reasoning high
 verde live chat send --pane $PANE --prompt "run the tests and fix failures"
+verde live chat followup --pane $PANE --prompt "also update the changelog"  # steer the running turn
 verde live terminal write --focused --text $'cargo test\r'
 verde open http://localhost:3000
 ```
+
+The same chat surface is exposed to agents over MCP (`verde mcp`): open panes, send prompts, read transcripts, and queue mid-turn follow-ups — daemon-direct, without stealing focus or touching your composer.
 
 → Full surface: [CLI reference](https://verdeai.dev/docs/cli)
 
@@ -280,9 +288,12 @@ The UI stack is SDL3 (window/events/scale) + SDL_GPU + Palette — not web UI or
 
 - **Zig 0.16** — native executable, no Electron shell
 - **SDL3 + Palette** — windowing, input, and in-tree Zig GUI framework
-- **Ghostty / libghostty-vt** — embedded terminal engine
+- **Headless session daemon** — owns chat turns and PTYs; GUI, web gateway, CLI, and MCP are detached clients, so agent work survives window restarts
+- **Ghostty / libghostty-vt** — embedded terminal engine, pinned to upstream (no vendored fork)
 - **Native webview** — WPE WebKit · WKWebView · WebView2 (no bundled Chromium)
-- **SQLite** — local projects, threads, transcripts
+- **SQLite** — local projects, threads, transcripts, drafts, and image attachments
+
+The render loop is tuned for low idle cost: prompt acceptance is sub-millisecond even on long threads, daemon round-trips run off the render thread, and streaming large transcripts stays O(delta) per update.
 
 Third-party notices and licenses for vendored components are listed under [Third-party components](#third-party-components) below when redistributing.
 

--- a/packages/website/src/content/docs/chat.md
+++ b/packages/website/src/content/docs/chat.md
@@ -62,17 +62,28 @@ message stays pinned above the composer. Double-click that pin to pull it back
 into an empty composer for editing, then press `Tab` to queue it again.
 
 **Stop** aborts the active run. Verde keeps the draft with its thread, so
-changing panes does not discard unfinished text.
+changing panes does not discard unfinished text. Drafts — including staged
+image attachments — persist with the thread across pane switches and app
+restarts.
+
+Runs are owned by Verde's session daemon rather than the window: once a send
+is accepted, the turn keeps running and its transcript lands durably even if
+the desktop app is closed or restarted mid-turn.
 
 The same paths are scriptable with `verde live chat send`, `followup`, `stop`,
-and `draft`. See [CLI reference](/docs/cli#chat-control).
+and `draft`, and are exposed to agents over MCP (including daemon-direct
+`read_chat_thread` and `queue_chat_followup`). See
+[CLI reference](/docs/cli#chat-control).
 
 ## Attach images and mention files
 
 Paste an image with `Ctrl+V` (`Cmd+V` on macOS) while the chat composer owns
 focus. Verde stages it above the composer instead of converting it to text.
 Paste again to attach multiple images, remove individual previews before
-sending, and click a transcript image to open its full-size preview.
+sending, and click a transcript image to open its full-size preview. Staged
+attachments are persisted with the thread's draft, so they survive switching
+threads or restarting the app, and sent images remain viewable in the saved
+transcript.
 
 Codex, Claude Code, and OpenCode accept local image attachments. Cursor accepts
 them only when its ACP session advertises image support. Remote Herdr Codex GUI

--- a/packages/website/src/content/docs/cli.md
+++ b/packages/website/src/content/docs/cli.md
@@ -204,9 +204,20 @@ verde live chat approve --pane <pane-id> --decision approve|deny [--call <id>] [
 - `transcript` returns persisted messages for the pane's thread.
 - `draft set` replaces the current draft; `draft append` appends to it.
 - `send` sends `--prompt`, `--text`, or a trailing prompt argument. If no prompt is supplied, it sends the current draft.
-- `followup` queues or steers a prompt while a send is active.
+- `followup` steers a prompt into the pane's **running** turn. It is
+  daemon-led: it resolves the pane's thread through the session daemon, never
+  changes focus, presentation, or the composer draft, and returns structured
+  results — `disposition: "steered"` on success, `invalid_state` when the pane
+  has no running turn (nothing is staged as a draft), and `not_found` for a
+  missing pane or thread. Steering currently supports Claude local-CLI turns;
+  other provider harnesses return a structured unsupported error.
 - `stop` aborts the current send for that chat thread.
 - `approve` resolves the current pending approval. `--decision` accepts `approve` or `deny`.
+
+Chat turns run in the session daemon, so an accepted turn keeps running and
+lands durably even if the desktop window is closed or restarted mid-turn.
+Drafts and staged image attachments persist with their thread across pane
+switches and app restarts.
 
 ## Terminal and process control
 
@@ -306,6 +317,25 @@ require an explicit confirmed retry so the agent client can ask the user first.
 requires `pane_id`, accepts an optional workspace selector, and takes either a
 named key plus modifier booleans or a chord. It preserves desktop focus and
 does not restart a stopped session.
+
+### Chat control over MCP
+
+The bridge exposes the full GUI-chat surface to agents: `open_chat`,
+`present_chat`, `send_chat_message`, `get_chat_draft` / `set_chat_draft`,
+`read_chat_thread`, `tail_chat_turn`, `stop_chat_turn`, `approve_chat_turn`,
+and `queue_chat_followup`, plus `list_workspaces` / `list_panes` for
+discovery.
+
+- `read_chat_thread` and `queue_chat_followup` are **daemon-direct**: they
+  read persisted thread state through the session daemon, so they work even
+  when the GUI has paged the thread out of memory.
+- `queue_chat_followup` steers a prompt into a running turn with the same
+  semantics as `verde live chat followup` — structured
+  `steered` / `invalid_state` / `not_found` results, no focus or composer
+  changes, and no silent draft staging when the turn is idle.
+- Capabilities are granular: a tool that cannot run in the current
+  configuration returns `capability_unavailable` instead of failing
+  ambiguously. Discover the active surface with `verde capabilities --json`.
 
 ### Process coordination and retained outcomes
 

--- a/packages/website/src/content/docs/troubleshooting.md
+++ b/packages/website/src/content/docs/troubleshooting.md
@@ -175,6 +175,20 @@ Exit code `3` means the live server is not running or not ready — start the ap
 first. See [CLI reference](/docs/cli) for the full command surface and exit
 codes.
 
+## The session daemon
+
+Chat turns and persistent terminal sessions run in a background session daemon
+that outlives the desktop window. Useful properties when debugging:
+
+- Closing or restarting the app does **not** kill running agent turns or
+  terminal sessions; the GUI reattaches to them on the next launch.
+- When a newer Verde starts against an older daemon, the daemon drains and
+  upgrades itself automatically. If the CLI reports `method_not_found` for a
+  feature the docs say exists, an old daemon is usually still winding down —
+  retry after a moment, or restart the app.
+- `verde session list --json` shows daemon-owned terminal sessions even while
+  the desktop app is closed.
+
 ## Getting help
 
 - [GitHub issues](https://github.com/JonathanRiche/verde/issues) for bugs and feature requests.


### PR DESCRIPTION
Documents the user-facing v0.1.111 features on README + docs site:

- **README** — headless session daemon feature section and architecture bullet, `chat open`/`chat followup` CLI examples, MCP chat surface, perf characteristics, upstream libghostty pin
- **docs/cli** — `followup` daemon-led steering semantics with structured results, durable daemon-owned turns, new **Chat control over MCP** section (`queue_chat_followup`, daemon-direct `read_chat_thread`, granular `capability_unavailable`)
- **docs/chat** — draft + image-attachment persistence, daemon-owned runs
- **docs/troubleshooting** — session daemon behavior: turns survive restarts, automatic daemon upgrade/drain, stale-daemon `method_not_found` hint

Markdown-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)